### PR TITLE
Make torch_glow tests deterministic

### DIFF
--- a/torch_glow/tests/backends/NNPI/qconv_big_stride_small_kernel_test.py
+++ b/torch_glow/tests/backends/NNPI/qconv_big_stride_small_kernel_test.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
-class TestQuantizedConv2dBigStrideSmallKernel(unittest.TestCase):
+class TestQuantizedConv2dBigStrideSmallKernel(utils.TorchGlowTestCase):
     # These tests should be run on NNPI card manually, or else
     # buck test will only run them on emulator.
     supported_backends = {"NNPI"}
@@ -22,29 +21,29 @@ class TestQuantizedConv2dBigStrideSmallKernel(unittest.TestCase):
         "aten::dequantize",
     }
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "2d_stride_bigger_in_one_dim",
                 torch.nn.Conv2d(8, 4, [1, 1], groups=1, stride=[2, 1]),
                 torch.randn([1, 8, 8, 8]),
             ),
-            (
+            lambda: (
                 "2d_stride_bigger_in_multi_dims",
                 torch.nn.Conv2d(8, 4, [1, 1], groups=1, stride=[2, 2]),
                 torch.randn([1, 8, 8, 8]),
             ),
-            (
+            lambda: (
                 "2d_stride_bigger_in_multi_groups",
                 torch.nn.Conv2d(8, 4, [1, 1], groups=4, stride=[2, 1]),
                 torch.randn([1, 8, 8, 8]),
             ),
-            (
+            lambda: (
                 "2d_stride_bigger_strong_test_1",
                 torch.nn.Conv2d(4, 8, [2, 3], groups=2, stride=[1, 4]),
                 torch.randn([1, 4, 29, 23]),
             ),
-            (
+            lambda: (
                 "2d_stride_bigger_strong_test_2",
                 torch.nn.Conv2d(6, 8, [7, 3], groups=2, stride=[8, 4]),
                 torch.randn([2, 6, 47, 35]),
@@ -74,9 +73,9 @@ class TestQuantizedConv2dBigStrideSmallKernel(unittest.TestCase):
             )
 
     # Skiped 3d tests
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "3d_stride_bigger_in_one_dim",
                 torch.nn.Conv3d(8, 4, kernel_size=2, groups=1, stride=1),
                 torch.randn([1, 8, 16, 8, 8]),

--- a/torch_glow/tests/functionality/blacklist_test.py
+++ b/torch_glow/tests/functionality/blacklist_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP, SUBGRAPH_ATTR
 
 
-class TestBlackList(unittest.TestCase):
+class TestBlackList(utils.TorchGlowTestCase):
     def test_op_blacklist(self):
         """Test Glow fuser op kind blacklisting mechanism."""
 

--- a/torch_glow/tests/functionality/compilation_spec_test.py
+++ b/torch_glow/tests/functionality/compilation_spec_test.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pickle
-import unittest
 
 import torch
 import torch_glow
+from tests import utils
 
 
-class TestCompilationSpec(unittest.TestCase):
+class TestCompilationSpec(utils.TorchGlowTestCase):
     def build_compiliation_spec(self):
         compilation_spec = torch_glow.CompilationSpec()
 

--- a/torch_glow/tests/functionality/conv_to_glow_test.py
+++ b/torch_glow/tests/functionality/conv_to_glow_test.py
@@ -1,11 +1,11 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from collections import OrderedDict
 
 import torch
 import torch_glow
+from tests import utils
 
 
 def create_model(x, relu, bias=True):
@@ -69,7 +69,7 @@ def run_to_glow(m, x):
     return lowered_module
 
 
-class TestConvToGlow(unittest.TestCase):
+class TestConvToGlow(utils.TorchGlowTestCase):
     def test_conv2d_to_glow(self):
         x = torch.randn([1, 3, 30, 30])
         m = create_model(x, False)

--- a/torch_glow/tests/functionality/fuse_parallel_branches_test.py
+++ b/torch_glow/tests/functionality/fuse_parallel_branches_test.py
@@ -5,9 +5,10 @@ import unittest
 
 import torch
 import torch_glow
+from tests import utils
 
 
-class TestFuseParallelBranches(unittest.TestCase):
+class TestFuseParallelBranches(utils.TorchGlowTestCase):
     def test_fuse_parallel_branches_with_fusible_root(self):
         r"""Test GlowFuser fusing parallel branches with a common fusible root
 

--- a/torch_glow/tests/functionality/fused_linear_test.py
+++ b/torch_glow/tests/functionality/fused_linear_test.py
@@ -1,10 +1,9 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import graph_contains_str
 
 
@@ -30,7 +29,7 @@ graph(%input : Tensor, %weight : Tensor, %bias : Tensor):
 """
 
 
-class TestFuseLinear(unittest.TestCase):
+class TestFuseLinear(utils.TorchGlowTestCase):
     def test_fuse_linear(self):
         """Test Glow's fuseBranchedLinearPattern JIT pass"""
         graph = torch._C.parse_ir(graph_str)

--- a/torch_glow/tests/functionality/input_spec_test.py
+++ b/torch_glow/tests/functionality/input_spec_test.py
@@ -1,10 +1,9 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 
 
 def get_compilation_spec(inputs):
@@ -37,7 +36,7 @@ class TestModule(torch.nn.Module):
         return self.dequant(self.add(self.quant(a), self.quant(b)))
 
 
-class TestInputSpec(unittest.TestCase):
+class TestInputSpec(utils.TorchGlowTestCase):
     def test_input_spec(self):
         """Test setting quantized and non-quantized input specs."""
         with torch.no_grad():

--- a/torch_glow/tests/functionality/jit_vs_glow_path_test.py
+++ b/torch_glow/tests/functionality/jit_vs_glow_path_test.py
@@ -1,15 +1,14 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 import torch_glow
 from tests import utils
+from tests import utils
 
 
-class TestJITVsGlowPath(unittest.TestCase):
+class TestJITVsGlowPath(utils.TorchGlowTestCase):
     def test_jit_vs_glow_path(self):
         """Basic test of the JIT vs. Glow logging feature."""
 

--- a/torch_glow/tests/functionality/load_backend_specific_options_test.py
+++ b/torch_glow/tests/functionality/load_backend_specific_options_test.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import tempfile
-import unittest
 
 import torch
 import torch_glow
+from tests import utils
 
 
-class TestLoadBackendSpecificOptions(unittest.TestCase):
+class TestLoadBackendSpecificOptions(utils.TorchGlowTestCase):
     def test_backend_specific_options(self):
         """Test loading backend specific options from YAML file."""
 

--- a/torch_glow/tests/functionality/max_fusion_merge_size_test.py
+++ b/torch_glow/tests/functionality/max_fusion_merge_size_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP
 
 
-class TestMaxFusionMergeSize(unittest.TestCase):
+class TestMaxFusionMergeSize(utils.TorchGlowTestCase):
     def test_max_fusion_merge_size(self):
         """Test Glow fuser maximum fusion merge size mechanism."""
 

--- a/torch_glow/tests/functionality/min_graph_size_test.py
+++ b/torch_glow/tests/functionality/min_graph_size_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP
 
 
-class TestMinGraphSize(unittest.TestCase):
+class TestMinGraphSize(utils.TorchGlowTestCase):
     def test_min_graph_size(self):
         """Test Glow fuser minimum fusion group size mechanism."""
 

--- a/torch_glow/tests/functionality/only_tensor_outputs_test.py
+++ b/torch_glow/tests/functionality/only_tensor_outputs_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP
 
 
-class TestOnlyTensorOutputs(unittest.TestCase):
+class TestOnlyTensorOutputs(utils.TorchGlowTestCase):
     def test_only_tensor_outputs(self):
         """Test that Glow fuser only produces tensor outputs."""
 

--- a/torch_glow/tests/functionality/print_jit_index_test.py
+++ b/torch_glow/tests/functionality/print_jit_index_test.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 
 
-class TestPrintJitNodeIndices(unittest.TestCase):
+class TestPrintJitNodeIndices(utils.TorchGlowTestCase):
     """Test printing PyTorch jit node indices."""
 
     def test_print_jit_indices(self):

--- a/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
+++ b/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP
 
 
-class TestQuantizedCut(unittest.TestCase):
+class TestQuantizedCut(utils.TorchGlowTestCase):
     def test_quantized_cut(self):
         """Test cut quantized chunk in the middle."""
         torch._C._jit_set_profiling_executor(False)

--- a/torch_glow/tests/functionality/randomize_constants_test.py
+++ b/torch_glow/tests/functionality/randomize_constants_test.py
@@ -1,10 +1,9 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 
 
 class Model(torch.nn.Module):
@@ -40,7 +39,7 @@ def run_model(m, input, randomize):
     return glow_m(input)
 
 
-class TestRandomizeWeights(unittest.TestCase):
+class TestRandomizeWeights(utils.TorchGlowTestCase):
     def test_randomize_weights(self):
         m = Model()
         input = torch.randn(5)

--- a/torch_glow/tests/functionality/remove_exceptions_test.py
+++ b/torch_glow/tests/functionality/remove_exceptions_test.py
@@ -1,10 +1,9 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import graph_contains_str
 
 
@@ -19,7 +18,7 @@ def foo(x):
             raise RuntimeError("hi")
 
 
-class TestRemoveException(unittest.TestCase):
+class TestRemoveException(utils.TorchGlowTestCase):
     def test_remove_exceptions(self):
         """Test Glow's removeExceptions JIT pass"""
 

--- a/torch_glow/tests/functionality/set_glow_backend_test.py
+++ b/torch_glow/tests/functionality/set_glow_backend_test.py
@@ -1,12 +1,11 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch_glow
+from tests import utils
 
 
-class TestSetGlowBackend(unittest.TestCase):
+class TestSetGlowBackend(utils.TorchGlowTestCase):
     def test_set_glow_backend(self):
         """Test setting the Glow backend type"""
 

--- a/torch_glow/tests/functionality/to_glow_multiple_input_sets_test.py
+++ b/torch_glow/tests/functionality/to_glow_multiple_input_sets_test.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 
 
 class Foo(torch.nn.Module):
@@ -14,7 +13,7 @@ class Foo(torch.nn.Module):
         return x + y
 
 
-class TestToGlowMultpleInputSets(unittest.TestCase):
+class TestToGlowMultpleInputSets(utils.TorchGlowTestCase):
     def test_to_glow_multiple_groups_and_input_sets(self):
         x1 = torch.randn(1, 4)
         y1 = torch.randn(2, 4)

--- a/torch_glow/tests/functionality/to_glow_save_preprocessed_test.py
+++ b/torch_glow/tests/functionality/to_glow_save_preprocessed_test.py
@@ -1,11 +1,10 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.jit
 import torch_glow
+from tests import utils
 from tests import utils
 
 
@@ -29,7 +28,7 @@ class Bar(torch.nn.Module):
         return self.model(x)
 
 
-class TestToGlowSavePreprocessedModule(unittest.TestCase):
+class TestToGlowSavePreprocessedModule(utils.TorchGlowTestCase):
     def test_save_preprocessed_module(self):
         with torch.no_grad():
             x = torch.randn([1, 4, 4, 4], dtype=torch.float32)

--- a/torch_glow/tests/functionality/to_glow_selective_test.py
+++ b/torch_glow/tests/functionality/to_glow_selective_test.py
@@ -1,10 +1,9 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 
 
 class Qux(torch.nn.Module):
@@ -81,7 +80,7 @@ def get_compilation_spec(inputs):
     return spec
 
 
-class TestSelectiveToGlow(unittest.TestCase):
+class TestSelectiveToGlow(utils.TorchGlowTestCase):
     def test_to_glow_selective(self):
         inputs = (torch.zeros(4) + 8, torch.zeros(4) + 7)
         torch_res = model(*inputs)

--- a/torch_glow/tests/functionality/to_glow_tuple_output_test.py
+++ b/torch_glow/tests/functionality/to_glow_tuple_output_test.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import io
-import unittest
 
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import assertModulesEqual
 
 
@@ -26,7 +26,7 @@ class OneTupleModule(torch.nn.Module):
         return (y,)
 
 
-class TestToGlowTupleOutput(unittest.TestCase):
+class TestToGlowTupleOutput(utils.TorchGlowTestCase):
     def tuple_test_helper(self, ModType):
         input = torch.randn(4)
 

--- a/torch_glow/tests/functionality/to_glow_write_to_onnx_test.py
+++ b/torch_glow/tests/functionality/to_glow_write_to_onnx_test.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import glob
 import os
-import unittest
 
 import torch
 import torch_glow
+from tests import utils
 
 
 class Foo(torch.nn.Module):
@@ -54,7 +54,7 @@ def create_model(x, ModType):
     return model
 
 
-class TestToGlowWriteToOnnx(unittest.TestCase):
+class TestToGlowWriteToOnnx(utils.TorchGlowTestCase):
     def lower_and_write_to_onnx_helper(self, ModType, onnx_prefix):
         x = torch.randn(1, 3, 8, 8)
         model = create_model(x, ModType)

--- a/torch_glow/tests/nodes/Int_test.py
+++ b/torch_glow/tests/nodes/Int_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -38,7 +36,7 @@ class SimpleIntModule(torch.nn.Module):
         return res
 
 
-class TestInt(unittest.TestCase):
+class TestInt(utils.TorchGlowTestCase):
     def test_Int(self):
         """Basic test of the PyTorch Int Node on Glow, along with constant
         propagation. Using int32 dtype, and aten::add."""

--- a/torch_glow/tests/nodes/abs_test.py
+++ b/torch_glow/tests/nodes/abs_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -14,7 +12,7 @@ class SimpleAbsModule(torch.nn.Module):
         return torch.abs(a + a)
 
 
-class TestAbs(unittest.TestCase):
+class TestAbs(utils.TorchGlowTestCase):
     def test_abs_basic(self):
         """Basic test of the PyTorch Abs Node on Glow."""
 

--- a/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
+++ b/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -16,7 +14,7 @@ class SimpleAdapativeAvgPool2dModule(torch.nn.Module):
         return F.adaptive_avg_pool2d(inputs, self.output_size)
 
 
-class TestAdaptiveAvgPool2d(unittest.TestCase):
+class TestAdaptiveAvgPool2d(utils.TorchGlowTestCase):
     def test_adaptive_avg_pool2d_basic(self):
         """Basic test of PyTorch adaptive_avg_pool2d Node."""
         inputs = torch.randn(3, 6, 14, 14)

--- a/torch_glow/tests/nodes/add_test.py
+++ b/torch_glow/tests/nodes/add_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -23,31 +20,31 @@ class SimpleAddModule(torch.nn.Module):
             return c.add(c)
 
 
-class TestAdd(unittest.TestCase):
-    @parameterized.expand(
+class TestAdd(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleAddModule(), torch.randn(4), torch.randn(4)),
-            ("inplace", SimpleAddModule(True), torch.randn(4), torch.randn(4)),
-            (
+            lambda: ("basic", SimpleAddModule(), torch.randn(4), torch.randn(4)),
+            lambda: ("inplace", SimpleAddModule(True), torch.randn(4), torch.randn(4)),
+            lambda: (
                 "broadcast",
                 SimpleAddModule(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(4, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleAddModule(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(1, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleAddModule(),
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
-            ("float", SimpleAddModule(), torch.randn(4), torch.tensor(1.2345)),
-            ("int", SimpleAddModule(), torch.randn(4), torch.tensor(42), True),
+            lambda: ("float", SimpleAddModule(), torch.randn(4), torch.tensor(1.2345)),
+            lambda: ("int", SimpleAddModule(), torch.randn(4), torch.tensor(42), True),
         ]
     )
     def test_add(self, _, module, a, b, skip_to_glow=False):

--- a/torch_glow/tests/nodes/addmm_test.py
+++ b/torch_glow/tests/nodes/addmm_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleAddMmModule(torch.nn.Module):
         return (a + a).addmm(b, c)
 
 
-class TestAddMM(unittest.TestCase):
+class TestAddMM(utils.TorchGlowTestCase):
     def test_addmm_basic(self):
         """Basic test of the PyTorch addmm Node on Glow."""
         utils.compare_tracing_methods(

--- a/torch_glow/tests/nodes/and_test.py
+++ b/torch_glow/tests/nodes/and_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,20 +13,20 @@ class SimpleAndModule(torch.nn.Module):
         return torch.logical_or(c, b)
 
 
-class TestAnd(unittest.TestCase):
-    @parameterized.expand(
+class TestAnd(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 torch.tensor([True, True, False, False], dtype=torch.bool),
                 torch.tensor([True, False, True, False], dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "basic_3d",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((3, 4, 5), dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcast_3d",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((4, 5), dtype=torch.bool),

--- a/torch_glow/tests/nodes/arange_test.py
+++ b/torch_glow/tests/nodes/arange_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -21,7 +18,7 @@ class SimpleArangeModule(torch.nn.Module):
         return torch.arange(start=start, end=end, step=step)
 
 
-class TestArange(unittest.TestCase):
+class TestArange(utils.TorchGlowTestCase):
     """
     Tests for torch.arange glow fusion.
 
@@ -31,20 +28,24 @@ class TestArange(unittest.TestCase):
     happening. Otherwise, there would be nothing to fuse.
     """
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            ("simple", SimpleArangeModule(end=lambda x: x.size(0)), torch.randn(10)),
-            (
+            lambda: (
+                "simple",
+                SimpleArangeModule(end=lambda x: x.size(0)),
+                torch.randn(10),
+            ),
+            lambda: (
                 "all_args",
                 SimpleArangeModule(start=lambda x: x.size(0), end=30, step=1),
                 torch.randn(10),
             ),
-            (
+            lambda: (
                 "floats",
                 SimpleArangeModule(start=lambda x: x.size(0), end=30.5, step=0.8),
                 torch.randn(10),
             ),
-            (
+            lambda: (
                 "negative_step",
                 SimpleArangeModule(
                     start=lambda x: x.size(0), end=lambda x: x.size(1), step=-1.2

--- a/torch_glow/tests/nodes/arg_min_max_test.py
+++ b/torch_glow/tests/nodes/arg_min_max_test.py
@@ -1,7 +1,4 @@
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -31,12 +28,12 @@ class ArgMaxModule(torch.nn.Module):
             return torch.argmax(tensor)
 
 
-class TestArgMin(unittest.TestCase):
-    @parameterized.expand(
+class TestArgMin(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", ArgMinModule(), torch.randn(4)),
-            ("dimensions1", ArgMinModule(1, False), torch.randn(4, 4)),
-            ("dimensions2", ArgMinModule(1), torch.randn(5, 5)),
+            lambda: ("basic", ArgMinModule(), torch.randn(4)),
+            lambda: ("dimensions1", ArgMinModule(1, False), torch.randn(4, 4)),
+            lambda: ("dimensions2", ArgMinModule(1), torch.randn(5, 5)),
         ]
     )
     def test_argmin_node(self, _, module, tensor):
@@ -44,12 +41,12 @@ class TestArgMin(unittest.TestCase):
         utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::argmin"})
 
 
-class TestArgMax(unittest.TestCase):
-    @parameterized.expand(
+class TestArgMax(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", ArgMaxModule(), torch.randn(4)),
-            ("dimensions1", ArgMaxModule(1, False), torch.randn(4, 4)),
-            ("dimensions2", ArgMaxModule(1), torch.randn(5, 5)),
+            lambda: ("basic", ArgMaxModule(), torch.randn(4)),
+            lambda: ("dimensions1", ArgMaxModule(1, False), torch.randn(4, 4)),
+            lambda: ("dimensions2", ArgMaxModule(1), torch.randn(5, 5)),
         ]
     )
     def test_argmax_node(self, _, module, tensor):

--- a/torch_glow/tests/nodes/avgpool2d_test.py
+++ b/torch_glow/tests/nodes/avgpool2d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -20,7 +18,7 @@ class SimpleAvgPool2dModule(torch.nn.Module):
         )
 
 
-class TestAvgPool2d(unittest.TestCase):
+class TestAvgPool2d(utils.TorchGlowTestCase):
     def test_avg_pool2d_basic(self):
         """Basic test of the PyTorch avg_pool2d Node on Glow."""
         inputs = torch.randn(1, 4, 5, 5)

--- a/torch_glow/tests/nodes/avgpool3d_test.py
+++ b/torch_glow/tests/nodes/avgpool3d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -17,7 +15,7 @@ class SimpleAvgPool3dModule(torch.nn.Module):
         return F.avg_pool3d(inputs, self.kernel_size, padding=self.padding)
 
 
-class TestAvgPool3d(unittest.TestCase):
+class TestAvgPool3d(utils.TorchGlowTestCase):
     def test_avg_pool3d_basic(self):
         """Basic test of the PyTorch avg_pool3d Node on Glow."""
 

--- a/torch_glow/tests/nodes/batch_permutation_test.py
+++ b/torch_glow/tests/nodes/batch_permutation_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -11,7 +9,7 @@ class SimpleBatchPermutationModule(torch.nn.Module):
         return torch.ops._caffe2.BatchPermutation(input + input, indices)
 
 
-class TestBatchPermutation(unittest.TestCase):
+class TestBatchPermutation(utils.TorchGlowTestCase):
     def test_batch_permutation_basic(self):
         """Basic test of the _caffe2::BatchPermutation Node on Glow."""
 

--- a/torch_glow/tests/nodes/batchnorm0d_test.py
+++ b/torch_glow/tests/nodes/batchnorm0d_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
 
 
-class TestBatchNorm0D(unittest.TestCase):
+class TestBatchNorm0D(utils.TorchGlowTestCase):
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 0D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/batchnorm1d_test.py
+++ b/torch_glow/tests/nodes/batchnorm1d_test.py
@@ -1,13 +1,20 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
 
 
-class TestBatchNorm1D(unittest.TestCase):
+class TestBatchNorm1D(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
+        [
+            lambda: ("basic", torch.randn(2)),
+            lambda: ("nextthing", torch.randn(2)),
+        ]
+    )
+    def test_foo(self, name, tensor):
+        print(name, tensor)
+
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 1D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/batchnorm2d_test.py
+++ b/torch_glow/tests/nodes/batchnorm2d_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
 
 
-class TestBatchNorm2D(unittest.TestCase):
+class TestBatchNorm2D(utils.TorchGlowTestCase):
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 2D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/batchnorm3d_test.py
+++ b/torch_glow/tests/nodes/batchnorm3d_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
 
 
-class TestBatchNorm3D(unittest.TestCase):
+class TestBatchNorm3D(utils.TorchGlowTestCase):
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 3D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/bbox_transform_test.py
+++ b/torch_glow/tests/nodes/bbox_transform_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import numpy as np
 import torch
 from tests import utils
@@ -65,7 +63,7 @@ def create_bbox_transform_inputs(roi_counts, num_classes, rotated):
     return rois, deltas, im_info
 
 
-class TestBBoxTransform(unittest.TestCase):
+class TestBBoxTransform(utils.TorchGlowTestCase):
     def test_bbox_transform_basic(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 

--- a/torch_glow/tests/nodes/bmm_test.py
+++ b/torch_glow/tests/nodes/bmm_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -11,7 +9,7 @@ class SimpleBmmModule(torch.nn.Module):
         return (a + a).bmm(b)
 
 
-class TestBmm(unittest.TestCase):
+class TestBmm(utils.TorchGlowTestCase):
     def test_bmm(self):
         """Basic test of the PyTorch bmm Node on Glow."""
 

--- a/torch_glow/tests/nodes/cat_test.py
+++ b/torch_glow/tests/nodes/cat_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -18,7 +16,7 @@ class SimpleCatModule(torch.nn.Module):
         return other
 
 
-class TestCat(unittest.TestCase):
+class TestCat(utils.TorchGlowTestCase):
     def test_cat_basic(self):
         """Basic test of the PyTorch cat Node on Glow."""
 

--- a/torch_glow/tests/nodes/ceil_test.py
+++ b/torch_glow/tests/nodes/ceil_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -12,7 +10,7 @@ class SimpleCeilModule(torch.nn.Module):
         return torch.ceil(c)
 
 
-class TestCeil(unittest.TestCase):
+class TestCeil(utils.TorchGlowTestCase):
     def test_ceil(self):
         """Basic test of the PyTorch Ceil Node on Glow."""
 

--- a/torch_glow/tests/nodes/clamp_min_test.py
+++ b/torch_glow/tests/nodes/clamp_min_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -15,7 +13,7 @@ class SimpleClampMinModel(torch.nn.Module):
         return torch.clamp_min(input, self.min)
 
 
-class TestClamp(unittest.TestCase):
+class TestClamp(utils.TorchGlowTestCase):
     def test_clamp_min(self):
         """Test of the PyTorch clamp_min Node on Glow."""
 

--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -17,12 +14,12 @@ class SimpleClampModel(torch.nn.Module):
         return torch.clamp(input, self.min, self.max)
 
 
-class TestClamp(unittest.TestCase):
-    @parameterized.expand(
+class TestClamp(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", 0.0, 0.8),
-            ("no_min", None, 0.8),
-            ("no_max", 0.0, None),
+            lambda: ("basic", 0.0, 0.8),
+            lambda: ("no_min", None, 0.8),
+            lambda: ("no_max", 0.0, None),
         ]
     )
     def test_clamp(self, _, min, max):

--- a/torch_glow/tests/nodes/cmp_test.py
+++ b/torch_glow/tests/nodes/cmp_test.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from typing import Union
 
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -49,7 +47,7 @@ class SimpleScalarVectorCmpModule(torch.nn.Module):
             return a != self.rhsScalar
 
 
-class TestCmp(unittest.TestCase):
+class TestCmp(utils.TorchGlowTestCase):
     def test_equal_basic(self):
         """Basic test of the PyTorch Equal Node on Glow."""
         utils.compare_tracing_methods(
@@ -158,92 +156,128 @@ class TestCmp(unittest.TestCase):
             fusible_ops={"aten::ge"},
         )
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            ("eq_tensor_scalar", "equal", "aten::eq", torch.randn(3, 4, 5), 0.5),
-            ("gt_tensor_scalar", "greaterThan", "aten::gt", torch.randn(3, 4, 5), 0.5),
-            ("ge_tensor_scalar", "greaterEqual", "aten::ge", torch.randn(3, 4, 5), 0.5),
-            ("le_tensor_scalar", "lessEqual", "aten::le", torch.randn(3, 4, 5), 0.5),
-            ("lt_tensor_scalar", "lessThan", "aten::lt", torch.randn(3, 4, 5), 0.5),
-            ("ne_tensor_scalar", "notEqual", "aten::ne", torch.randn(3, 4, 5), 0.5),
-            (
+            lambda: (
+                "eq_tensor_scalar",
+                "equal",
+                "aten::eq",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
+                "gt_tensor_scalar",
+                "greaterThan",
+                "aten::gt",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
+                "ge_tensor_scalar",
+                "greaterEqual",
+                "aten::ge",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
+                "le_tensor_scalar",
+                "lessEqual",
+                "aten::le",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
+                "lt_tensor_scalar",
+                "lessThan",
+                "aten::lt",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
+                "ne_tensor_scalar",
+                "notEqual",
+                "aten::ne",
+                torch.randn(3, 4, 5),
+                0.5,
+            ),
+            lambda: (
                 "eq_tensor_scalar_int64",
                 "equal",
                 "aten::eq",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "gt_tensor_scalar_int64",
                 "greaterThan",
                 "aten::gt",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "ge_tensor_scalar_int64",
                 "greaterEqual",
                 "aten::ge",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "le_tensor_scalar_int64",
                 "lessEqual",
                 "aten::le",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "lt_tensor_scalar_int64",
                 "lessThan",
                 "aten::lt",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "ne_tensor_scalar_int64",
                 "notEqual",
                 "aten::ne",
                 torch.randn(3, 4, 5).to(torch.int64),
                 5,
             ),
-            (
+            lambda: (
                 "eq_tensor_scalar_int32",
                 "equal",
                 "aten::eq",
                 torch.randn(3, 4, 5).to(torch.int32),
                 5,
             ),
-            (
+            lambda: (
                 "gt_tensor_scalar_int32",
                 "greaterThan",
                 "aten::gt",
                 torch.randn(3, 4, 5).to(torch.int32),
                 5,
             ),
-            (
+            lambda: (
                 "lt_tensor_scalar_int32",
                 "lessThan",
                 "aten::lt",
                 torch.randn(3, 4, 5).to(torch.int32),
                 5,
             ),
-            (
+            lambda: (
                 "eq_tensor_scalar_float_int",
                 "equal",
                 "aten::eq",
                 torch.randn(3, 4, 5),
                 5,
             ),
-            (
+            lambda: (
                 "gt_tensor_scalar_float_int",
                 "greaterThan",
                 "aten::gt",
                 torch.randn(3, 4, 5),
                 5,
             ),
-            (
+            lambda: (
                 "lt_tensor_scalar_float_int",
                 "lessThan",
                 "aten::lt",

--- a/torch_glow/tests/nodes/constant_chunk_test.py
+++ b/torch_glow/tests/nodes/constant_chunk_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleChunkModel(torch.nn.Module):
         return torch.chunk(input + input, self.chunks, self.dimension)
 
 
-class TestConstantChunk(unittest.TestCase):
+class TestConstantChunk(utils.TorchGlowTestCase):
     def test_constant_chunk_basic(self):
         """Test of prim::ConstantChunk node on glow"""
 

--- a/torch_glow/tests/nodes/contiguous_test.py
+++ b/torch_glow/tests/nodes/contiguous_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleContiguousModel(torch.nn.Module):
         return formatted + formatted
 
 
-class TestContiguous(unittest.TestCase):
+class TestContiguous(utils.TorchGlowTestCase):
     def test_contiguous_basic(self):
         """Test of the PyTorch contiguous Node on Glow."""
 

--- a/torch_glow/tests/nodes/conv3d_test.py
+++ b/torch_glow/tests/nodes/conv3d_test.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from collections import namedtuple
 
 import torch
 import torch.nn.functional as F
-from parameterized import parameterized
 from tests import utils
 
 
@@ -30,16 +28,16 @@ class SimpleConv3dModule(torch.nn.Module):
         return F.relu(conv)
 
 
-class TestConv3d(unittest.TestCase):
-    @parameterized.expand(
+class TestConv3d(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleConv3dModule(padding=1),
                 torch.randn(1, 4, 5, 5, 3),
                 torch.randn(8, 4, 3, 3, 3),
             ),
-            (
+            lambda: (
                 "with_bias",
                 SimpleConv3dModule(padding=1),
                 torch.randn(1, 4, 5, 5, 3),

--- a/torch_glow/tests/nodes/conv_transpose2d_test.py
+++ b/torch_glow/tests/nodes/conv_transpose2d_test.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from collections import namedtuple
 
 import torch
 import torch.nn.functional as F
-from parameterized import parameterized
 from tests import utils
 
 
@@ -32,16 +30,16 @@ class SimpleConvTranspose2dModule(torch.nn.Module):
         return F.relu(convTranspose)
 
 
-class TestConvTranpose2d(unittest.TestCase):
-    @parameterized.expand(
+class TestConvTranpose2d(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleConvTranspose2dModule(padding=1),
                 torch.randn(1, 4, 5, 5),
                 torch.randn(4, 8, 3, 3),
             ),
-            (
+            lambda: (
                 "with_bias",
                 SimpleConvTranspose2dModule(padding=1),
                 torch.randn(1, 4, 5, 5),

--- a/torch_glow/tests/nodes/cumsum_test.py
+++ b/torch_glow/tests/nodes/cumsum_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,22 +13,24 @@ class SimpleCumSumModule(torch.nn.Module):
         return torch.cumsum(tensor, dim=0)
 
 
-class TestCumSum(unittest.TestCase):
-    @parameterized.expand(
+class TestCumSum(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("1", torch.randn(1)),
-            ("2", torch.randn(2)),
-            ("20", torch.randn(20)),
+            lambda: ("1", False, torch.randn(1)),
+            lambda: ("2", False, torch.randn(2)),
+            lambda: ("20", False, torch.randn(20)),
             # TODO add these tests when multi-dimension is supported
-            # ("3x3", torch.randn(3, 3)),
-            # ("5x4", torch.randn(5, 4)),
-            # ("3x3x3", torch.randn(3, 4, 5)),
-            # ("3x4x5", torch.randn(3, 4, 5)),
-            # ("4x4x4x4", torch.randn(6, 5, 4, 3)),
-            # ("6x5x4x3", torch.randn(6, 5, 4, 3)),
+            lambda: ("3x3", True, torch.randn(3, 3)),
+            lambda: ("5x4", True, torch.randn(5, 4)),
+            lambda: ("3x3x3", True, torch.randn(3, 4, 5)),
+            lambda: ("3x4x5", True, torch.randn(3, 4, 5)),
+            lambda: ("4x4x4x4", True, torch.randn(6, 5, 4, 3)),
+            lambda: ("6x5x4x3", True, torch.randn(6, 5, 4, 3)),
         ]
     )
-    def test_cumsum(self, _, tensor):
+    def test_cumsum(self, _, skip, tensor):
+        if skip:
+            self.skipTest("multi-dimension is supported yet support")
         utils.compare_tracing_methods(
             SimpleCumSumModule(), tensor, fusible_ops={"aten::cumsum"}
         )

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -19,32 +16,47 @@ class SimpleDivModule(torch.nn.Module):
             return c.div(c)
 
 
-class TestDiv(unittest.TestCase):
-    @parameterized.expand(
+class TestDiv(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleDivModule(), torch.randn(4), torch.randn(4)),
-            (
+            lambda: ("basic", SimpleDivModule(), torch.randn(4), torch.randn(4)),
+            lambda: (
                 "broadcast",
                 SimpleDivModule(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(4, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleDivModule(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(1, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleDivModule(),
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
-            ("float_tensor", SimpleDivModule(), torch.randn(4), torch.tensor(3.9)),
-            ("int_tensor", SimpleDivModule(), torch.tensor([4]), torch.tensor([10])),
+            lambda: (
+                "float_tensor",
+                SimpleDivModule(),
+                torch.randn(4),
+                torch.tensor(3.9),
+            ),
+            lambda: (
+                "int_tensor",
+                SimpleDivModule(),
+                torch.tensor([4]),
+                torch.tensor([10]),
+            ),
             # This one will go through (a * a) / b.item() and b.item() is an integer.
-            ("int_number", SimpleDivModule(), torch.tensor([4]), torch.tensor(10)),
+            lambda: (
+                "int_number",
+                SimpleDivModule(),
+                torch.tensor([4]),
+                torch.tensor(10),
+            ),
         ]
     )
     def test_div(self, _, module, a, b):

--- a/torch_glow/tests/nodes/dropout_test.py
+++ b/torch_glow/tests/nodes/dropout_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -20,7 +18,7 @@ class SimpleDropoutModule(torch.nn.Module):
         )
 
 
-class TestDropout(unittest.TestCase):
+class TestDropout(utils.TorchGlowTestCase):
     def test_dropout(self):
         """Basic test of the PyTorch aten::dropout Node on Glow."""
 

--- a/torch_glow/tests/nodes/embedding_bag_test.py
+++ b/torch_glow/tests/nodes/embedding_bag_test.py
@@ -1,15 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import numpy as np
 import torch
-from parameterized import parameterized
 from tests import utils
 from tests.utils import DEFAULT_BACKEND, check_skip
 
 
-class TestEmbeddingBag(unittest.TestCase):
+class TestEmbeddingBag(utils.TorchGlowTestCase):
     supported_backends = {"Interpreter", "NNPI"}
 
     def test_embedding_bag_basic(self):
@@ -42,12 +39,12 @@ class TestEmbeddingBag(unittest.TestCase):
         )
 
 
-class TestQuantizedEmbeddingBag(unittest.TestCase):
+class TestQuantizedEmbeddingBag(utils.TorchGlowTestCase):
     supported_backends = {"Interpreter", "NNPI"}
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            [
+            lambda: (
                 "{len}{bits}{weighted}{fp16}{sample_weights}{backend}".format(
                     len=num_lengths,
                     bits="_4bit" if is4bit else "_byte",
@@ -63,7 +60,7 @@ class TestQuantizedEmbeddingBag(unittest.TestCase):
                 is_weighted,
                 use_fp16,
                 per_sample_weights_fp16,
-            ]
+            )
             for num_lengths in [0, 8]
             for is4bit in [False, True]
             for is_weighted in [False, True]

--- a/torch_glow/tests/nodes/embedding_test.py
+++ b/torch_glow/tests/nodes/embedding_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 from tests.utils import check_skip
 
 
-class TestEmbedding(unittest.TestCase):
+class TestEmbedding(utils.TorchGlowTestCase):
     supported_backends = {"Interpreter", "NNPI"}
 
     def test_embedding_wt_float32_ind_int64(self):

--- a/torch_glow/tests/nodes/exp_test.py
+++ b/torch_glow/tests/nodes/exp_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -12,7 +10,7 @@ class SimpleExpModule(torch.nn.Module):
         return torch.exp(other)
 
 
-class TestExp(unittest.TestCase):
+class TestExp(utils.TorchGlowTestCase):
     def test_exp_basic(self):
         """Test of the PyTorch exp Node on Glow."""
 

--- a/torch_glow/tests/nodes/expand_as_test.py
+++ b/torch_glow/tests/nodes/expand_as_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -15,7 +13,7 @@ class ExpandAsModel(torch.nn.Module):
         return a.expand_as(self.other)
 
 
-class TestClamp(unittest.TestCase):
+class TestClamp(utils.TorchGlowTestCase):
     def test_clamp_min(self):
         """Test of the PyTorch expand_as Node on Glow."""
 

--- a/torch_glow/tests/nodes/flatten_test.py
+++ b/torch_glow/tests/nodes/flatten_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -17,15 +14,23 @@ class SimpleFlattenModule(torch.nn.Module):
         return torch.flatten(input, start_dim=self.start_dim, end_dim=self.end_dim)
 
 
-class TestFlatten(unittest.TestCase):
-    @parameterized.expand(
+class TestFlatten(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleFlattenModule(), torch.randn(2, 3, 2, 5)),
-            ("start_at_0", SimpleFlattenModule(0, 2), torch.randn(2, 3, 2, 5)),
-            ("start_in_middle", SimpleFlattenModule(1, 2), torch.randn(2, 3, 2, 5)),
-            ("negative_end_dim", SimpleFlattenModule(0, -2), torch.randn(2, 3, 2, 5)),
-            ("same_dim", SimpleFlattenModule(2, 2), torch.randn(2, 3, 2, 5)),
-            (
+            lambda: ("basic", SimpleFlattenModule(), torch.randn(2, 3, 2, 5)),
+            lambda: ("start_at_0", SimpleFlattenModule(0, 2), torch.randn(2, 3, 2, 5)),
+            lambda: (
+                "start_in_middle",
+                SimpleFlattenModule(1, 2),
+                torch.randn(2, 3, 2, 5),
+            ),
+            lambda: (
+                "negative_end_dim",
+                SimpleFlattenModule(0, -2),
+                torch.randn(2, 3, 2, 5),
+            ),
+            lambda: ("same_dim", SimpleFlattenModule(2, 2), torch.randn(2, 3, 2, 5)),
+            lambda: (
                 "negative_start_dim",
                 SimpleFlattenModule(-3, -1),
                 torch.randn(2, 3, 2, 5),

--- a/torch_glow/tests/nodes/floor_div_test.py
+++ b/torch_glow/tests/nodes/floor_div_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -21,58 +18,58 @@ class SimpleFloorDivideModule(torch.nn.Module):
             return (a + a).floor_divide(b)
 
 
-class TestFloorDiv(unittest.TestCase):
-    @parameterized.expand(
+class TestFloorDiv(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleFloorDivideModule(),
                 torch.Tensor(4).random_(0, 5),
                 torch.Tensor(4).random_(1, 5),
             ),
-            (
+            lambda: (
                 "inplace",
                 SimpleFloorDivideModule(True),
                 torch.Tensor(4).random_(0, 5),
                 torch.Tensor(4).random_(1, 5),
             ),
-            (
+            lambda: (
                 "positive_float",
                 SimpleFloorDivideModule(),
                 torch.Tensor(4).random_(0, 5),
                 torch.tensor(3.9),
             ),
-            (
+            lambda: (
                 "negative_float",
                 SimpleFloorDivideModule(),
                 torch.tensor([-4.0]),
                 torch.tensor([3.0]),
             ),
-            (
+            lambda: (
                 "positive_broadcast",
                 SimpleFloorDivideModule(),
                 torch.Tensor(8, 3, 4, 2).random_(0, 5),
                 torch.Tensor(4, 2).random_(1, 5),
             ),
-            (
+            lambda: (
                 "positive_broadcast",
                 SimpleFloorDivideModule(),
                 torch.Tensor(8, 3, 4, 2).random_(0, 5),
                 torch.Tensor(1, 2).random_(1, 5),
             ),
-            (
+            lambda: (
                 "positive_broadcast",
                 SimpleFloorDivideModule(),
                 torch.Tensor(4, 2).random_(0, 5),
                 torch.Tensor(8, 3, 4, 2).random_(1, 5),
             ),
-            (
+            lambda: (
                 "positive_int",
                 SimpleFloorDivideModule(),
                 torch.tensor([5]),
                 torch.tensor([4]),
             ),
-            (
+            lambda: (
                 "negative_int",
                 SimpleFloorDivideModule(),
                 torch.tensor([-5]),

--- a/torch_glow/tests/nodes/floor_test.py
+++ b/torch_glow/tests/nodes/floor_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -12,7 +10,7 @@ class SimpleFloorModule(torch.nn.Module):
         return torch.floor(c)
 
 
-class TestFloor(unittest.TestCase):
+class TestFloor(utils.TorchGlowTestCase):
     def test_floor(self):
         """Basic test of the PyTorch floor Node on Glow."""
 

--- a/torch_glow/tests/nodes/full_like_test.py
+++ b/torch_glow/tests/nodes/full_like_test.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
 
-class TestFullLike(unittest.TestCase):
+class TestFullLike(utils.TorchGlowTestCase):
     def test_empty_like_basic(self):
         """Basic test of the PyTorch empty_like Node on Glow."""
 

--- a/torch_glow/tests/nodes/gelu_test.py
+++ b/torch_glow/tests/nodes/gelu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -12,7 +10,7 @@ class SimpleGeluModule(torch.nn.Module):
         return F.gelu(tensor + tensor)
 
 
-class TestGelu(unittest.TestCase):
+class TestGelu(utils.TorchGlowTestCase):
     def test_gelu_basic(self):
         """Basic test of the PyTorch gelu Node on Glow."""
 

--- a/torch_glow/tests/nodes/getattr_test.py
+++ b/torch_glow/tests/nodes/getattr_test.py
@@ -1,14 +1,13 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch_glow
+from tests import utils
 from tests.utils import GLOW_FUSION_GROUP, SUBGRAPH_ATTR
 
 
-class TestGetAttr(unittest.TestCase):
+class TestGetAttr(utils.TorchGlowTestCase):
     def test_getattr(self):
         """Test fusion of the PyTorch prim::GetAttr Node into the Glow subgraph."""
         with torch.no_grad():

--- a/torch_glow/tests/nodes/iand_test.py
+++ b/torch_glow/tests/nodes/iand_test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,20 +15,20 @@ class SimpleIandModule(torch.nn.Module):
         return torch.logical_or(a, b)
 
 
-class TestIand(unittest.TestCase):
-    @parameterized.expand(
+class TestIand(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 torch.tensor([True, True, False, False], dtype=torch.bool),
                 torch.tensor([True, False, True, False], dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "basic_3d",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((3, 4, 5), dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcast_3d",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((4, 5), dtype=torch.bool),

--- a/torch_glow/tests/nodes/index_select_test.py
+++ b/torch_glow/tests/nodes/index_select_test.py
@@ -1,7 +1,4 @@
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -14,12 +11,12 @@ class IndexSelectModule(torch.nn.Module):
         return torch.index_select(tensor, self.dimension, index)
 
 
-class TestIndexSelect(unittest.TestCase):
-    @parameterized.expand(
+class TestIndexSelect(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("0-dim", torch.randn(3, 4), 0, torch.tensor([0, 2])),
-            ("1-dim", torch.randn(3, 4), 1, torch.tensor([0, 2])),
-            ("repeat index", torch.randn(3, 4), 1, torch.tensor([2, 2])),
+            lambda: ("0-dim", torch.randn(3, 4), 0, torch.tensor([0, 2])),
+            lambda: ("1-dim", torch.randn(3, 4), 1, torch.tensor([0, 2])),
+            lambda: ("repeat index", torch.randn(3, 4), 1, torch.tensor([2, 2])),
         ]
     )
     def test_index_select(self, _, tensor, dimension, index):

--- a/torch_glow/tests/nodes/layernorm_test.py
+++ b/torch_glow/tests/nodes/layernorm_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -16,7 +14,7 @@ class SimpleLayerNormModule(torch.nn.Module):
         return F.layer_norm(input, self.normalized_shape, weight, bias)
 
 
-class TestLayerNorm(unittest.TestCase):
+class TestLayerNorm(utils.TorchGlowTestCase):
     def test_layernorm_basic(self):
         """Basic test of the PyTorch layernorm Node on Glow."""
 

--- a/torch_glow/tests/nodes/linear_test.py
+++ b/torch_glow/tests/nodes/linear_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -15,7 +13,7 @@ class SimpleLinearModule(torch.nn.Module):
         return F.linear((input + input), weight, bias)
 
 
-class TestLinear(unittest.TestCase):
+class TestLinear(utils.TorchGlowTestCase):
     def test_linear_basic(self):
         """Basic test of the PyTorch aten::linear op on Glow."""
 

--- a/torch_glow/tests/nodes/log_softmax_test.py
+++ b/torch_glow/tests/nodes/log_softmax_test.py
@@ -4,7 +4,6 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from parameterized import parameterized
 from tests import utils
 
 
@@ -17,19 +16,19 @@ class SimpleLogSoftmaxModel(torch.nn.Module):
         return F.log_softmax(tensor, self.dimension)
 
 
-class TestLogSoftmax(unittest.TestCase):
-    @parameterized.expand(
+class TestLogSoftmax(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (-2, [2, 3]),
-            (-1, [2, 3]),
-            (0, [2, 3]),
-            (1, [2, 3]),
-            (-3, [2, 3, 4]),
-            (-2, [2, 3, 4]),
-            (-1, [2, 3, 4]),
-            (0, [2, 3, 4]),
-            (1, [2, 3, 4]),
-            (2, [2, 3, 4]),
+            lambda: (-2, [2, 3]),
+            lambda: (-1, [2, 3]),
+            lambda: (0, [2, 3]),
+            lambda: (1, [2, 3]),
+            lambda: (-3, [2, 3, 4]),
+            lambda: (-2, [2, 3, 4]),
+            lambda: (-1, [2, 3, 4]),
+            lambda: (0, [2, 3, 4]),
+            lambda: (1, [2, 3, 4]),
+            lambda: (2, [2, 3, 4]),
         ]
     )
     def test_log_softmax(self, dim, input_dims):

--- a/torch_glow/tests/nodes/log_test.py
+++ b/torch_glow/tests/nodes/log_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -18,7 +16,7 @@ class SimpleLogModule(torch.nn.Module):
         return torch.log(b)
 
 
-class TestLog(unittest.TestCase):
+class TestLog(utils.TorchGlowTestCase):
     def test_log_basic(self):
 
         x = 1 / torch.rand(3, 4, 5)

--- a/torch_glow/tests/nodes/logical_ops_test.py
+++ b/torch_glow/tests/nodes/logical_ops_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -43,15 +40,15 @@ class SimpleNotModule(torch.nn.Module):
         return torch.logical_not(b)
 
 
-class TestXor(unittest.TestCase):
-    @parameterized.expand(
+class TestXor(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((3, 4, 5), dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcast",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((4, 5), dtype=torch.bool),
@@ -68,15 +65,15 @@ class TestXor(unittest.TestCase):
         )
 
 
-class TestOr(unittest.TestCase):
-    @parameterized.expand(
+class TestOr(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((3, 4, 5), dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcast",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((4, 5), dtype=torch.bool),
@@ -93,15 +90,15 @@ class TestOr(unittest.TestCase):
         )
 
 
-class TestAnd(unittest.TestCase):
-    @parameterized.expand(
+class TestAnd(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((3, 4, 5), dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcast",
                 torch.zeros((3, 4, 5), dtype=torch.bool),
                 torch.ones((4, 5), dtype=torch.bool),
@@ -118,8 +115,10 @@ class TestAnd(unittest.TestCase):
         )
 
 
-class TestNot(unittest.TestCase):
-    @parameterized.expand([("basic", torch.zeros((3, 4, 5), dtype=torch.bool))])
+class TestNot(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
+        [lambda: ("basic", torch.zeros((3, 4, 5), dtype=torch.bool))]
+    )
     def test_not(self, _, a, skip_to_glow=False):
         utils.compare_tracing_methods(
             SimpleNotModule(),

--- a/torch_glow/tests/nodes/lstm_test.py
+++ b/torch_glow/tests/nodes/lstm_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
 
 
-class TestLSTM(unittest.TestCase):
+class TestLSTM(utils.TorchGlowTestCase):
     def test_lstm_basic(self):
         """Basic test of the PyTorch lstm Node on Glow."""
 

--- a/torch_glow/tests/nodes/masked_fill_test.py
+++ b/torch_glow/tests/nodes/masked_fill_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -21,22 +18,22 @@ class SimpleMaskedFillModule(torch.nn.Module):
             return torch.masked_fill(tensor + tensor, mask, 42.0)
 
 
-class TestMaskedFill(unittest.TestCase):
-    @parameterized.expand(
+class TestMaskedFill(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleMaskedFillModule(),
                 torch.randn([3]),
                 torch.tensor([True, False, True], dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcasted_unit_dim",
                 SimpleMaskedFillModule(),
                 torch.randn([4, 1, 3]),
                 torch.tensor([True, True, True], dtype=torch.bool),
             ),
-            (
+            lambda: (
                 "broadcasted_multi_dim",
                 SimpleMaskedFillModule(),
                 torch.randn([2, 4, 3, 3]),
@@ -44,7 +41,7 @@ class TestMaskedFill(unittest.TestCase):
                     [[[[True, False, True]]], [[[True, False, True]]]], dtype=torch.bool
                 ),
             ),
-            (
+            lambda: (
                 "inplace",
                 SimpleMaskedFillModule(True),
                 torch.randn([3]),

--- a/torch_glow/tests/nodes/matmul_test.py
+++ b/torch_glow/tests/nodes/matmul_test.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
-import unittest
 
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,16 +14,16 @@ class SimpleMatmulModule(torch.nn.Module):
         return a.matmul(b + b)
 
 
-class TestMatMul(unittest.TestCase):
-    @parameterized.expand(
+class TestMatMul(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("1d_1d", torch.randn(4), torch.randn(4)),
-            ("1d_2d", torch.randn(4), torch.randn(4, 9)),
-            ("1d_3d", torch.randn(4), torch.randn(3, 4, 9)),
-            ("1d_4d", torch.randn(4), torch.randn(5, 3, 4, 9)),
-            ("2d_1d", torch.randn(9, 4), torch.randn(4)),
-            ("3d_1d", torch.randn(6, 9, 4), torch.randn(4)),
-            ("4d_1d", torch.randn(2, 6, 9, 4), torch.randn(4)),
+            lambda: ("1d_1d", torch.randn(4), torch.randn(4)),
+            lambda: ("1d_2d", torch.randn(4), torch.randn(4, 9)),
+            lambda: ("1d_3d", torch.randn(4), torch.randn(3, 4, 9)),
+            lambda: ("1d_4d", torch.randn(4), torch.randn(5, 3, 4, 9)),
+            lambda: ("2d_1d", torch.randn(9, 4), torch.randn(4)),
+            lambda: ("3d_1d", torch.randn(6, 9, 4), torch.randn(4)),
+            lambda: ("4d_1d", torch.randn(2, 6, 9, 4), torch.randn(4)),
         ]
     )
     def test_matmul(self, _, left, right):

--- a/torch_glow/tests/nodes/max_test.py
+++ b/torch_glow/tests/nodes/max_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -14,7 +12,7 @@ class SimpleMaxModule(torch.nn.Module):
         return torch.max(a + a, b + b)
 
 
-class TestMax(unittest.TestCase):
+class TestMax(utils.TorchGlowTestCase):
     def test_elementwise_max(self):
         """Test of the PyTorch max Node on Glow."""
 

--- a/torch_glow/tests/nodes/maxpool2d_test.py
+++ b/torch_glow/tests/nodes/maxpool2d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -23,7 +21,7 @@ class SimpleMaxPool2dTest(torch.nn.Module):
         )
 
 
-class TestMaxPool2d(unittest.TestCase):
+class TestMaxPool2d(utils.TorchGlowTestCase):
     def test_max_pool2d_basic(self):
         """Basic test of the PyTorch max_pool2d Node on Glow."""
 

--- a/torch_glow/tests/nodes/mean_test.py
+++ b/torch_glow/tests/nodes/mean_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -18,7 +16,7 @@ class SimpleMeanModule(torch.nn.Module):
             return torch.mean(a + b)
 
 
-class TestMean(unittest.TestCase):
+class TestMean(utils.TorchGlowTestCase):
     def test_basic(self):
         """Test of the PyTorch mean Node on Glow."""
 

--- a/torch_glow/tests/nodes/min_test.py
+++ b/torch_glow/tests/nodes/min_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -14,7 +12,7 @@ class SimpleMinModule(torch.nn.Module):
         return torch.min(a + a, b + b)
 
 
-class TestMin(unittest.TestCase):
+class TestMin(utils.TorchGlowTestCase):
     def test_elementwise_min(self):
         """Test of the PyTorch min Node on Glow."""
 

--- a/torch_glow/tests/nodes/mm_test.py
+++ b/torch_glow/tests/nodes/mm_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -15,7 +13,7 @@ class SimpleMmModule(torch.nn.Module):
         return r.mm(t)
 
 
-class TestMm(unittest.TestCase):
+class TestMm(utils.TorchGlowTestCase):
     def test_mm_basic(self):
         """Test of the PyTorch mm Node on Glow."""
 

--- a/torch_glow/tests/nodes/mul_test.py
+++ b/torch_glow/tests/nodes/mul_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,15 +13,15 @@ class SimpleMulModule(torch.nn.Module):
         return other.mul(other)
 
 
-class TestMul(unittest.TestCase):
-    @parameterized.expand(
+class TestMul(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", torch.randn(4), torch.randn(4)),
-            ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(4, 2)),
-            ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(1, 2)),
-            ("broadcast", torch.randn(4, 2), torch.randn(8, 3, 4, 2)),
-            ("float", torch.randn(4, 2), torch.tensor(3.2)),
-            ("int", torch.randn(4, 2), torch.tensor(22), True),
+            lambda: ("basic", torch.randn(4), torch.randn(4)),
+            lambda: ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(4, 2)),
+            lambda: ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(1, 2)),
+            lambda: ("broadcast", torch.randn(4, 2), torch.randn(8, 3, 4, 2)),
+            lambda: ("float", torch.randn(4, 2), torch.tensor(3.2)),
+            lambda: ("int", torch.randn(4, 2), torch.tensor(22), True),
         ]
     )
     def test_mul(self, _, left, right, skip_to_glow=False):

--- a/torch_glow/tests/nodes/norm_test.py
+++ b/torch_glow/tests/nodes/norm_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleNormModule(torch.nn.Module):
         return torch.norm(tensor, *self.args, **self.kwargs)
 
 
-class TestNorm(unittest.TestCase):
+class TestNorm(utils.TorchGlowTestCase):
     def test_norm_basic(self):
         """Basic test of the PyTorch norm Node on Glow."""
 

--- a/torch_glow/tests/nodes/num_to_tensor_test.py
+++ b/torch_glow/tests/nodes/num_to_tensor_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -25,7 +23,7 @@ class SimpleNumToTensorModule(torch.nn.Module):
         return torch.cat((at0.reshape(1), at1.reshape(1)))
 
 
-class TestNumToTensor(unittest.TestCase):
+class TestNumToTensor(utils.TorchGlowTestCase):
     def test_NumToTensor_basic(self):
         """Basic test of the PyTorch NumToTensor Node on Glow."""
 

--- a/torch_glow/tests/nodes/permute_test.py
+++ b/torch_glow/tests/nodes/permute_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -15,7 +13,7 @@ class SimplePermuteModule(torch.nn.Module):
         return tensor.permute(*self.dimensions)
 
 
-class TestPermute(unittest.TestCase):
+class TestPermute(utils.TorchGlowTestCase):
     def test_permute(self):
         """Basic test of the PyTorch aten::permute node on Glow."""
 

--- a/torch_glow/tests/nodes/pow_test.py
+++ b/torch_glow/tests/nodes/pow_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,13 +13,13 @@ class SimplePowModule(torch.nn.Module):
         return torch.pow(tensor, self.power)
 
 
-class TestPow(unittest.TestCase):
-    @parameterized.expand(
+class TestPow(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("float", 2.2),
-            ("tensor_basic", torch.randn(4) + 2),
-            ("tensor_size[]", torch.tensor(2.2)),
-            ("tensor_broadcast", torch.randn(1) + 2),
+            lambda: ("float", 2.2),
+            lambda: ("tensor_basic", torch.randn(4) + 2),
+            lambda: ("tensor_size[]", torch.tensor(2.2)),
+            lambda: ("tensor_broadcast", torch.randn(1) + 2),
         ]
     )
     def test_pow_basic(self, _, power):

--- a/torch_glow/tests/nodes/prelu_test.py
+++ b/torch_glow/tests/nodes/prelu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -15,7 +13,7 @@ class SimplePreluModule(torch.nn.Module):
         return F.prelu(inputs + inputs, weights)
 
 
-class TestPrelu(unittest.TestCase):
+class TestPrelu(utils.TorchGlowTestCase):
     def test_prelu_basic(self):
         """Basic test of the PyTorch prelu Node on Glow."""
 

--- a/torch_glow/tests/nodes/quantized_add_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_add_relu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -25,7 +23,7 @@ class SimpleQuantizedAddReluModule(torch.nn.Module):
         )
 
 
-class TestQuantizedAddRelu(unittest.TestCase):
+class TestQuantizedAddRelu(utils.TorchGlowTestCase):
     def test_quantized_add_relu_zerooffset(self):
         """Basic test of the PyTorch quantized::add Node_relu on Glow with zero offset."""
 

--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -25,7 +23,7 @@ class SimpleQuantizedAddModule(torch.nn.Module):
         )
 
 
-class TestQuantizedAdd(unittest.TestCase):
+class TestQuantizedAdd(utils.TorchGlowTestCase):
     def test_quantized_add_zerooffset(self):
         """Basic test of the PyTorch quantized::add Node on Glow with zero offset."""
 

--- a/torch_glow/tests/nodes/quantized_avgpool2d_test.py
+++ b/torch_glow/tests/nodes/quantized_avgpool2d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -18,7 +16,7 @@ class SimpleQuantizedAvgPool2DModule(torch.nn.Module):
         return torch.nn.quantized.DeQuantize()(self.average_pool(self.quantize(inputs)))
 
 
-class TestQuantizedAvgPool(unittest.TestCase):
+class TestQuantizedAvgPool(utils.TorchGlowTestCase):
     def test_quantized_avgpool(self):
         """Basic test of the PyTorch quantized::avg_pool2d Node on Glow."""
 

--- a/torch_glow/tests/nodes/quantized_avgpool3d_test.py
+++ b/torch_glow/tests/nodes/quantized_avgpool3d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -18,7 +16,7 @@ class SimpleQuantizedAvgPool3DModule(torch.nn.Module):
         return torch.nn.quantized.DeQuantize()(self.average_pool(self.quantize(inputs)))
 
 
-class TestQuantizedAvgPool3D(unittest.TestCase):
+class TestQuantizedAvgPool3D(utils.TorchGlowTestCase):
     def test_quantized_avgpool3d(self):
         """Basic test of the PyTorch quantized::avg_pool2d Node on Glow."""
 

--- a/torch_glow/tests/nodes/quantized_batchnorm2d_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm2d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
@@ -14,7 +12,7 @@ my_qconfig = QConfig(
 )
 
 
-class TestQuantizedBatchNorm2D(unittest.TestCase):
+class TestQuantizedBatchNorm2D(utils.TorchGlowTestCase):
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 3D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
@@ -22,7 +20,7 @@ my_qconfig = QConfig(
 )
 
 
-class TestQuantizedBatchNorm3DRelu(unittest.TestCase):
+class TestQuantizedBatchNorm3DRelu(utils.TorchGlowTestCase):
     def test_batchnorm_relu_basic(self):
         """
         Basic test of the PyTorch 3D batchnorm RELU Node on Glow.

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn as nn
 from tests import utils
@@ -14,7 +12,7 @@ my_qconfig = QConfig(
 )
 
 
-class TestQuantizedBatchNorm3D(unittest.TestCase):
+class TestQuantizedBatchNorm3D(utils.TorchGlowTestCase):
     def test_batchnorm_basic(self):
         """
         Basic test of the PyTorch 3D batchnorm Node on Glow.

--- a/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from collections import OrderedDict
 
 import torch
 from tests import utils
 
 
-class TestQuantizedConv2dRelu(unittest.TestCase):
+class TestQuantizedConv2dRelu(utils.TorchGlowTestCase):
     def _test_quantized_conv2d_relu_packed(self, groups):
         """Basic test of PyTorch quantized::conv2d_relu Node with packed weights on Glow."""
         with torch.no_grad():

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -6,7 +6,7 @@ import torch
 from tests import utils
 
 
-class TestQuantizedConv2d(unittest.TestCase):
+class TestQuantizedConv2d(utils.TorchGlowTestCase):
     @unittest.skip(reason="Requires freezing")
     def test_quantized_conv2d_unpacked(self):
         """Basic test of the PyTorch quantize::conv2d Node with unpacked weights on Glow."""

--- a/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
 from collections import OrderedDict
 
 import torch
 from tests import utils
 
 
-class TestQuantizedConv3dRelu(unittest.TestCase):
+class TestQuantizedConv3dRelu(utils.TorchGlowTestCase):
     def _test_quantized_conv3d_relu_packed(self, groups):
         """Basic test of PyTorch quantized::conv3d_relu Node with packed weights on Glow."""
         with torch.no_grad():

--- a/torch_glow/tests/nodes/quantized_conv3d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_test.py
@@ -40,7 +40,7 @@ class PackedConv3dModel(torch.nn.Sequential):
         torch.quantization.convert(self, inplace=True)
 
 
-class TestQuantizedConv3d(unittest.TestCase):
+class TestQuantizedConv3d(utils.TorchGlowTestCase):
     @unittest.skip(reason="Requires freezing")
     def test_quantized_conv3d_unpacked(self):
         """Basic test of the PyTorch quantize::conv3d Node with unpacked weights on Glow."""

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -1,7 +1,4 @@
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -48,10 +45,10 @@ def _make_input(size, duplications, shape, dtype=torch.float):
     return tensor
 
 
-class TestQuantizedLinear(unittest.TestCase):
-    @parameterized.expand(
+class TestQuantizedLinear(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleQuantizedLinearModel(
                     5,
@@ -65,7 +62,7 @@ class TestQuantizedLinear(unittest.TestCase):
                 ),
                 _make_input(5, 6, [3, 2, 5]),
             ),
-            (
+            lambda: (
                 "no_bias",
                 SimpleQuantizedLinearModel(
                     5,
@@ -78,7 +75,7 @@ class TestQuantizedLinear(unittest.TestCase):
                 ),
                 _make_input(5, 6, [3, 2, 5]),
             ),
-            (
+            lambda: (
                 "exclude_dq",
                 SimpleQuantizedLinearModel(
                     5,
@@ -93,7 +90,7 @@ class TestQuantizedLinear(unittest.TestCase):
                 _make_input(5, 6, [3, 2, 5]),
                 {"aten::dequantize"},
             ),
-            (
+            lambda: (
                 "rowwise",
                 SimpleQuantizedLinearModel(
                     6,
@@ -105,7 +102,7 @@ class TestQuantizedLinear(unittest.TestCase):
                 ),
                 _make_input(36, 1, [3, 2, 6]),
             ),
-            (
+            lambda: (
                 "tensorwise",
                 SimpleQuantizedLinearModel(
                     6,

--- a/torch_glow/tests/nodes/quantized_maxpool_test.py
+++ b/torch_glow/tests/nodes/quantized_maxpool_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -24,15 +21,15 @@ class SimpleQuantizedMaxPoolModel(torch.nn.Module):
         return dequantize(maxpool(quantize(tensor)))
 
 
-class TestQuantizedMaxPool(unittest.TestCase):
-    @parameterized.expand(
+class TestQuantizedMaxPool(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "basic",
                 SimpleQuantizedMaxPoolModel(1.0 / 128, 3, torch.quint8, 3),
                 torch.randn(1, 4, 5, 5),
             ),
-            (
+            lambda: (
                 "cut_q",
                 SimpleQuantizedMaxPoolModel(1.0 / 128, 3, torch.quint8, 3),
                 torch.randn(1, 4, 5, 5),

--- a/torch_glow/tests/nodes/quantized_mul_test.py
+++ b/torch_glow/tests/nodes/quantized_mul_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -33,10 +30,10 @@ class SimpleQuantizedMulModel(torch.nn.Module):
             )
 
 
-class TestQuantizedMul(unittest.TestCase):
-    @parameterized.expand(
+class TestQuantizedMul(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "zero_offset",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -51,7 +48,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.tensor([1, 2, 3, 4], dtype=torch.float32),
                 torch.tensor([5, 6, 7, 8], dtype=torch.float32),
             ),
-            (
+            lambda: (
                 "basic",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -66,7 +63,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn([5, 5]),
                 torch.randn([5, 5]),
             ),
-            (
+            lambda: (
                 "cut_q_dq",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -82,7 +79,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn([5, 5]),
                 ["aten::quantize_per_tensor", "aten::dequantize"],
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -98,7 +95,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn([1, 5, 1, 1]),
                 ["aten::quantize_per_tensor", "aten::dequantize"],
             ),
-            (
+            lambda: (
                 "positive_scalar",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -108,7 +105,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn(1, 2, 3, 4),
                 torch.tensor(3.14),
             ),
-            (
+            lambda: (
                 "negative_scalar",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -118,7 +115,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn(1, 2, 3, 4),
                 torch.tensor(-3.14),
             ),
-            (
+            lambda: (
                 "zero_scalar",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(
@@ -128,7 +125,7 @@ class TestQuantizedMul(unittest.TestCase):
                 torch.randn(1, 2, 3, 4),
                 torch.tensor(0.00),
             ),
-            (
+            lambda: (
                 "negative_int8_scalar",
                 SimpleQuantizedMulModel(
                     torch.nn.quantized.Quantize(

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -22,7 +20,7 @@ class SimpleQuantizedReluModel(torch.nn.Module):
         return dequantize(relu(quantize(tensor)))
 
 
-class TestQuantizedRelu(unittest.TestCase):
+class TestQuantizedRelu(utils.TorchGlowTestCase):
     def test_quantized_relu(self):
         """Basic test of the PyTorch quantized::relu Node on Glow."""
 

--- a/torch_glow/tests/nodes/reciprocal_test.py
+++ b/torch_glow/tests/nodes/reciprocal_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleReciprocalModel(torch.nn.Module):
         return other.reciprocal_() if self.inplace else torch.reciprocal(other)
 
 
-class TestReciprocal(unittest.TestCase):
+class TestReciprocal(utils.TorchGlowTestCase):
     def test_reciprocal(self):
         """Test of the PyTorch reciprocal Node on Glow."""
 

--- a/torch_glow/tests/nodes/relu_test.py
+++ b/torch_glow/tests/nodes/relu_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
 from tests import utils
@@ -17,7 +15,7 @@ class SimpleReluModel(torch.nn.Module):
         return F.relu(other, inplace=self.inplace)
 
 
-class TestRelu(unittest.TestCase):
+class TestRelu(utils.TorchGlowTestCase):
     def test_relu_basic(self):
         """Basic test of the PyTorch relu Node on Glow."""
 

--- a/torch_glow/tests/nodes/reshape_test.py
+++ b/torch_glow/tests/nodes/reshape_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleReshapeModel(torch.nn.Module):
         return combined.reshape(self.shape)
 
 
-class TestReshape(unittest.TestCase):
+class TestReshape(utils.TorchGlowTestCase):
     def test_reshape(self):
         """Test of the PyTorch reshape Node on Glow."""
 

--- a/torch_glow/tests/nodes/roi_align_rotated_test.py
+++ b/torch_glow/tests/nodes/roi_align_rotated_test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -60,31 +59,43 @@ class SimpleRoiAlignRotatedModel(torch.nn.Module):
         return torch.ops._caffe2.RoIAlignRotated(features, rois, **self.kwargs)
 
 
-class TestRoiAlignRotated(unittest.TestCase):
+class TestRoiAlignRotated(utils.TorchGlowTestCase):
     """TODO: Combine with TestRoiAlign"""
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleRoiAlignRotatedModel("NCHW"), torch.randn(1, 3, 16, 20)),
-            ("nhwc", SimpleRoiAlignRotatedModel("NHWC"), torch.randn(1, 16, 20, 3)),
-            ("batched", SimpleRoiAlignRotatedModel("NCHW"), torch.randn(4, 3, 16, 20)),
-            (
+            lambda: (
+                "basic",
+                SimpleRoiAlignRotatedModel("NCHW"),
+                torch.randn(1, 3, 16, 20),
+            ),
+            lambda: (
+                "nhwc",
+                SimpleRoiAlignRotatedModel("NHWC"),
+                torch.randn(1, 16, 20, 3),
+            ),
+            lambda: (
+                "batched",
+                SimpleRoiAlignRotatedModel("NCHW"),
+                torch.randn(4, 3, 16, 20),
+            ),
+            lambda: (
                 "horizontal",
                 SimpleRoiAlignRotatedModel("NCHW"),
                 torch.randn(4, 3, 16, 20),
                 True,
             ),
-            (
+            lambda: (
                 "scaled",
                 SimpleRoiAlignRotatedModel("NCHW", spatial_scale=0.0625),
                 torch.randn(1, 3, 224, 224),
             ),
-            (
+            lambda: (
                 "unaligned",
                 SimpleRoiAlignRotatedModel("NCHW", aligned=False),
                 torch.randn(1, 3, 16, 20),
             ),
-            (
+            lambda: (
                 "dynamic_sampling",
                 SimpleRoiAlignRotatedModel("NCHW", sampling_ratio=0),
                 torch.randn(1, 3, 16, 20),

--- a/torch_glow/tests/nodes/roi_align_test.py
+++ b/torch_glow/tests/nodes/roi_align_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -57,23 +54,23 @@ class SimpleRoiAlignModel(torch.nn.Module):
         return torch.ops._caffe2.RoIAlign(features, rois, **self.kwargs)
 
 
-class TestRoiAlign(unittest.TestCase):
-    @parameterized.expand(
+class TestRoiAlign(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleRoiAlignModel("NCHW"), torch.randn(1, 3, 16, 20)),
-            ("nhwc", SimpleRoiAlignModel("NHWC"), torch.randn(1, 16, 20, 3)),
-            ("batched", SimpleRoiAlignModel("NCHW"), torch.randn(4, 3, 16, 20)),
-            (
+            lambda: ("basic", SimpleRoiAlignModel("NCHW"), torch.randn(1, 3, 16, 20)),
+            lambda: ("nhwc", SimpleRoiAlignModel("NHWC"), torch.randn(1, 16, 20, 3)),
+            lambda: ("batched", SimpleRoiAlignModel("NCHW"), torch.randn(4, 3, 16, 20)),
+            lambda: (
                 "scaled",
                 SimpleRoiAlignModel("NCHW", spatial_scale=0.0625),
                 torch.randn(1, 3, 224, 224),
             ),
-            (
+            lambda: (
                 "unaligned",
                 SimpleRoiAlignModel("NCHW", aligned=False),
                 torch.randn(1, 3, 16, 20),
             ),
-            (
+            lambda: (
                 "dynamic_sampling",
                 SimpleRoiAlignModel("NCHW", sampling_ratio=0),
                 torch.randn(1, 3, 16, 20),

--- a/torch_glow/tests/nodes/rsub_test.py
+++ b/torch_glow/tests/nodes/rsub_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -19,30 +16,30 @@ class SimpleRsubModel(torch.nn.Module):
             return torch.rsub(third, third)
 
 
-class TestRsub(unittest.TestCase):
-    @parameterized.expand(
+class TestRsub(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleRsubModel(), torch.randn(4), torch.randn(4)),
-            (
+            lambda: ("basic", SimpleRsubModel(), torch.randn(4), torch.randn(4)),
+            lambda: (
                 "broadcast",
                 SimpleRsubModel(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(4, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleRsubModel(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(1, 2),
             ),
-            (
+            lambda: (
                 "broadcast",
                 SimpleRsubModel(),
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
-            ("float", SimpleRsubModel(), torch.randn(4), torch.tensor(13.293)),
-            ("int", SimpleRsubModel(), torch.randn(4), torch.tensor(4)),
+            lambda: ("float", SimpleRsubModel(), torch.randn(4), torch.tensor(13.293)),
+            lambda: ("int", SimpleRsubModel(), torch.randn(4), torch.tensor(4)),
         ]
     )
     def test_rsub(self, _, module, tensor, other):

--- a/torch_glow/tests/nodes/select_test.py
+++ b/torch_glow/tests/nodes/select_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -40,18 +37,22 @@ class SelectModule(torch.nn.Module):
                     return (a + a)[self.indices[0], self.indices[1], self.indices[2]]
 
 
-class TestComplexSelect(unittest.TestCase):
-    @parameterized.expand(
+class TestComplexSelect(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("2d_axis_0", SelectModule([1], 0, 2), torch.rand(2, 3)),
-            ("2d_axis_1", SelectModule([2], 1, 2), torch.rand(2, 3)),
-            ("2d_axis_0_1", SelectModule([0, 1], 2, 2), torch.rand(2, 3)),
-            ("3d_axis_0", SelectModule([0], 0, 3), torch.rand(3, 4, 5)),
-            ("3d_axis_0_1", SelectModule([2, 1], 0, 3), torch.rand(3, 4, 5)),
-            ("3d_axis_1", SelectModule([0], 1, 3), torch.rand(3, 4, 5)),
-            ("3d_axis_1_2", SelectModule([2, 1], 1, 3), torch.rand(3, 4, 5)),
-            ("3d_axis_0_2", SelectModule([1, 3], 2, 3), torch.rand(3, 4, 5)),
-            ("3d_axis_0_1_2", SelectModule([2, 0, 4], 1, 3), torch.rand(3, 4, 5)),
+            lambda: ("2d_axis_0", SelectModule([1], 0, 2), torch.rand(2, 3)),
+            lambda: ("2d_axis_1", SelectModule([2], 1, 2), torch.rand(2, 3)),
+            lambda: ("2d_axis_0_1", SelectModule([0, 1], 2, 2), torch.rand(2, 3)),
+            lambda: ("3d_axis_0", SelectModule([0], 0, 3), torch.rand(3, 4, 5)),
+            lambda: ("3d_axis_0_1", SelectModule([2, 1], 0, 3), torch.rand(3, 4, 5)),
+            lambda: ("3d_axis_1", SelectModule([0], 1, 3), torch.rand(3, 4, 5)),
+            lambda: ("3d_axis_1_2", SelectModule([2, 1], 1, 3), torch.rand(3, 4, 5)),
+            lambda: ("3d_axis_0_2", SelectModule([1, 3], 2, 3), torch.rand(3, 4, 5)),
+            lambda: (
+                "3d_axis_0_1_2",
+                SelectModule([2, 0, 4], 1, 3),
+                torch.rand(3, 4, 5),
+            ),
         ]
     )
     def test_f(self, _, module, tensor):

--- a/torch_glow/tests/nodes/shape_as_tensor_test.py
+++ b/torch_glow/tests/nodes/shape_as_tensor_test.py
@@ -1,10 +1,7 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -17,11 +14,15 @@ class SimpleShapeAsTensorModel(torch.nn.Module):
         return result + result
 
 
-class TestShapeAsTensor(unittest.TestCase):
-    @parameterized.expand(
+class TestShapeAsTensor(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("single dimension", SimpleShapeAsTensorModel(), torch.randn(6)),
-            ("multiple dimensions", SimpleShapeAsTensorModel(), torch.randn(3, 2, 4)),
+            lambda: ("single dimension", SimpleShapeAsTensorModel(), torch.randn(6)),
+            lambda: (
+                "multiple dimensions",
+                SimpleShapeAsTensorModel(),
+                torch.randn(3, 2, 4),
+            ),
         ]
     )
     def test_shape_as_tensor(self, _, module, tensor):

--- a/torch_glow/tests/nodes/sigmoid_test.py
+++ b/torch_glow/tests/nodes/sigmoid_test.py
@@ -1,10 +1,7 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -22,11 +19,11 @@ class SimpleSigmoidModel(torch.nn.Module):
             return other.sigmoid()
 
 
-class TestSigmoid(unittest.TestCase):
-    @parameterized.expand(
+class TestSigmoid(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleSigmoidModel(), torch.randn(6)),
-            ("inplace", SimpleSigmoidModel(inplace=True), torch.randn(6)),
+            lambda: ("basic", SimpleSigmoidModel(), torch.randn(6)),
+            lambda: ("inplace", SimpleSigmoidModel(inplace=True), torch.randn(6)),
         ]
     )
     def test_sigmoid(self, _, module, tensor):

--- a/torch_glow/tests/nodes/size_test.py
+++ b/torch_glow/tests/nodes/size_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,7 +13,7 @@ class SimpleSizeModel(torch.nn.Module):
         return tensor.size(self.dimension)
 
 
-class TestSize(unittest.TestCase):
+class TestSize(utils.TorchGlowTestCase):
     # Need to be able to export lists from Glow fused nodes
     # Commented out both test cases for not triggering internal CI
     # @unittest.skip(reason="not ready")
@@ -31,14 +28,26 @@ class TestSize(unittest.TestCase):
 
     #    utils.compare_tracing_methods(test_f, x, fusible_ops={"aten::size"})
 
-    @parameterized.expand(
-        [("basic", SimpleSizeModel(-1), torch.randn(2, 3, 4, dtype=torch.float32))]
+    @utils.deterministic_expand(
+        [
+            lambda: (
+                "basic",
+                SimpleSizeModel(-1),
+                torch.randn(2, 3, 4, dtype=torch.float32),
+            )
+        ]
     )
     def test_size(self, _, module, tensor):
         utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::size"})
 
-    @parameterized.expand(
-        [("oob", SimpleSizeModel(-4), torch.randn(2, 3, 4, dtype=torch.float32))]
+    @utils.deterministic_expand(
+        [
+            lambda: (
+                "oob",
+                SimpleSizeModel(-4),
+                torch.randn(2, 3, 4, dtype=torch.float32),
+            )
+        ]
     )
     def test_size_failure(self, _, module, tensor):
         with self.assertRaises(IndexError):

--- a/torch_glow/tests/nodes/slice_test.py
+++ b/torch_glow/tests/nodes/slice_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -15,7 +13,7 @@ class SimpleSliceModel(torch.nn.Module):
         return other[0][1:]
 
 
-class TestSlice(unittest.TestCase):
+class TestSlice(utils.TorchGlowTestCase):
     def test_slice_basic(self):
         """Test of the PyTorch slice Node on Glow."""
 

--- a/torch_glow/tests/nodes/softmax_test.py
+++ b/torch_glow/tests/nodes/softmax_test.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 import torch.nn.functional as F
-from parameterized import parameterized
 from tests import utils
 
 
@@ -17,19 +14,19 @@ class SimpleSoftmaxModel(torch.nn.Module):
         return F.softmax(tensor, self.dimension)
 
 
-class TestSoftmax(unittest.TestCase):
-    @parameterized.expand(
+class TestSoftmax(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (-2, [2, 3]),
-            (-1, [2, 3]),
-            (0, [2, 3]),
-            (1, [2, 3]),
-            (-3, [2, 3, 4]),
-            (-2, [2, 3, 4]),
-            (-1, [2, 3, 4]),
-            (0, [2, 3, 4]),
-            (1, [2, 3, 4]),
-            (2, [2, 3, 4]),
+            lambda: (-2, [2, 3]),
+            lambda: (-1, [2, 3]),
+            lambda: (0, [2, 3]),
+            lambda: (1, [2, 3]),
+            lambda: (-3, [2, 3, 4]),
+            lambda: (-2, [2, 3, 4]),
+            lambda: (-1, [2, 3, 4]),
+            lambda: (0, [2, 3, 4]),
+            lambda: (1, [2, 3, 4]),
+            lambda: (2, [2, 3, 4]),
         ]
     )
     def test_softmax(self, dim, input_dims):

--- a/torch_glow/tests/nodes/sqrt_test.py
+++ b/torch_glow/tests/nodes/sqrt_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -20,7 +18,7 @@ class SimpleSqrtModel(torch.nn.Module):
             return torch.sqrt(tensor)
 
 
-class TestSqrt(unittest.TestCase):
+class TestSqrt(utils.TorchGlowTestCase):
     def test_sqrt_basic(self):
         """Test of the PyTorch sqrt Node on Glow."""
 

--- a/torch_glow/tests/nodes/squeeze_test.py
+++ b/torch_glow/tests/nodes/squeeze_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -27,13 +24,17 @@ class SimpleSqueezeModel(torch.nn.Module):
                 return torch.squeeze(tensor + tensor)
 
 
-class TestSqueeze(unittest.TestCase):
-    @parameterized.expand(
+class TestSqueeze(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleSqueezeModel(), torch.randn(1, 3, 1, 2, 5, 1)),
-            ("with_dim", SimpleSqueezeModel(2), torch.randn(1, 3, 1, 2, 5, 1)),
-            ("with_neg_dim", SimpleSqueezeModel(-1), torch.randn(1, 3, 1, 2, 5, 1)),
-            (
+            lambda: ("basic", SimpleSqueezeModel(), torch.randn(1, 3, 1, 2, 5, 1)),
+            lambda: ("with_dim", SimpleSqueezeModel(2), torch.randn(1, 3, 1, 2, 5, 1)),
+            lambda: (
+                "with_neg_dim",
+                SimpleSqueezeModel(-1),
+                torch.randn(1, 3, 1, 2, 5, 1),
+            ),
+            lambda: (
                 "inplace",
                 SimpleSqueezeModel(inplace=True),
                 torch.randn(1, 3, 1, 2, 5, 1),

--- a/torch_glow/tests/nodes/stack_test.py
+++ b/torch_glow/tests/nodes/stack_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleStackModel(torch.nn.Module):
         return torch.stack((d, d), 2)
 
 
-class TestStack(unittest.TestCase):
+class TestStack(utils.TorchGlowTestCase):
     def test_stack_basic(self):
         """Basic test of the PyTorch aten::stack Node on Glow."""
 

--- a/torch_glow/tests/nodes/sub_test.py
+++ b/torch_glow/tests/nodes/sub_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -19,30 +16,36 @@ class SimpleSubtractModel(torch.nn.Module):
             return c.sub(c)
 
 
-class TestSub(unittest.TestCase):
-    @parameterized.expand(
+class TestSub(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("basic", SimpleSubtractModel(), torch.randn(4), torch.randn(4)),
-            (
+            lambda: ("basic", SimpleSubtractModel(), torch.randn(4), torch.randn(4)),
+            lambda: (
                 "broadcast_1",
                 SimpleSubtractModel(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(4, 2),
             ),
-            (
+            lambda: (
                 "broadcast_2",
                 SimpleSubtractModel(),
                 torch.randn(8, 3, 4, 2),
                 torch.randn(1, 2),
             ),
-            (
+            lambda: (
                 "broadcast_3",
                 SimpleSubtractModel(),
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
-            ("float", SimpleSubtractModel(), torch.randn(4), torch.tensor(3.9)),
-            ("int", SimpleSubtractModel(), torch.randn(4), torch.tensor(20), True),
+            lambda: ("float", SimpleSubtractModel(), torch.randn(4), torch.tensor(3.9)),
+            lambda: (
+                "int",
+                SimpleSubtractModel(),
+                torch.randn(4),
+                torch.tensor(20),
+                True,
+            ),
         ]
     )
     def test_subtract(self, _, module, tensor, other, skip_to_glow=False):

--- a/torch_glow/tests/nodes/sum_test.py
+++ b/torch_glow/tests/nodes/sum_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -29,34 +26,34 @@ class KeepdimSumModule(torch.nn.Module):
         return torch.sum(b, self.axis, keepdim=self.keepdim, dtype=self.dtype)
 
 
-class TestSumBasic(unittest.TestCase):
+class TestSumBasic(utils.TorchGlowTestCase):
     def test_sum_basic(self):
         a = torch.randn(2, 3, 4)
 
         utils.compare_tracing_methods(SimpleSumModule(), a, fusible_ops={"aten::sum"})
 
 
-class TestSumKeepdim(unittest.TestCase):
-    @parameterized.expand(
+class TestSumKeepdim(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("keepdim", KeepdimSumModule(0, True), torch.randn(2, 3, 4)),
-            ("axis_1", KeepdimSumModule(1, False), torch.randn(4, 3, 4)),
-            (
+            lambda: ("keepdim", KeepdimSumModule(0, True), torch.randn(2, 3, 4)),
+            lambda: ("axis_1", KeepdimSumModule(1, False), torch.randn(4, 3, 4)),
+            lambda: (
                 "axis_2_keepdim_f16",
                 KeepdimSumModule(2, True, torch.float16),
                 torch.randn(5, 2, 4),
             ),
-            (
+            lambda: (
                 "axis_1_f16",
                 KeepdimSumModule(1, False, torch.float16),
                 torch.randn(3, 1, 2),
             ),
-            (
+            lambda: (
                 "neg_axis_f16",
                 KeepdimSumModule(-2, False, torch.float16),
                 torch.randn(3, 1, 2),
             ),
-            (
+            lambda: (
                 "neg_axis_keepdim",
                 KeepdimSumModule(-2, True),
                 torch.randn(3, 1, 2),

--- a/torch_glow/tests/nodes/tanh_test.py
+++ b/torch_glow/tests/nodes/tanh_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleTanhModel(torch.nn.Module):
         return tensor.tanh_() if self.inplace else tensor.tanh()
 
 
-class TestTanh(unittest.TestCase):
+class TestTanh(utils.TorchGlowTestCase):
     def test_tanh(self):
         """Basic test of the PyTorch aten::tanh Node on Glow."""
 

--- a/torch_glow/tests/nodes/to_test.py
+++ b/torch_glow/tests/nodes/to_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -48,23 +45,23 @@ class SimplePrimToModel(torch.nn.Module):
         return torch.ops.prim.NumToTensor(dummy.size(0)).to(self.conversion)
 
 
-class TestTo(unittest.TestCase):
-    @parameterized.expand(
+class TestTo(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("to_int", SimpleToModel(torch.int), torch.randn(1, 2, 3, 4)),
-            ("to_float", SimpleToModel(torch.float), torch.randn(1, 2, 3, 4)),
-            (
+            lambda: ("to_int", SimpleToModel(torch.int), torch.randn(1, 2, 3, 4)),
+            lambda: ("to_float", SimpleToModel(torch.float), torch.randn(1, 2, 3, 4)),
+            lambda: (
                 "to_int_to_float",
                 SimpleToModel(torch.int, torch.float),
                 torch.randn(1, 2, 3, 4),
             ),
-            (
+            lambda: (
                 "to_int_with_device",
                 ToWithDeviceModel(torch.int),
                 torch.randn(1, 2, 3, 4),
             ),
-            ("to_cpu", SimpleToModel("cpu"), torch.randn(1, 2, 3, 4)),
-            (
+            lambda: ("to_cpu", SimpleToModel("cpu"), torch.randn(1, 2, 3, 4)),
+            lambda: (
                 "to_tensor",
                 SimpleToModel(torch.randn(3, 4).type(torch.int32)),
                 torch.randn(1, 2, 3, 4),
@@ -74,12 +71,16 @@ class TestTo(unittest.TestCase):
     def test_to(self, _, module, tensor):
         utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::to"})
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            ("to_prim_dtype", SimplePrimToModel(torch.float), torch.randn(5, 6, 7)),
+            lambda: (
+                "to_prim_dtype",
+                SimplePrimToModel(torch.float),
+                torch.randn(5, 6, 7),
+            ),
             # The following test is not yet supported:
             # ("to_prim_device", SimplePrimToModel("cpu"), torch.randn(5, 6, 7)),
-            (
+            lambda: (
                 "to_prim_device_with_dtype",
                 SimplePrimToModel(torch.float, "cpu"),
                 torch.randn(5, 6, 7),

--- a/torch_glow/tests/nodes/topk_test.py
+++ b/torch_glow/tests/nodes/topk_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
 from tests import utils
 
@@ -16,7 +14,7 @@ class SimpleTopkModel(torch.nn.Module):
         return torch.topk(tensor, self.count)
 
 
-class TestTopk(unittest.TestCase):
+class TestTopk(utils.TorchGlowTestCase):
     def test_topk_basic(self):
         """Test of the PyTorch TopK Node on Glow."""
         utils.compare_tracing_methods(

--- a/torch_glow/tests/nodes/trig_ops_test.py
+++ b/torch_glow/tests/nodes/trig_ops_test.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import numpy as np
 import torch
 from tests import utils
@@ -47,7 +45,7 @@ class SimpleATanModule(torch.nn.Module):
         return torch.atan(a + a)
 
 
-class TestCos(unittest.TestCase):
+class TestCos(utils.TorchGlowTestCase):
     def test_cos(self, skip_to_glow=False):
         # Ensures range is in [-2*pi, 2*pi]
         x = 4 * np.pi * (torch.rand(2, 3, 4) - 0.5)
@@ -56,7 +54,7 @@ class TestCos(unittest.TestCase):
         )
 
 
-class TestSin(unittest.TestCase):
+class TestSin(utils.TorchGlowTestCase):
     def test_sin(self, skip_to_glow=False):
         # Ensures range is in [-2*pi, 2*pi]
         x = 4 * np.pi * (torch.rand(2, 3, 4) - 0.5)
@@ -65,7 +63,7 @@ class TestSin(unittest.TestCase):
         )
 
 
-class TestACos(unittest.TestCase):
+class TestACos(utils.TorchGlowTestCase):
     def test_acos(self, skip_to_glow=False):
         x = torch.rand(2, 3, 4) - 0.5  # Ensures range is in [-1,1]
         utils.compare_tracing_methods(
@@ -73,7 +71,7 @@ class TestACos(unittest.TestCase):
         )
 
 
-class TestASin(unittest.TestCase):
+class TestASin(utils.TorchGlowTestCase):
     def test_asin(self, skip_to_glow=False):
         x = torch.rand(2, 3, 4) - 0.5  # Ensures range is in [-1,1]
         utils.compare_tracing_methods(
@@ -81,7 +79,7 @@ class TestASin(unittest.TestCase):
         )
 
 
-class TestATan(unittest.TestCase):
+class TestATan(utils.TorchGlowTestCase):
     def test_atan(self, skip_to_glow=False):
         x = torch.randn(2, 3, 4)
         utils.compare_tracing_methods(

--- a/torch_glow/tests/nodes/typeas_test.py
+++ b/torch_glow/tests/nodes/typeas_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -21,36 +18,36 @@ class SimpleTypeasModel(torch.nn.Module):
         return typed + typed
 
 
-class TestTypeAs(unittest.TestCase):
-    @parameterized.expand(
+class TestTypeAs(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "to_int32",
                 SimpleTypeasModel(),
                 torch.randn(4),
                 torch.zeros(4, dtype=torch.int32),
             ),
-            (
+            lambda: (
                 "from_int32",
                 SimpleTypeasModel(),
                 torch.randn(4).to(dtype=torch.int32),
                 torch.zeros(4),
             ),
-            (
+            lambda: (
                 "from_bool",
                 SimpleTypeasModel(),
                 torch.randn(4).to(dtype=torch.bool),
                 torch.zeros(4),
             ),
-            ("self", SimpleTypeasModel(), torch.randn(4), None, False),
-            (
+            lambda: ("self", SimpleTypeasModel(), torch.randn(4), None, False),
+            lambda: (
                 "f2f2",
                 SimpleTypeasModel(),
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
                 False,
             ),
-            (
+            lambda: (
                 "f2i2",
                 SimpleTypeasModel(),
                 torch.randn(4, 2),

--- a/torch_glow/tests/nodes/unsqueeze_test.py
+++ b/torch_glow/tests/nodes/unsqueeze_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -21,15 +18,19 @@ class SimpleUnsqueezeModel(torch.nn.Module):
             return torch.unsqueeze(tensor + tensor, self.dimension)
 
 
-class TestUnsqueeze(unittest.TestCase):
-    @parameterized.expand(
+class TestUnsqueeze(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            ("dim0", SimpleUnsqueezeModel(0), torch.randn(2, 3, 4)),
-            ("dim1", SimpleUnsqueezeModel(1), torch.randn(2, 3, 4)),
-            ("dim2", SimpleUnsqueezeModel(2), torch.randn(2, 3, 4)),
-            ("dim3", SimpleUnsqueezeModel(3), torch.randn(2, 3, 4)),
-            ("dim_negative", SimpleUnsqueezeModel(-1), torch.randn(2, 3, 4)),
-            ("inplace", SimpleUnsqueezeModel(-1, inplace=True), torch.randn(2, 3, 4)),
+            lambda: ("dim0", SimpleUnsqueezeModel(0), torch.randn(2, 3, 4)),
+            lambda: ("dim1", SimpleUnsqueezeModel(1), torch.randn(2, 3, 4)),
+            lambda: ("dim2", SimpleUnsqueezeModel(2), torch.randn(2, 3, 4)),
+            lambda: ("dim3", SimpleUnsqueezeModel(3), torch.randn(2, 3, 4)),
+            lambda: ("dim_negative", SimpleUnsqueezeModel(-1), torch.randn(2, 3, 4)),
+            lambda: (
+                "inplace",
+                SimpleUnsqueezeModel(-1, inplace=True),
+                torch.randn(2, 3, 4),
+            ),
         ]
     )
     def test_unsqueeze(self, _, module, tensor):

--- a/torch_glow/tests/nodes/upsample_test.py
+++ b/torch_glow/tests/nodes/upsample_test.py
@@ -1,10 +1,7 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -18,35 +15,35 @@ class SimpleUpsampleModel(torch.nn.Module):
         return torch.nn.Upsample(*self.args, **self.kwargs)(tensor)
 
 
-class TestUpsample(unittest.TestCase):
-    @parameterized.expand(
+class TestUpsample(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "3d_2x_size_nearest",
                 SimpleUpsampleModel(size=(8, 10, 12)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
-            (
+            lambda: (
                 "3d_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(2, 2, 2)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
-            (
+            lambda: (
                 "3d_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=2),
                 torch.rand(2, 3, 4, 5, 6),
             ),
-            (
+            lambda: (
                 "3d_not_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=5),
                 torch.rand(2, 3, 4, 5, 6),
             ),
-            (
+            lambda: (
                 "3d_not_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(1, 2, 3)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
-            (
+            lambda: (
                 "3d_not_2x_size_nearest",
                 SimpleUpsampleModel(size=(10, 12, 13)),
                 torch.rand(2, 3, 4, 5, 6),
@@ -60,34 +57,34 @@ class TestUpsample(unittest.TestCase):
             fusible_ops=["aten::upsample_nearest3d"],
         )
 
-    @parameterized.expand(
+    @utils.deterministic_expand(
         [
-            (
+            lambda: (
                 "2d_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(2, 2)),
                 torch.rand(1, 1, 3, 3),
             ),
-            (
+            lambda: (
                 "2d_not_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(3, 4)),
                 torch.rand(1, 1, 3, 3),
             ),
-            (
+            lambda: (
                 "2d_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=2),
                 torch.rand(1, 1, 3, 3),
             ),
-            (
+            lambda: (
                 "2d_not_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=3),
                 torch.rand(1, 1, 3, 3),
             ),
-            (
+            lambda: (
                 "2d_2x_size_nearest",
                 SimpleUpsampleModel(size=(6, 6)),
                 torch.rand(1, 1, 3, 3),
             ),
-            (
+            lambda: (
                 "2d_not_2x_size_nearest",
                 SimpleUpsampleModel(size=(4, 8)),
                 torch.rand(1, 1, 3, 3),

--- a/torch_glow/tests/nodes/view_test.py
+++ b/torch_glow/tests/nodes/view_test.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
-from parameterized import parameterized
 from tests import utils
 
 
@@ -16,11 +13,11 @@ class SimpleViewModule(torch.nn.Module):
         return (tensor + tensor).view(self.shape)
 
 
-class TestView(unittest.TestCase):
-    @parameterized.expand(
+class TestView(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
         [
-            (SimpleViewModule(2, -1), torch.rand(2, 3, 4)),
-            (SimpleViewModule(-1, 2), torch.rand(2, 3, 4)),
+            lambda: (SimpleViewModule(2, -1), torch.rand(2, 3, 4)),
+            lambda: (SimpleViewModule(-1, 2), torch.rand(2, 3, 4)),
         ]
     )
     def test_simple(self, module, tensor):

--- a/torch_glow/tests/nodes/zero_test.py
+++ b/torch_glow/tests/nodes/zero_test.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 import torch
+from tests import utils
 from tests import utils
 
 
-class TestZero(unittest.TestCase):
+class TestZero(utils.TorchGlowTestCase):
     def test_zero_basic(self):
         """Basic test of the PyTorch zero Node on Glow."""
 

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -3,12 +3,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import itertools
 import os
+import unittest
 from contextlib import contextmanager
 from copy import deepcopy
 from io import BytesIO
 
 import torch
 import torch_glow
+from parameterized import parameterized
 
 GLOW_FUSION_GROUP = "glow::FusionGroup"
 SUBGRAPH_ATTR = "Subgraph"
@@ -232,3 +234,27 @@ def save_and_reload_model(model):
     reloaded_model = torch.jit.load(buf)
     print("done")
     return reloaded_model
+
+
+class TorchGlowTestCase(unittest.TestCase):
+    """
+    Base class for torch_glow tests that ensure that torch.manual_seed is
+    called before each test.
+    NOTE: this won't effect arguments to the test case so make sure that test
+    cases generate their own inputs to the test network within the test case not
+    outside of it.
+    """
+
+    def setUp(self):
+        torch.manual_seed(0)
+        print("running the setup for TorchGlowTest")
+
+
+def deterministic_expand(params):
+    """Takes params as a list of lambdas where each lambda produces a tuple of
+    unique parameters for the test"""
+    torch.manual_seed(0)
+    real_params = []
+    for p in params:
+        real_params.append(p())
+    return parameterized.expand(real_params)


### PR DESCRIPTION
Summary:
Make torch_glow tests deterministic, no more flaky tests.

This diff accomplishes this by
* Creating `utils.TorchGlowTestCase` which all torch_glow unit tests inherit from instead of from `unittest.TestCase`. `utils.TorchGlowTestCase` calls `torch.manual_seed` before each test to ensure that tests are deterministic
* Creating `utils.deterministic_expand` decorator that replaces `parameterized.expand` which takes a lambda that generates each test case parameterization tuple instead of taking each tuple directly. This decorator also calls torch.manual_seed before generating each parameterization and delegating to `parameterized.expand`. This causes any tensors created in as test parameters to be deterministic as well

Reviewed By: yinghai

Differential Revision: D26481289

