### PR TITLE
Add shape inference for aten::linear

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -219,6 +219,8 @@ private:
   static Expected<TensorOutput> matmul(const MetaStack &variableMetas);
   // Shape inference for aten::layerNorm
   static Expected<TensorOutput> layerNorm(const MetaStack &variableMetas);
+  // Shape inference for aten::linear
+  static Expected<TensorOutput> linear(const MetaStack &variableMetas);
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary:
Context:
As titled, this operator is in recent models.
Change
Add shape inference function and unit test

Differential Revision: D26827744

