### PR TITLE
Add support to the Provisioner for FX deferred weights

### DIFF
--- a/lib/Backends/NNPI/FXNNPICompiledFunction.cpp
+++ b/lib/Backends/NNPI/FXNNPICompiledFunction.cpp
@@ -16,6 +16,15 @@ NNPICompiledFunction::NNPICompiledFunction(
       compilationOptions_({}) {
   std::memset(&config_, 0, sizeof(config_));
   std::memset(&devNetConfig_, 0, sizeof(devNetConfig_));
+  for (auto info : runtimeBundle_.getSymbolTable()) {
+    if (info.second.symbolCategory ==
+        glow::runtime::SymbolCategory::Placeholder) {
+      auto PH = glowModule->getPlaceholderByNameSlow(info.first);
+      if (PH->isStatic()) {
+        staticInputs_.insert(PH);
+      }
+    }
+  }
 }
 
 Error NNPICompiledFunction::compileFX(


### PR DESCRIPTION
Summary:
Adds support to profisionFX() for deferredWeights. Also introduces a new field to the FX json serialization.
Nodes now have an optional "is_static" attribute which is used to signal that a placeholder represents a deferred weight.
Going this route means the the serializer will need to convert deferred weights into static placeholders.

Differential Revision: D26701965

