### PR TITLE
Extend aten::cumsum operator implementation to multi-dimensional inputs in Glow

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -342,7 +342,7 @@ private:
                                          const ShapeVector &eDestDims);
 
   template <typename ElemTy>
-  void fwdCumSumInstImpl(Value *input, Value *dest, bool exclusive,
+  void fwdCumSumInstImpl(Value *input, Value *dest, int64_t dim, bool exclusive,
                          bool reverse);
 
   template <typename ElemTy>

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1253,7 +1253,8 @@ public:
   /// Create a node performing a Cumulative Sum operation, output type matches
   /// \p input type.
   CumSumNode *createCumSum(llvm::StringRef name, NodeValue input,
-                           bool exclusive = false, bool reverse = false);
+                           int64_t dim = 0, bool exclusive = false,
+                           bool reverse = false);
 
   /// Implements an operation that accumulates the values in \p data along the
   /// first dimension into len(\p lengths) entries by summing together the first

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2132,9 +2132,9 @@ BatchedMulNode *Function::createBatchedMul(llvm::StringRef name, TypeRef outTy,
 }
 
 CumSumNode *Function::createCumSum(llvm::StringRef name, NodeValue input,
-                                   bool exclusive, bool reverse) {
+                                   int64_t dim, bool exclusive, bool reverse) {
   return addNode(
-      new CumSumNode(name, input.getType(), input, exclusive, reverse));
+      new CumSumNode(name, input.getType(), input, dim, exclusive, reverse));
 }
 
 LengthsSumNode *Function::createLengthsSum(llvm::StringRef name, NodeValue data,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -4078,7 +4078,9 @@ Error ONNXModelLoader::loadCumSum(const ONNX_NAMESPACE::NodeProto &op,
     ASSIGN_VALUE_OR_RETURN_ERR(reverse, loadInt(dict.at("reverse")));
   }
 
-  Node *N = G_->createCumSum(loadOperatorName(op), input, exclusive, reverse);
+  // TODO: add axis/dim support
+  Node *N =
+      G_->createCumSum(loadOperatorName(op), input, 0, exclusive, reverse);
   RETURN_IF_ERR(addNodeAsOutput(op, N));
   return Error::success();
 }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -13802,12 +13802,12 @@ TEST_P(OperatorTest, testQuantizedBatchMul_Int8) {
 template <typename DataType>
 static Tensor *testCumSum(glow::PlaceholderBindings &bindings,
                           glow::Module &mod, glow::Function *F,
-                          glow::ExecutionEngine &EE, ElemKind DTy,
+                          glow::ExecutionEngine &EE, ElemKind DTy, int64_t dim,
                           bool exclusive, bool reverse) {
   auto *data = mod.createPlaceholder(DTy, {4}, "data", false);
   bindings.allocate(data)->getHandle<DataType>() = {1, 2, 3, 4};
 
-  auto *CS = F->createCumSum("CumSum", data, exclusive, reverse);
+  auto *CS = F->createCumSum("CumSum", data, dim, exclusive, reverse);
   auto *S = F->createSave("save", CS);
   bindings.allocate(S->getPlaceholder());
 
@@ -13825,7 +13825,7 @@ TEST_P(OperatorTest, CumSum_Float) {
 
   Tensor *result =
       testCumSum<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                        /*exclusive*/ false, /*reverse*/ false);
+                        /*dim*/ 0, /*exclusive*/ false, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<float>() = {1, 3, 6, 10};
 
@@ -13841,7 +13841,7 @@ TEST_P(OperatorTest, CumSum_Float16) {
 
   Tensor *result =
       testCumSum<float16_t>(bindings_, mod_, F_, EE_, ElemKind::Float16Ty,
-                            /*exclusive*/ false, /*reverse*/ false);
+                            /*dim*/ 0, /*exclusive*/ false, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<float16_t>() = {1, 3, 6, 10};
 
@@ -13857,7 +13857,7 @@ TEST_P(OperatorTest, CumSum_BFloat16) {
 
   Tensor *result =
       testCumSum<bfloat16_t>(bindings_, mod_, F_, EE_, ElemKind::BFloat16Ty,
-                             /*exclusive*/ false, /*reverse*/ false);
+                             /*dim*/ 0, /*exclusive*/ false, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<bfloat16_t>() = {1, 3, 6, 10};
 
@@ -13873,7 +13873,7 @@ TEST_P(OperatorTest, CumSum_Int32) {
 
   Tensor *result =
       testCumSum<int32_t>(bindings_, mod_, F_, EE_, ElemKind::Int32ITy,
-                          /*exclusive*/ false, /*reverse*/ false);
+                          /*dim*/ 0, /*exclusive*/ false, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<int32_t>() = {1, 3, 6, 10};
 
@@ -13889,7 +13889,7 @@ TEST_P(OperatorTest, CumSum_Int64) {
 
   Tensor *result =
       testCumSum<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                        /*exclusive*/ false, /*reverse*/ false);
+                        /*dim*/ 0, /*exclusive*/ false, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<float>() = {1, 3, 6, 10};
 
@@ -13905,7 +13905,7 @@ TEST_P(OperatorTest, CumSum_Exclusive) {
 
   Tensor *result =
       testCumSum<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                        /*exclusive*/ true, /*reverse*/ false);
+                        /*dim*/ 0, /*exclusive*/ true, /*reverse*/ false);
   Tensor expected(result->getType());
   expected.getHandle<float>() = {0, 1, 3, 6};
 
@@ -13921,7 +13921,7 @@ TEST_P(OperatorTest, CumSum_Reverse) {
 
   Tensor *result =
       testCumSum<float16_t>(bindings_, mod_, F_, EE_, ElemKind::Float16Ty,
-                            /*exclusive*/ false, /*reverse*/ true);
+                            /*dim*/ 0, /*exclusive*/ false, /*reverse*/ true);
   Tensor expected(result->getType());
   expected.getHandle<float16_t>() = {10, 9, 7, 4};
 
@@ -13937,7 +13937,7 @@ TEST_P(OperatorTest, CumSum_Reverse_BFloat16) {
 
   Tensor *result =
       testCumSum<bfloat16_t>(bindings_, mod_, F_, EE_, ElemKind::BFloat16Ty,
-                             /*exclusive*/ false, /*reverse*/ true);
+                             /*dim*/ 0, /*exclusive*/ false, /*reverse*/ true);
   Tensor expected(result->getType());
   expected.getHandle<bfloat16_t>() = {10, 9, 7, 4};
 
@@ -13953,7 +13953,7 @@ TEST_P(OperatorTest, CumSum_ExclusiveReverse) {
 
   Tensor *result =
       testCumSum<int32_t>(bindings_, mod_, F_, EE_, ElemKind::Int32ITy,
-                          /*exclusive*/ true, /*reverse*/ true);
+                          /*dim*/ 0, /*exclusive*/ true, /*reverse*/ true);
   Tensor expected(result->getType());
   expected.getHandle<int32_t>() = {9, 7, 4, 0};
 
@@ -13970,7 +13970,7 @@ TEST_P(OperatorTest, CumSum_WithZeroes) {
   auto *data = mod_.createPlaceholder(ElemKind::Int64ITy, {9}, "data", false);
   bindings_.allocate(data)->getHandle<int64_t>() = {0, 0, 1, 0, 0, 2, 0, 0, 3};
 
-  auto *CS = F_->createCumSum("CumSum", data);
+  auto *CS = F_->createCumSum("CumSum", data, 0);
   auto *S = F_->createSave("save", CS);
   bindings_.allocate(S->getPlaceholder());
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -353,6 +353,7 @@ int main(int argc, char **argv) {
   BB.newInstr("CumSum")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Input", OperandKind::In)
+      .addMember(MemberType::Int64, "Dim")
       .addMember(MemberType::Unsigned, "Exclusive")
       .addMember(MemberType::Unsigned, "Reverse")
       .inplaceOperand({"Dest", "Input"})

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -720,6 +720,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("CumSum")
       .addInput("Input")
+      .addMember(MemberType::Int64, "Dim")
       .addMember(MemberType::Unsigned, "Exclusive")
       .addMember(MemberType::Unsigned, "Reverse")
       .addResultFromCtorArg()

--- a/torch_glow/tests/nodes/cumsum_test.py
+++ b/torch_glow/tests/nodes/cumsum_test.py
@@ -5,32 +5,41 @@ from tests import utils
 
 
 class SimpleCumSumModule(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, dim):
         super(SimpleCumSumModule, self).__init__()
+        self.dim = dim
 
     def forward(self, tensor):
-        # TODO remove default of 0 when axis/dimension to sum is supported
-        return torch.cumsum(tensor, dim=0)
+        return torch.cumsum(tensor, self.dim)
 
 
 class TestCumSum(utils.TorchGlowTestCase):
     @utils.deterministic_expand(
         [
-            lambda: ("1", False, torch.randn(1)),
-            lambda: ("2", False, torch.randn(2)),
-            lambda: ("20", False, torch.randn(20)),
-            # TODO add these tests when multi-dimension is supported
-            lambda: ("3x3", True, torch.randn(3, 3)),
-            lambda: ("5x4", True, torch.randn(5, 4)),
-            lambda: ("3x3x3", True, torch.randn(3, 4, 5)),
-            lambda: ("3x4x5", True, torch.randn(3, 4, 5)),
-            lambda: ("4x4x4x4", True, torch.randn(6, 5, 4, 3)),
-            lambda: ("6x5x4x3", True, torch.randn(6, 5, 4, 3)),
+            lambda: ("1", torch.randn(1), 0),
+            lambda: ("2", torch.randn(2), 0),
+            lambda: ("20", torch.randn(20), 0),
+            lambda: ("3x4_0", torch.randn(3, 4), 0),
+            lambda: ("3x4_1", torch.randn(3, 4), 1),
+            lambda: ("3x4_-1", torch.randn(3, 4), -1),
+            lambda: ("3x4_-2", torch.randn(3, 4), -2),
+            lambda: ("3x4x5_0", torch.randn(3, 4, 5), 0),
+            lambda: ("3x4x5_1", torch.randn(3, 4, 5), 1),
+            lambda: ("3x4x5_2", torch.randn(3, 4, 5), 2),
+            lambda: ("3x4x5_-1", torch.randn(3, 4, 5), -1),
+            lambda: ("3x4x5_-2", torch.randn(3, 4, 5), -2),
+            lambda: ("3x4x5_-3", torch.randn(3, 4, 5), -3),
+            lambda: ("6x5x4x3_0", torch.randn(6, 5, 4, 3), 0),
+            lambda: ("6x5x4x3_1", torch.randn(6, 5, 4, 3), 1),
+            lambda: ("6x5x4x3_2", torch.randn(6, 5, 4, 3), 2),
+            lambda: ("6x5x4x3_3", torch.randn(6, 5, 4, 3), 3),
+            lambda: ("6x5x4x3_-1", torch.randn(6, 5, 4, 3), -1),
+            lambda: ("6x5x4x3_-2", torch.randn(6, 5, 4, 3), -2),
+            lambda: ("6x5x4x3_-3", torch.randn(6, 5, 4, 3), -3),
+            lambda: ("6x5x4x3_-4", torch.randn(6, 5, 4, 3), -4),
         ]
     )
-    def test_cumsum(self, _, skip, tensor):
-        if skip:
-            self.skipTest("multi-dimension is supported yet support")
+    def test_cumsum(self, _, tensor, dim):
         utils.compare_tracing_methods(
-            SimpleCumSumModule(), tensor, fusible_ops={"aten::cumsum"}
+            SimpleCumSumModule(dim), tensor, fusible_ops={"aten::cumsum"}
         )


### PR DESCRIPTION
Summary:
Extended the IR to add `dim` param to both `CumSumNode` and `CumSumInstr`;
Added multi-dimensional support in the interpreter backend;
Added related test cases in the `cumsum_test.py`.

Differential Revision: D26782370

