### PR TITLE
Add option for varying lengths across uniform distribution

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -89,6 +89,21 @@
     }                                                                          \
   } while (0)
 
+/// Takes an Expected<T> \p rhsOrErr and if it is an Error then LOG(FATAL)'s,
+/// otherwise takes the value from rhsOrErr and assigns it to \p lhs.
+#define ASSIGN_VALUE_OR_FATAL(lhs, rhsOrErr)                                   \
+  do {                                                                         \
+    auto rhsOrErrV = (rhsOrErr);                                               \
+    static_assert(glow::detail::IsExpected<decltype(rhsOrErrV)>(),             \
+                  "Expected value to be a Expected");                          \
+    if (rhsOrErrV) {                                                           \
+      lhs = std::move(rhsOrErrV.get());                                        \
+    } else {                                                                   \
+      auto err = rhsOrErrV.takeError();                                        \
+      LOG(FATAL) << ERR_TO_STRING(std::move(err));                             \
+    }                                                                          \
+  } while (0)
+
 /// Takes an Error, adds stack information to it, and returns it unconditionally
 #define RETURN_ERR(err)                                                        \
   do {                                                                         \


### PR DESCRIPTION
Summary:
Add support for `numIndicesPerBatchMin` and `numIndicesPerBatchMax`, where the num indices per batch is uniformly distributed between the two, inclusive.

Before we would specify an int for `numIndicesPerBatch`. Now you still can specify a single value in that same index in the input config, which should keep the same behavior. Alternatively you can specify a range like `1:2` to assign `numIndicesPerBatchMin` and `numIndicesPerBatchMax` respectively. Note that `1` is the same as `1:1`.

Differential Revision: D26972808

