### PR TITLE
Add correctness check to Int8GemmBench

### DIFF
--- a/torch_glow/tests/functionality/jit_vs_glow_path_test.py
+++ b/torch_glow/tests/functionality/jit_vs_glow_path_test.py
@@ -7,6 +7,7 @@ import torch_glow
 from tests import utils
 import unittest
 
+
 class TestJITVsGlowPath(utils.TorchGlowTestCase):
     @unittest.skip("Temp disabled")
     def test_jit_vs_glow_path(self):


### PR DESCRIPTION
Summary:
Update the benchmark to compare results against the Interpreter.

The check is protected by an option "-check-results".

Reviewed By: jfix71

Differential Revision: D26506976

