### PR TITLE
Support of aten::avg_pool1d in torch_glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -767,13 +767,10 @@ private:
   /// \returns error on failure.
   Error loadSilu(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch avg_pool2d node.
+  /// Load a PyTorch avg_pool1d node.
+  /// \tparam numDims - number of dimentions, support 1d, 2d and 3d.
   /// \returns error on failure.
-  Error loadAvgPool2d(const torch::jit::Node *ptNode);
-
-  /// Load a PyTorch avg_pool3d node.
-  /// \returns error on failure.
-  Error loadAvgPool3d(const torch::jit::Node *ptNode);
+  template <size_t numDims> Error loadAvgPool(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch adaptive_avg_pool2d node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/avgpool1d_test.py
+++ b/torch_glow/tests/nodes/avgpool1d_test.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch.nn.functional as F
+from tests import utils
+
+
+class SimpleAvgPool1dModule(torch.nn.Module):
+    def __init__(self, kernel_size, stride=None, padding=0):
+        super(SimpleAvgPool1dModule, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+        self.stride = stride
+
+    def forward(self, inputs):
+        return F.avg_pool1d(
+            inputs, self.kernel_size, padding=self.padding, stride=self.stride
+        )
+
+
+class TestAvgPool1d(utils.TorchGlowTestCase):
+    def test_avg_pool1d_basic(self):
+        """Basic test of the PyTorch avg_pool1d Node on Glow."""
+        inputs = torch.randn(1, 4, 9)
+
+        utils.compare_tracing_methods(
+            SimpleAvgPool1dModule(3), inputs, fusible_ops={"aten::avg_pool1d"}
+        )
+
+    def test_avg_pool1d_with_args(self):
+        """Test of the PyTorch avg_pool1d Node with arguments on Glow."""
+
+        inputs = torch.randn(1, 4, 10)
+
+        utils.compare_tracing_methods(
+            SimpleAvgPool1dModule(3, stride=7), inputs, fusible_ops={"aten::avg_pool1d"}
+        )


### PR DESCRIPTION
Summary:
This diff supported aten::avg_pool1d in torch_glow,
by reshaping 1d input for avg_pool1d to 2d, and then run avg_pool2d on it.

Reviewed By: jackm321

Differential Revision: D26621198

