### PR TITLE
fix torch.stack loading where dim=input.dim()

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3074,7 +3074,7 @@ createConcatNode(PyTorchModelLoader *loader, Function &F,
   glow::NodeValue glowInput0;
   ASSIGN_VALUE_OR_RETURN_ERR(glowInput0,
                              loader->getGlowNodeValueForValue(inputs[0]));
-  size_t numInputDims = glowInput0.dims().size();
+  int64_t numInputDims = glowInput0.dims().size();
 
   int64_t dim = ptNode->i(at::attr::dim);
 
@@ -3140,7 +3140,8 @@ createConcatNode(PyTorchModelLoader *loader, Function &F,
   }
 
   if (!doBroadcast || noBroadcastNeeded) {
-    return F.createConcat(isStack ? "stack_concat" : "cat", glowInputs, dim);
+    return F.createConcat(isStack ? "stack_concat" : "cat", glowInputs,
+                          std::min(dim, numInputDims - 1));
   }
   // For concat, we perform opportunistic concat before broadcast if
   // the adjacent nodes can be broadcast the same way. Doing this saves the
@@ -3211,7 +3212,7 @@ createConcatNode(PyTorchModelLoader *loader, Function &F,
   }
 
   return F.createConcat(isStack ? "stack_concat" : "cat", finalConcatInputs,
-                        dim);
+                        std::min(dim, numInputDims - 1));
 }
 
 Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
@@ -3259,12 +3260,16 @@ createReshapeNodeForStack(glow::Function &F, const torch::jit::Node *ptNode,
 
   auto concat = concatNode->getResult();
   auto concatDims = concat.dims();
-
-  size_t numInputs = inputs.size();
+  uint ndims = concatDims.size();
+  auto numInputs = inputs.size();
   std::vector<glow::dim_t> reshapeDims;
 
-  for (size_t i = 0; i < concatDims.size(); ++i) {
-    if (i == dim) {
+  // if dim == a.dim(), then the correct calculation should be:
+  // torch.stack([a, a], dim=dim)
+  // <==> torch.stack([a, a], dim=dim-1).transpose(dim, dim - 1)
+
+  for (size_t i = 0; i < ndims; ++i) {
+    if ((dim == ndims && i == dim - 1) || i == dim) {
       reshapeDims.push_back(numInputs);
       reshapeDims.push_back(concatDims[i] / numInputs);
     } else {
@@ -3272,13 +3277,16 @@ createReshapeNodeForStack(glow::Function &F, const torch::jit::Node *ptNode,
     }
   }
 
-  // Handle the case when dim is the innermost dimension.
-  if (reshapeDims.size() == concatDims.size()) {
-    reshapeDims.back() /= numInputs;
-    reshapeDims.push_back(numInputs);
-  }
+  auto reshapeNode =
+      F.createReshape("stack_reshape", concat, reshapeDims)->getResult();
 
-  return F.createReshape("stack_reshape", concat, reshapeDims)->getResult();
+  if (dim == ndims) {
+    return F
+        .createTranspose("stack_transpose", reshapeNode, {ndims, ndims - 1})
+        ->getResult();
+  } else {
+    return reshapeNode;
+  }
 }
 
 Error PyTorchModelLoader::loadFusedStack(const torch::jit::Node *ptNode) {

--- a/torch_glow/tests/nodes/stack_test.py
+++ b/torch_glow/tests/nodes/stack_test.py
@@ -5,25 +5,26 @@ from tests import utils
 
 
 class SimpleStackModel(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, dim):
         super(SimpleStackModel, self).__init__()
+        self.dim = dim
 
     def forward(self, a, b):
-        c = torch.stack((a, b), 0)
-        d = torch.stack((c, c), 1)
-        return torch.stack((d, d), 2)
+        c = b + b
+        return torch.stack((c, b), dim=self.dim)
 
 
 class TestStack(utils.TorchGlowTestCase):
     def test_stack_basic(self):
         """Basic test of the PyTorch aten::stack Node on Glow."""
 
-        utils.compare_tracing_methods(
-            SimpleStackModel(),
-            torch.randn(2, 3, 4),
-            torch.randn(2, 3, 4),
-            skip_to_glow=True,
-        )
+        for d in range(0, 3):
+            utils.compare_tracing_methods(
+                SimpleStackModel(d),
+                torch.randn(2, 3, 4),
+                torch.randn(2, 3, 4),
+                skip_to_glow=True,
+            )
 
     def test_stack_different_types(self):
         """Test stack between fp16 and fp32, which is supported in pytorch."""
@@ -31,9 +32,10 @@ class TestStack(utils.TorchGlowTestCase):
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4, dtype=torch.half)
 
-        utils.compare_tracing_methods(
-            SimpleStackModel(),
-            x,
-            y,
-            skip_to_glow=True,
-        )
+        for d in range(0, 3):
+            utils.compare_tracing_methods(
+                SimpleStackModel(d),
+                x,
+                y,
+                skip_to_glow=True,
+            )


### PR DESCRIPTION
Summary: Previously, the lowering of `torch.stack` was not handled correctly when dim == input.dim(). For example, suppose `a = torch.randn([2, 3, 4])`. In current logic we calculate `torch.stack([a, a], dim=3)` as `torch.cat([a, a], dim=3).reshape([2, 3, 4, 2])`, while it should be `torch.cat([a, a], dim=2).reshape([2, 3, 2, 4]).transpose(3, 2)`

Differential Revision: D26811908

