### PR TITLE
Use only inputs from peers for resource validation check

### DIFF
--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -184,6 +184,11 @@ bool isOutput(const Value *W);
 /// other Instructions as OperandKind::InOut or OperandKind::Out.
 bool isOutput(const Placeholder *PH, const IRFunction &F);
 
+/// \returns true if \p PH is an output Placeholder for any function in \p
+/// funcs.
+bool isOutput(const Placeholder *PH,
+              const std::vector<const Function *> &funcs);
+
 /// If \p PH is an input placeholder in the IRFunction \p F,
 /// \returns true.
 /// This is determined by checking if the PH is always used as an @in parameter

--- a/include/glow/Partitioner/PartitionerTypes.h
+++ b/include/glow/Partitioner/PartitionerTypes.h
@@ -38,9 +38,11 @@ struct GraphMemInfo {
   // The number of contexts reserved on the device, this affecting input/out
   // memory useage.
   unsigned contextCount;
-  // Count of inputs to the graph, this is needed to calculate p2p resource
-  // consumption.
+  // Count of inputs to the graph.
   unsigned inputCount{0};
+  // Count of inputs to the graph that are coming from a peer graph, i.e. are
+  // the output of another graph, and not inputs to the original input model.
+  unsigned inputFromPeerCount{0};
 
   GraphMemInfo()
       : inMemSize(0), outMemSize(0), constMemSize(0), contextCount(1){};

--- a/lib/Backend/BackendUtils.cpp
+++ b/lib/Backend/BackendUtils.cpp
@@ -182,8 +182,6 @@ bool isInput(const Placeholder *PH, const IRFunction &F) {
   return isInput(weight);
 }
 
-/// \returns true if \p PH is an output Placeholder for any function in \p
-/// funcs.
 bool isOutput(const Placeholder *PH,
               const std::vector<const Function *> &funcs) {
   for (const auto &f : funcs) {


### PR DESCRIPTION
Summary: The previous validation check was comparing against all inputs, not just the peer intermediate inputs. Fix that, and add printing of number of peer inputs to the partitioner info dump.

Reviewed By: gcatron

Differential Revision: D26760331

