### PR TITLE
Implement tensor replication with aten::expand operator in AI Compiler (Glow)

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -993,6 +993,14 @@ struct ExpandAsInputs {
   };
 };
 
+/// Indexes of aten::expand inputs.
+struct ExpandInputs {
+  enum {
+    input = 0,
+    shape,
+  };
+};
+
 /// Indexes of fb::glow_embedding_bag inputs.
 struct GlowEmbeddingBagInputs {
   enum {
@@ -1300,6 +1308,7 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::index_select"}, &PyTorchModelLoader::loadIndexSelect},
       {{"aten::clamp_min"}, &PyTorchModelLoader::loadClampMin},
       {{"aten::expand_as"}, &PyTorchModelLoader::loadExpandAs},
+      {{"aten::expand"}, &PyTorchModelLoader::loadExpand},
       {{"glow::nnckernel"}, &PyTorchModelLoader::loadNNCKernel},
       {{"aten::cumsum"}, &PyTorchModelLoader::loadCumSum},
   });
@@ -5242,6 +5251,58 @@ Error PyTorchModelLoader::loadExpandAs(const torch::jit::Node *ptNode) {
 
   auto output = F_.createBroadcast("expand_as", input, other.dims(),
                                    other.dims().size() - input.dims().size());
+  RETURN_ERR(addValueMapping(outputs[0], output));
+}
+
+Error PyTorchModelLoader::loadExpand(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 3, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      input, getGlowNodeValueForValue(inputs[ExpandInputs::input]));
+  auto shapeOriginal = input.dims();
+
+  std::vector<int64_t> *shapeInput;
+  ASSIGN_VALUE_OR_RETURN_ERR(shapeInput, iValToIntList(getGlowIValueForValue(
+                                             inputs[ExpandInputs::shape])));
+
+  // Copy shapeInput so we can modify it.
+  std::vector<int64_t> shapeDesired = *shapeInput;
+
+  if (shapeDesired.size() < shapeOriginal.size()) {
+    return MAKE_ERR(
+        strFormat("Expanded shape may not have fewer dimensions than original "
+                  "shape : %ld vs %ld",
+                  shapeDesired.size(), shapeOriginal.size()));
+  }
+
+  // -1 for some dimension means keep its original size, so loop through
+  // shapeDesired and perform this lookup where needed. Also check for
+  // invalid input (<0 && !=-1). Note that the desired shape is aligned
+  // to the *end* of the original shape.
+  auto iterDesired = shapeDesired.rbegin();
+  auto iterOriginal = shapeOriginal.rbegin();
+  while (iterDesired != shapeDesired.rend()) {
+    if (*iterDesired == 0 || *iterDesired < -1 ||
+        (*iterDesired == -1 && iterOriginal == shapeOriginal.rend())) {
+      return MAKE_ERR(
+          strFormat("Could not determine a size for dimension %" PRId64,
+                    std::distance(iterDesired, shapeDesired.rend())));
+    }
+    if (iterOriginal != shapeOriginal.rend()) {
+      if (*iterDesired == -1) {
+        *iterDesired = *iterOriginal;
+      }
+      ++iterOriginal;
+    }
+    ++iterDesired;
+  }
+
+  auto output =
+      F_.createBroadcast("expand", input, castVector<dim_t>(shapeDesired),
+                         shapeDesired.size() - shapeOriginal.size());
   RETURN_ERR(addValueMapping(outputs[0], output));
 }
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -925,6 +925,10 @@ private:
   /// \returns error on failure.
   Error loadExpandAs(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::expand node.
+  /// \returns error on failure.
+  Error loadExpand(const torch::jit::Node *ptNode);
+
   /// Load an NNCKernel node.
   /// \returns error on failure.
   Error loadNNCKernel(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/expand_test.py
+++ b/torch_glow/tests/nodes/expand_test.py
@@ -1,0 +1,141 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+from tests import utils
+
+
+class ExpandModel(torch.nn.Module):
+    def __init__(self, shape):
+        super(ExpandModel, self).__init__()
+        self.shape = shape
+
+    def forward(self, a):
+        return a.expand(self.shape)
+
+
+class TestExpand(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
+        [
+            lambda: (
+                "unit_vector",
+                ExpandModel([3]),
+                torch.randn(1),
+            ),
+            lambda: (
+                "unit_matrix",
+                ExpandModel([3, 4]),
+                torch.randn(1, 1),
+            ),
+            lambda: (
+                "singleton_matrix",
+                ExpandModel([2, 4]),
+                torch.randn(2, 1),
+            ),
+            lambda: (
+                "singleton_matrix_minus_one",
+                ExpandModel([-1, 4]),
+                torch.randn(2, 1),
+            ),
+            lambda: (
+                "fourD",
+                ExpandModel([2, 4, 5, 8]),
+                torch.randn(2, 1, 5, 8),
+            ),
+            lambda: (
+                "fourD_two_singleton",
+                ExpandModel([2, 4, 5, 8]),
+                torch.randn(2, 1, 5, 1),
+            ),
+            lambda: (
+                "fourD_minus_ones",
+                ExpandModel([2, 4, -1, -1]),
+                torch.randn(2, 1, 5, 8),
+            ),
+            lambda: (
+                "add_dim",
+                ExpandModel([3, 4, 2]),
+                torch.randn(4, 2),
+            ),
+            lambda: (
+                "add_two_dims",
+                ExpandModel([8, 3, 4, 2]),
+                torch.randn(4, 2),
+            ),
+            lambda: (
+                "add_dim_minus_one",
+                ExpandModel([3, -1, 2]),
+                torch.randn(4, 2),
+            ),
+            lambda: (
+                "add_dim_minus_ones",
+                ExpandModel([3, -1, -1]),
+                torch.randn(4, 2),
+            ),
+            lambda: (
+                "add_dims_minus_one",
+                ExpandModel([8, 3, -1, 2]),
+                torch.randn(4, 2),
+            ),
+            lambda: (
+                "add_dims_minus_ones",
+                ExpandModel([8, 3, -1, -1]),
+                torch.randn(4, 2),
+            ),
+        ]
+    )
+    def test_expand(self, _, module, a):
+        """Test of the PyTorch expand Node on Glow."""
+        utils.compare_tracing_methods(
+            module,
+            a,
+            fusible_ops={"aten::expand"},
+        )
+
+
+class TestExpandError(utils.TorchGlowTestCase):
+    @utils.deterministic_expand(
+        [
+            lambda: (
+                "no_singleton",
+                ExpandModel([3, 3]),
+                torch.randn(2, 2),
+            ),
+            lambda: (
+                "shape_too_small",
+                ExpandModel([3]),
+                torch.randn(2, 2),
+            ),
+            lambda: (
+                "invalid_zero",
+                ExpandModel([0, 3]),
+                torch.randn(1, 2),
+            ),
+            lambda: (
+                "invalid_negative",
+                ExpandModel([-2, 3]),
+                torch.randn(1, 2),
+            ),
+            lambda: (
+                "add_dims_undefined_m1",
+                ExpandModel([-1, 2, 3]),
+                torch.randn(1, 2),
+            ),
+            lambda: (
+                "add_dims_undefined_zero",
+                ExpandModel([0, 2, 3]),
+                torch.randn(1, 2),
+            ),
+            lambda: (
+                "add_dims_undefined_m2",
+                ExpandModel([-2, 2, 3]),
+                torch.randn(1, 2),
+            ),
+        ]
+    )
+    def test_expand_error(self, _, module, a):
+        """Test of the PyTorch expand Node on Glow."""
+        utils.compare_tracing_methods_error(
+            module,
+            a,
+            fusible_ops={"aten::expand"},
+        )


### PR DESCRIPTION
Summary:
The goal of this diff is to extend glow to handle aten::expand. aten::expand implements
the expand() method described here => https://pytorch.org/docs/stable/tensors.html

Differential Revision: D26640527

