### PR TITLE
Less verbose log

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5846,8 +5846,9 @@ bool Function::verify(const Backend *backend) const {
   bool isValid = true;
   // Check if the layout verifying is disabled, which will accept all layout for
   // any ops.
-  LOG(INFO) << "Layout requirements checking is "
-            << (glow::flags::DisableLayoutVerifying ? "disabled" : "enabled");
+  LOG_FIRST_N(INFO, 1) << "Layout requirements checking is "
+                       << (glow::flags::DisableLayoutVerifying ? "disabled"
+                                                               : "enabled");
   if (!glow::flags::DisableLayoutVerifying) {
     if (backend) {
       if (backend->getTensorLayoutRequirements().isEnabled()) {


### PR DESCRIPTION
Summary:
We only need to print
```
Layout requirements checking is enabled
```
Now it's flooding the log.

Reviewed By: zrphercule

Differential Revision: D26716631

