### PR TITLE
Enable xl_embedding_bag Glow lowering

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -346,6 +346,10 @@ private:
   // \returns error on failure.
   Error loadGlowEmbeddingBag(const torch::jit::Node *ptNode);
 
+  // Load a PyTorch fb::xl_embedding_bag node.
+  // \returns error on failure.
+  Error loadXLEmbeddingBag(const torch::jit::Node *ptNode);
+
   /// Load a _caffe2::BatchPermutation node.
   Error loadBatchPermutation(const torch::jit::Node *ptNode);
 
@@ -380,12 +384,27 @@ private:
   // \returns error on failure.
   Error loadGlowEmbeddingBag4bitRowwiseOffsets(const torch::jit::Node *ptNode);
 
+  // Load a PyTorch fb::xl_embedding_bag_byte_rowwise_offsets node.
+  // \returns error on failure.
+  Error loadXLEmbeddingBagByteRowwiseOffsets(const torch::jit::Node *ptNode);
+
+  // Load a PyTorch fb::xl_embedding_bag_4bit_rowwise_offsets node.
+  // \returns error on failure.
+  Error loadXLEmbeddingBag4bitRowwiseOffsets(const torch::jit::Node *ptNode);
+
   // Helper function that implements the loading logic for
   // fb::glow_embedding_bag_byte_rowwise_offsets and
   // fb::glow_embedding_bag_4bit_rowwise_offsets
   // \returns error on failure
   Error loadRowwiseQuantizedEmbeddingBagHelper(const torch::jit::Node *ptNode,
                                                bool is4Bit = false);
+
+  // Helper function that implements the loading logic for
+  // fb::xl_embedding_bag_byte_rowwise_offsets and
+  // fb::xl_embedding_bag_4bit_rowwise_offsets
+  // \returns error on failure
+  Error loadRowwiseQuantizedXLEmbeddingBagHelper(const torch::jit::Node *ptNode,
+                                                 bool is4Bit = false);
 
   // Load a PyTorch fb::lengths_range node.
   // \returns error on failure.

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -189,6 +189,8 @@ private:
   // Shape inference for fb::glow_embedding_bag_4bit_rowwise_offsets
   static Expected<TensorOutput>
   quantizedGlowEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
+  // Shape inference for fb::xl_embedding_bag
+  static Expected<TensorOutput> xlEmbeddingBag(const MetaStack &variableMetas);
   // Shape inference for aten::chuck
   static Expected<TensorListOutput> chunk(const MetaStack &variableMetas);
   // Shape inference for aten::stack

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -183,6 +183,12 @@ private:
   // Shape inference for fb::glowEmbedding_bag
   static Expected<TensorOutput>
   glowEmbeddingBag(const MetaStack &variableMetas);
+  // Shape inference for fb::glow_embedding_bag_byte_rowwise_offsets
+  static Expected<TensorOutput>
+  quantizedGlowEmbeddingBagByteRowwiseOffsets(const MetaStack &variableMetas);
+  // Shape inference for fb::glow_embedding_bag_4bit_rowwise_offsets
+  static Expected<TensorOutput>
+  quantizedGlowEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for aten::chuck
   static Expected<TensorListOutput> chunk(const MetaStack &variableMetas);
   // Shape inference for aten::stack


### PR DESCRIPTION
Summary: This diff enables Glow lowering for xl_embedding_bag (basically copying glow_embedding_bag implementations). We will deprecate glow_embedding_bag later and replace it with xl_embedding_bag after this enablement. See https://fb.quip.com/8aU2Adp6r1yT for the context. We  only support quantization in this diff and pruning support + support for quantized shape inference support will be in the following diff.

Reviewed By: qizzzh

Differential Revision: D26405570

