### PR TITLE
Support different pad values for W and H in pytorch loadConvolution

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4351,11 +4351,11 @@ Error PyTorchModelLoader::loadConvolution(const torch::jit::Node *ptNode) {
                  getGlowIValueForValue(inputs[ConvInputs::padding]), 3)));
     pads = {pad[0], pad[0], pad[1], pad[1], pad[2], pad[2]};
   } else {
-    glow::unsigned_t pad;
+    std::vector<glow::unsigned_t> pad;
     ASSIGN_VALUE_OR_RETURN_ERR(
-        pad, static_cast_expected<glow::unsigned_t>(contractIntIValIfNeeded(
-                 getGlowIValueForValue(inputs[ConvInputs::padding]))));
-    pads = {pad, pad, pad, pad};
+        pad, castVector<glow::unsigned_t>(expandIntIValIfNeeded(
+                 getGlowIValueForValue(inputs[ConvInputs::padding]), 2)));
+    pads = {pad[0], pad[1], pad[0], pad[1]};
   }
 
   std::vector<glow::unsigned_t> dilations;

--- a/torch_glow/tests/nodes/conv2d_test.py
+++ b/torch_glow/tests/nodes/conv2d_test.py
@@ -51,6 +51,12 @@ class TestConv2d(utils.TorchGlowTestCase):
                 torch.randn(1, 4, 5, 5),
                 torch.randn(8, 4, 3, 3),
             ),
+            lambda: (
+                "different_padding",
+                SimpleConv2dModule(padding=[1, 0]),
+                torch.randn(1, 4, 5, 5),
+                torch.randn(8, 4, 3, 3),
+            ),
         ]
     )
     def test_conv2d(self, _, module, inputs, filters, bias=None):


### PR DESCRIPTION
Summary:

Some convolutions require zero-padding only in single dimension. This adds support to load such convolutions.

Documentation:

Test Plan:

Added different_padding test case in conv2d_test.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
