### PR TITLE
Fix quantizing layernorm in NNPI backend

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -519,7 +519,23 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor) {
     }
     auto glowType =
         ptTypeToGlowType(*c10::TensorType::create(ptTensor), scale, offset);
-    return glow::Tensor(ptTensor.data_ptr(), &glowType);
+    glow::Tensor glowTensor(ptTensor.data_ptr(), &glowType);
+
+    // If tensor is of UInt8QTy kind, convert it to Int8QTy.
+    if (glowTensor.getElementType() == ElemKind::UInt8QTy) {
+      auto handle = glowTensor.getHandle<uint8_t>();
+      glow::Tensor newTensor(glow::ElemKind::Int8QTy, glowTensor.dims(),
+                             glowTensor.getType().getScale(),
+                             glowTensor.getType().getOffset() -
+                                 UINT8_TO_INT8_SHIFT);
+      auto newHandle = newTensor.getHandle<int8_t>();
+      for (size_t i = 0; i < handle.size(); i++) {
+        newHandle.raw(i) =
+            static_cast<int8_t>((int32_t)handle.raw(i) - UINT8_TO_INT8_SHIFT);
+      }
+      return newTensor;
+    }
+    return glowTensor;
   } else if (ptTensor.scalar_type() == at::kDouble) {
     at::Tensor atTensor = ptTensor.to(at::kFloat);
     auto glowType = ptTypeToGlowType(*c10::TensorType::create(atTensor));


### PR DESCRIPTION
Summary: For NNPI backend, we need to quantize the scale and bias if they are fp for quantized layernorm. However, scale and bias could be either fp32 or fp16. If they are fp16 we need to pass the fp32 data to quantization because Glow quantization only works for fp32.

Differential Revision: D27063708

