### PR TITLE
Warmcache on all inputs

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -219,13 +219,14 @@ public:
   /// it as a Glow Function and compiles. \returns error of failure.
   Error run(torch::jit::Stack &stack);
 
-  /// Warm up the cache by compiling a Glow function and storing its info in
-  /// perGlowGraphInfoMap_ with the hash computed using \p metaStack. \p
-  /// metaStack is used to pass Glow shapes and types (Only tensors are valid
-  /// inputs). \p settings enable different settings for each compilation.
-  /// If \p useMaxSizeCompilation , compile only a single Glow graph with an
+  /// Warm up the cache by compiling one Glow function per metaStack and storing
+  /// its info in perGlowGraphInfoMap_ with the hash computed using metaStack in
+  /// \p metaStacks. Each metaStack in \p metaStacks is used to pass Glow shapes
+  /// and types (Only tensors are valid inputs) for one Glow function. \p
+  /// settings enable different settings for each compilation. If \p
+  /// useMaxSizeCompilation , compile only a single Glow graph with an
   /// upper-bound on the input sizes (smaller inputs will be padded by Glow.)
-  Error warmCache(const InputMetaStack &metaStack,
+  Error warmCache(const std::vector<InputMetaStack> &metaStacks,
                   const PyTorchLoaderSettings &settings,
                   runtime::DeferredWeightLoader *loader,
                   bool useMaxSizeCompilation = true);

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -453,8 +453,8 @@ at::Tensor convertQuantizedToDtype(at::Tensor ptTensor, c10::ScalarType dtype) {
     LOG(FATAL) << "Can not reach here.";
   }
 
-  float scale = static_cast<float>(ptTensor.q_scale());
-  int32_t offset = static_cast<int32_t>(ptTensor.q_zero_point());
+  auto scale = static_cast<float>(ptTensor.q_scale());
+  auto offset = static_cast<int32_t>(ptTensor.q_zero_point());
   auto ptNewTensor = ptTensor.int_repr().to(targetDQType).add(offsetShift);
   auto ptNewQTensor = at::_make_per_tensor_quantized_tensor(
       ptNewTensor, scale, offset + offsetShift);
@@ -544,7 +544,7 @@ void glowAOTFusionWithShapeInference(torch::jit::Module &model,
   // could lower whatever we want.
   std::vector<torch::jit::IValue> inputs;
   for (const auto &i : metaStack.inputMetas) {
-    inputs.push_back(
+    inputs.emplace_back(
         torch::empty(i.dims, torch::TensorOptions().dtype(i.type)));
   }
 
@@ -607,7 +607,7 @@ void glowAOTFusionWithShapeInference(torch::jit::Module &model,
             itr->second.dtype, itr->second.shape<TensorShape>());
       }
 
-      e = runner->warmCache(metaStackForCompilation, settings, loader,
+      e = runner->warmCache({metaStackForCompilation}, settings, loader,
                             /*useMaxSizeCompilation*/ true);
       if (e) {
         // If the graph is already compiled previously, warmCache() will report
@@ -663,7 +663,7 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr,
             subgraph, getHostManager(settings), settings, /*useRunOnly*/ true);
       });
 
-  auto e = runner->warmCache(metaStack, settings, loader,
+  auto e = runner->warmCache({metaStack}, settings, loader,
                              /*useMaxSizeCompilation*/ true);
   if (e) {
     // If the graph is already compiled previously, warmCache() will report


### PR DESCRIPTION
Summary:
1. Compile different sizes for the same graph in the same module.
2. In TorchGlowBackend accumulate MetaStacks and make a single call to warmCache with all of them at once.
3. CachingGraphRunner::warmCache takes a list of MetaStacks and compile them all together by calling hostManager_->addNetwork(module).

Reviewed By: jackm321

Differential Revision: D26413968

