### PR TITLE
Support loading aten::linear

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -709,6 +709,10 @@ private:
   /// \return error on failure.
   Error loadQuantizedLinear(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::linear node.
+  /// \return error on failure.
+  Error loadLinear(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch quantize_per_tensor node.
   /// \returns error on failure.
   Error loadQuantize(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/functionality/jit_vs_glow_path_test.py
+++ b/torch_glow/tests/functionality/jit_vs_glow_path_test.py
@@ -5,10 +5,9 @@ import torch
 import torch.nn.functional as F
 import torch_glow
 from tests import utils
-import unittest
+
 
 class TestJITVsGlowPath(utils.TorchGlowTestCase):
-    @unittest.skip("Temp disabled")
     def test_jit_vs_glow_path(self):
         """Basic test of the JIT vs. Glow logging feature."""
 
@@ -29,7 +28,7 @@ class TestJITVsGlowPath(utils.TorchGlowTestCase):
             TestModule(),
             input,
             weight,
-            fusible_ops={"aten::add", "aten::t", "aten::matmul"},
+            fusible_ops={"aten::add", "aten::linear"},
         )
 
     def test_jit_vs_glow_int_path(self):

--- a/torch_glow/tests/functionality/randomize_constants_test.py
+++ b/torch_glow/tests/functionality/randomize_constants_test.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 import torch_glow
 from tests import utils
-import unittest
 
 
 class Model(torch.nn.Module):
@@ -41,7 +40,6 @@ def run_model(m, input, randomize):
 
 
 class TestRandomizeWeights(utils.TorchGlowTestCase):
-    @unittest.skip("Temp disabled")
     def test_randomize_weights(self):
         m = Model()
         input = torch.randn(5)

--- a/torch_glow/tests/nodes/getattr_test.py
+++ b/torch_glow/tests/nodes/getattr_test.py
@@ -5,11 +5,9 @@ import torch
 import torch_glow
 from tests import utils
 from tests.utils import GLOW_FUSION_GROUP, SUBGRAPH_ATTR
-import unittest
 
 
 class TestGetAttr(utils.TorchGlowTestCase):
-    @unittest.skip("Temp disabled")
     def test_getattr(self):
         """Test fusion of the PyTorch prim::GetAttr Node into the Glow subgraph."""
         with torch.no_grad():

--- a/torch_glow/tests/nodes/linear_test.py
+++ b/torch_glow/tests/nodes/linear_test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 import torch.nn.functional as F
 from tests import utils
-import unittest
 
 
 class SimpleLinearModule(torch.nn.Module):
@@ -15,7 +14,6 @@ class SimpleLinearModule(torch.nn.Module):
 
 
 class TestLinear(utils.TorchGlowTestCase):
-    @unittest.skip("Temp disabled")
     def test_linear_basic(self):
         """Basic test of the PyTorch aten::linear op on Glow."""
 
@@ -29,12 +27,10 @@ class TestLinear(utils.TorchGlowTestCase):
         input = torch.randn(n, in_features)
         weight = torch.randn(out_features, in_features)
 
-        # fusible_ops has is empty because linear gets lowered to other ops
         utils.compare_tracing_methods(
-            SimpleLinearModule(), input, weight, fusible_ops={}
+            SimpleLinearModule(), input, weight, fusible_ops={"aten::linear"}
         )
 
-    @unittest.skip("True")
     def test_linear_bias(self):
         """Test of the PyTorch aten::linear op on Glow."""
 
@@ -49,12 +45,10 @@ class TestLinear(utils.TorchGlowTestCase):
         weight = torch.randn(out_features, in_features)
         bias = torch.randn(out_features)
 
-        # fusible_ops has is empty because linear gets lowered to other ops
         utils.compare_tracing_methods(
-            SimpleLinearModule(), input, weight, bias, fusible_ops={}
+            SimpleLinearModule(), input, weight, bias, fusible_ops={"aten::linear"}
         )
 
-    @unittest.skip("Temp disabled")
     def test_linear_broadcast(self):
         """Test of the PyTorch aten::linear op with broadcasting on Glow."""
 
@@ -68,7 +62,6 @@ class TestLinear(utils.TorchGlowTestCase):
         input = torch.randn(n, 9, 7, in_features)
         weight = torch.randn(out_features, in_features)
 
-        # fusible_ops has is empty because linear gets lowered to other ops
         utils.compare_tracing_methods(
-            SimpleLinearModule(), input, weight, fusible_ops={}
+            SimpleLinearModule(), input, weight, fusible_ops={"aten::linear"}
         )


### PR DESCRIPTION
Summary: Prior to D26320711 linear is lowered to other ops during tracing. So now we want to support load aten::linear.

Reviewed By: jackm321

Differential Revision: D26425617

