### PR TITLE
Add unnamed_addr attribute to constant string literals to enable ConstantMergePass

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -635,6 +635,8 @@ llvm::Value *LLVMIRGen::emitStringConst(llvm::IRBuilder<> &builder,
       *llmodule_, constStrArray->getType(), true,
       llvm::GlobalValue::PrivateLinkage, constStrArray, ".str");
   gvarStr->setAlignment(1);
+  // Add unnamed_addr attribute to enable constmerge pass.
+  gvarStr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   return builder.CreateBitCast(gvarStr, builder.getInt8PtrTy());
 }
 


### PR DESCRIPTION
Summary: This is useful e.g. if you instrument LLVM code and use a lot of constant string literals with the same content. Such strings with the same content can be now merged with this change and reduce the size of the object code.

Differential Revision: D26566732

