### PR TITLE
LoadNorm take keepdim into account

### DIFF
--- a/torch_glow/tests/nodes/norm_test.py
+++ b/torch_glow/tests/nodes/norm_test.py
@@ -50,3 +50,12 @@ class TestNorm(utils.TorchGlowTestCase):
             torch.arange(16, dtype=torch.float).reshape(2, 2, 2, 2),
             fusible_ops={"aten::frobenius_norm"},
         )
+
+    def test_norm_keepdim(self):
+        """Basic test of the PyTorch norm Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=[1], keepdim=True),
+            torch.arange(16, dtype=torch.float).reshape(2, 4, 2),
+            fusible_ops={"aten::frobenius_norm"},
+        )


### PR DESCRIPTION
Summary: Checking `keepdim` and do a reshape if `keepdim` is true when loading aten::norm or aten::frobenius_norm.

Reviewed By: mortzur

Differential Revision: D26769458

