### PR TITLE
Reference implementation for Bucketize

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -797,6 +797,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::BatchedPairwiseDotProductGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
 
+  case Kinded::Kind::BucketizeNodeKind:
+    return NI.getInElemTy(BucketizeNode::InputIdx) == ElemKind::FloatTy &&
+           NI.getOutElemTy(BucketizeNode::ResultIdx) == ElemKind::Int32ITy;
+
   default:
     return false;
   }
@@ -893,6 +897,7 @@ bool Interpreter::shouldLower(const Node *N) const {
   case Kinded::Kind::SparseLengthsSumNodeKind:
   case Kinded::Kind::FullyConnectedNodeKind:
   case Kinded::Kind::BatchNormalizationNodeKind:
+  case Kinded::Kind::BucketizeNodeKind:
     return false;
   default:
     return true;

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2971,6 +2971,24 @@ void BoundInterpreterFunction::fwdLocalResponseNormalizationGradInst(
   }
 }
 
+//===--------------------------------------------------------------------===//
+//                     Bucketing
+//===--------------------------------------------------------------------===//
+
+void BoundInterpreterFunction::fwdBucketizeInst(const BucketizeInst *I) {
+  auto inputH = getTensor(I->getSrc())->getHandle<float>();
+  auto outputH = getTensor(I->getDest())->getHandle<int32_t>();
+  const auto boundaries = I->getBoundaries();
+
+  const auto numItems = inputH.size();
+
+  for (size_t i = 0; i < numItems; ++i) {
+    outputH.raw(i) =
+        std::lower_bound(boundaries.begin(), boundaries.end(), inputH.raw(i)) -
+        boundaries.begin();
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                       Arithmetic operations
 //===----------------------------------------------------------------------===//

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -271,6 +271,18 @@ int main(int argc, char **argv) {
       .addGradientInstr({"Dest", "Src", "Scale"}, {"Dest", "Src"});
 
   //===--------------------------------------------------------------------===//
+  //                     Bucketing
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("Bucketize")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addMember(MemberType::VectorFloat, "Boundaries")
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Src", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int32ITy"});
+
+  //===--------------------------------------------------------------------===//
   //                      Loss functions
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary:
Here is a reference implementation for Bucketize from Caffe2.

It was implemented previously as an optimization pass in https://github.com/pytorch/glow/pull/3236, but we want a native operator instead.

Differential Revision: D26824865

