### PR TITLE
Set the p2p and drt flags in the cctx

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1930,9 +1930,7 @@ Error NNPIBackend::bindContexts(
       runtime::NNPIDeviceManager *nnpiDM =
           dynamic_cast<runtime::NNPIDeviceManager *>(devMgr);
       LOG_IF_NOT_RETURN_LLVMERROR(nnpiDM, "Invalid device manager bound");
-      LOG_IF_NOT_RETURN_LLVMERROR(
-          !nnpiDM->bindContext(dagNode->name, ctx, phUsage),
-          "Failed to bind context");
+      RETURN_IF_ERR(nnpiDM->bindContext(dagNode->name, ctx, phUsage));
     }
   }
 

--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -342,10 +342,12 @@ Error NNPIDeviceManager::bindContext(std::string functionName,
                   "Invalid function name.");
   std::shared_ptr<InferenceContext> infCtx(
       inferencePools_.at(functionName).createDetachedInferenceContext(phUsage));
-  ASSERT_WITH_MSG(
-      infCtx, "Failed to create detached context; NNPIDeviceManager status: " +
-                  getStatusStr() +
-                  "; with NNPIDeviceOptions: " + deviceOptions_->dumpStatus());
+  if (!infCtx) {
+    return MAKE_ERR(
+        "Failed to create detached context; NNPIDeviceManager status: " +
+        getStatusStr() +
+        "; with NNPIDeviceOptions: " + deviceOptions_->dumpStatus());
+  }
 
   // Set the inference context into NNPIDeviceBinding and store in the ExCtx.
   ctx->setDeviceBindings(std::make_unique<NNPIDeviceBindings>(infCtx));

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <map>
@@ -669,3 +670,24 @@ bool glow::flags::processBackendSpecificOpts(
   }
   return true;
 }
+
+namespace {
+llvm::cl::OptionCategory flagsLibCat("Glow Flags Lib CmdLine Options");
+/// Allows enabling DRT support.
+llvm::cl::opt<bool, /* ExternalStorage */ true>
+    enableDRT("enable-DRT",
+              llvm::cl::desc(
+                  "Deprecated. Enabled DRT support. Alias to glow_enable_drt."),
+              llvm::cl::Optional,
+              llvm::cl::location(glow::runtime::flags::EnableDRT),
+              llvm::cl::cat(flagsLibCat));
+
+/// Allows enabling P2P support.
+llvm::cl::opt<bool, /* ExternalStorage */ true>
+    enableP2P("enable-P2P",
+              llvm::cl::desc(
+                  "Deprecated. Enabled P2P support. Alias to glow_enable_drt."),
+              llvm::cl::Optional,
+              llvm::cl::location(glow::runtime::flags::EnableP2P),
+              llvm::cl::cat(flagsLibCat));
+} // namespace

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -259,6 +259,14 @@ onnxStatus HostManagerBackend::addNetwork(
           glow::flags::BackendSpecificOpts)) {
     return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
+  if (glow::runtime::flags::EnableP2P) {
+    LOG(INFO) << "Glow P2P Enabled";
+    cctx.enableP2P = true;
+  }
+  if (glow::runtime::flags::EnableDRT) {
+    LOG(INFO) << "Glow DRT Enabled";
+    cctx.enableDRT = true;
+  }
 
   auto err = hostManager_->addNetwork(std::move(module), cctx);
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -76,20 +76,6 @@ llvm::cl::opt<std::string> loadDeviceConfigsFileOpt(
     llvm::cl::value_desc("configs.yaml"), llvm::cl::Optional,
     llvm::cl::cat(hostManagerCat));
 
-/// Allows enabling DRT support.
-llvm::cl::opt<bool, /* ExternalStorage */ true>
-    enableDRT("enable-DRT", llvm::cl::desc("Enabled DRT support"),
-              llvm::cl::Optional,
-              llvm::cl::location(glow::runtime::flags::EnableDRT),
-              llvm::cl::cat(hostManagerCat));
-
-/// Allows enabling P2P support.
-llvm::cl::opt<bool, /* ExternalStorage */ true>
-    enableP2P("enable-P2P", llvm::cl::desc("Enabled P2P support"),
-              llvm::cl::Optional,
-              llvm::cl::location(glow::runtime::flags::EnableP2P),
-              llvm::cl::cat(hostManagerCat));
-
 /// The value that should be used for device initialization timeout, default:
 /// 5000 milliseconds.
 llvm::cl::opt<unsigned, /* ExternalStorage */ true> deviceInitTimeout(
@@ -587,8 +573,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
       // Note: currently getNextNetworkExecutionState assumes that pool size is
       // >= currentInFlight requests, so we set pool size to maxActiveRequests.
       executor_->createPool(node.root.get(), config_.maxActiveRequests,
-                            cctx.enableP2P || flags::EnableP2P,
-                            cctx.enableDRT || flags::EnableDRT);
+                            cctx.enableP2P, cctx.enableDRT);
     }
   }
   // Clear constants contents from the module then put it in a
@@ -727,8 +712,7 @@ Error HostManager::addNetworkFX(
       // Note: currently getNextNetworkExecutionState assumes that pool size is
       // >= currentInFlight requests, so we set pool size to maxActiveRequests.
       executor_->createPool(node.root.get(), config_.maxActiveRequests,
-                            cctx.enableP2P || flags::EnableP2P,
-                            cctx.enableDRT || flags::EnableDRT);
+                            cctx.enableP2P, cctx.enableDRT);
     }
   }
   // Clear constants contents from the module then put it in a

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -550,6 +550,14 @@ int run() {
   if (glow::flags::DelayAndRecordConstantModification) {
     cctx.optimizationOpts.delayAndRecordConstantModification = true;
   }
+  if (glow::runtime::flags::EnableP2P) {
+    LOG(INFO) << "Glow P2P Enabled";
+    cctx.enableP2P = true;
+  }
+  if (glow::runtime::flags::EnableDRT) {
+    LOG(INFO) << "Glow DRT Enabled";
+    cctx.enableDRT = true;
+  }
 
   // Load deferred weights if applicable
   const auto &placeholderList = mod->getPlaceholders();


### PR DESCRIPTION
Summary:
These were never getting set, leading to the resource validator not knowing the max size to check against. We also had two sets of flags for the same thing -- I moved the llvm version to Flags and marked it as deprecated. They alias to the same variable.

Also change the NNPI InferenceContext creation to return an error up the stack if it fails. Before it was hard aborting only in debug mode.

Reviewed By: gcatron

Differential Revision: D26736869

