### PR TITLE
Fix potential segfault in ThreadPoolExecutor

### DIFF
--- a/include/glow/Runtime/Executor/ThreadPoolExecutor.h
+++ b/include/glow/Runtime/Executor/ThreadPoolExecutor.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "NetworkExecutionState.h"
+#include "folly/Synchronized.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "glow/Runtime/Executor/Executor.h"
 
@@ -104,8 +105,8 @@ private:
   folly::CPUThreadPoolExecutor threadPool_;
 
   /// Map of networkExecutionState pools for each network.
-  std::unordered_map<const DAGNode *,
-                     std::unique_ptr<NetworkExecutionStatePool>>
+  folly::Synchronized<std::unordered_map<
+      const DAGNode *, std::unique_ptr<NetworkExecutionStatePool>>>
       states_;
 
   /// Barrier for making sure all asynchronous requests made to the


### PR DESCRIPTION
Summary:
states_, the storage for the networkExecutionStates for each network is a non-threadsafe map. Which results in the occasional segfault when multiple networks are added and removed concurrently.
This diff adds a mutex to protect access to states_ for modification.

Reviewed By: khabinov

Differential Revision: D26612114

