### PR TITLE
Make relu, gelu, swish, and log consistent with other unary ops

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -711,15 +711,21 @@ public:
 
   /// Create a ReLU node with the given \p name and \p input.
   /// Result type will be implicitly set based on the \p input type.
+  ReluNode *createRelu(llvm::StringRef name, NodeValue input);
+  // deprecated.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input);
 
   /// Create a ReLU node with the given \p name, \p input and
   /// output type \p outTy.
+  ReluNode *createRelu(llvm::StringRef name, TypeRef outTy, NodeValue input);
+  // deprecated.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input, TypeRef outTy);
 
   /// Create a series of nodes representing a GeLU with the given \p name and \p
   /// input. Result type will be implicitly set based on the \p input type.
-  Node *createGELU(llvm::StringRef name, NodeValue input);
+  GeluNode *createGelu(llvm::StringRef name, NodeValue input);
+  // deprecated.
+  GeluNode *createGELU(llvm::StringRef name, NodeValue input);
 
   /// Create a PReLU node with the given \p name, \p input and  \p slope.
   /// Result type will be implicitly set based on the \p input type.
@@ -743,8 +749,10 @@ public:
   /// Create a Swish node with the given \p name and \p input.
   /// If \p OT is nullptr, then result type will be implicitly set based on the
   /// \p input type.
-  SwishNode *createSwish(llvm::StringRef name, NodeValue input,
-                         TypeRef OT = nullptr);
+  SwishNode *createSwish(llvm::StringRef name, NodeValue input);
+  SwishNode *createSwish(llvm::StringRef name, TypeRef OT, NodeValue input);
+  // deprecated.
+  SwishNode *createSwish(llvm::StringRef name, NodeValue input, TypeRef OT);
 
   /// Create a Tanh node with the given \p name, \p input and
   /// output type \p outTy.
@@ -764,8 +772,10 @@ public:
 
   /// Create a Log node with \p name, which calculates element-wise natural log
   /// of \p input, with output type \p outTy.
-  LogNode *createLog(llvm::StringRef name, NodeValue input,
-                     TypeRef outTy = nullptr);
+  LogNode *createLog(llvm::StringRef name, NodeValue input);
+  LogNode *createLog(llvm::StringRef name, TypeRef outTy, NodeValue input);
+  // deprecated
+  LogNode *createLog(llvm::StringRef name, NodeValue input, TypeRef outTy);
 
   /// \returns a LogitNode with \p name given \p input and \p eps.
   LogitNode *createLogit(llvm::StringRef name, NodeValue input, float eps);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1186,17 +1186,30 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
       name, outTy, input, qWeights, scales, offsets, B));
 }
 
-ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input,
-                               TypeRef outTy) {
+ReluNode *Function::createRelu(llvm::StringRef name, TypeRef outTy,
+                               NodeValue input) {
   return addNode(new ReluNode(name, outTy, input));
 }
 
-ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input) {
-  return addNode(new ReluNode(name, input.getType(), input));
+ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input,
+                               TypeRef outTy) {
+  return createRelu(name, outTy, input);
 }
 
-Node *Function::createGELU(llvm::StringRef name, NodeValue input) {
+ReluNode *Function::createRelu(llvm::StringRef name, NodeValue input) {
+  return createRelu(name, input.getType(), input);
+}
+
+ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input) {
+  return createRelu(name, input);
+}
+
+GeluNode *Function::createGelu(llvm::StringRef name, NodeValue input) {
   return addNode(new GeluNode(name, input.getType(), input));
+}
+
+GeluNode *Function::createGELU(llvm::StringRef name, NodeValue input) {
+  return createGelu(name, input);
 }
 
 PReluNode *Function::createPRELU(llvm::StringRef name, NodeValue input,
@@ -1218,12 +1231,18 @@ SigmoidNode *Function::createSigmoid(llvm::StringRef name, NodeValue input) {
   return createSigmoid(name, input.getType(), input);
 }
 
+SwishNode *Function::createSwish(llvm::StringRef name, NodeValue input) {
+  return createSwish(name, getParent()->uniqueType(*input.getType()), input);
+}
+
+SwishNode *Function::createSwish(llvm::StringRef name, TypeRef OT,
+                                 NodeValue input) {
+  return addNode(new SwishNode(name, OT, input));
+}
+
 SwishNode *Function::createSwish(llvm::StringRef name, NodeValue input,
                                  TypeRef OT) {
-  if (!OT) {
-    OT = getParent()->uniqueType(*input.getType());
-  }
-  return addNode(new SwishNode(name, OT, input));
+  return createSwish(name, OT, input);
 }
 
 TanhNode *Function::createTanh(llvm::StringRef name, TypeRef outTy,
@@ -1885,9 +1904,18 @@ PowNode *Function::createPow(llvm::StringRef name, NodeValue base, float exp) {
   return createPow(name, base, SP);
 }
 
+LogNode *Function::createLog(llvm::StringRef name, NodeValue input) {
+  return createLog(name, input.getType(), input);
+}
+
+LogNode *Function::createLog(llvm::StringRef name, TypeRef outTy,
+                             NodeValue input) {
+  return addNode(new LogNode(name, outTy, input));
+}
+
 LogNode *Function::createLog(llvm::StringRef name, NodeValue input,
                              TypeRef outTy) {
-  return addNode(new LogNode(name, outTy ? outTy : input.getType(), input));
+  return createLog(name, outTy, input);
 }
 
 ExpNode *Function::createExp(llvm::StringRef name, NodeValue input) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -529,10 +529,6 @@ private:
   /// \returns error on failure.
   Error loadRsub(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch log node.
-  /// \returns error on failure.
-  Error loadLog(const torch::jit::Node *ptNode);
-
   /// Load a PyTorch sum node.
   /// \returns error on failure.
   Error loadSum(const torch::jit::Node *ptNode);
@@ -540,10 +536,6 @@ private:
   /// Load a PyTorch max node.
   /// \returns error on failure.
   Error loadMax(const torch::jit::Node *ptNode);
-
-  /// Load a PyTorch gelu node.
-  /// \returns error on failure.
-  Error loadGelu(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch pow node.
   /// \returns error on failure.
@@ -731,10 +723,6 @@ private:
   /// Load a PyTorch max_pool2d node.
   /// \returns error on failure.
   Error loadMaxPool2d(const torch::jit::Node *ptNode);
-
-  /// Load a PyTorch silu node.
-  /// \returns error on failure.
-  Error loadSilu(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch avg_pool1d node.
   /// \tparam numDims - number of dimentions, support 1d, 2d and 3d.


### PR DESCRIPTION
Summary:
These functions had names or signatures that did not match other create methods
in glow::Function. This change adds overloads that are consistent with the
other methods, allowing PyTorchModelLoader to wrap them like other unary ops.

The old overloads are left in place. Once references to them are switched to
the new overloads, they can be deleted.

Differential Revision: D26994437

