### PR TITLE
[DottyGraph] Wrap very long node names when dumping graph.

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -74,6 +74,12 @@ inline std::string truncateString(const std::string &str, size_t length,
   return (str.size() > length) ? (str.substr(0, length) + suffix) : str;
 }
 
+/// \returns a string obtained from the input string \p str by adding a
+/// delimiter string \p delimiter after each block of \p length characters.
+/// After the last block no delimiter is added.
+std::string separateString(const std::string &str, size_t length,
+                           const std::string &delimiter = "\n");
+
 /// \returns the escaped content of string \p str.
 /// The char '\n' becomes '\'+'n' and quotes are handled correctly.
 std::string escapeDottyString(const std::string &str);

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -65,15 +65,6 @@ Stream &operator<<(Stream &os, const llvm::ArrayRef<E> list) {
   return os;
 }
 
-/// \returns a truncated version of the input string \p str to a maximum
-/// length of \p length. If the string effectively needs truncation then a
-/// given \p suffix will pe appended to the truncated string to signal that
-/// string was actually truncated.
-inline std::string truncateString(const std::string &str, size_t length,
-                                  const std::string &suffix = "...") {
-  return (str.size() > length) ? (str.substr(0, length) + suffix) : str;
-}
-
 /// \returns a string obtained from the input string \p str by adding a
 /// delimiter string \p delimiter after each block of \p length characters.
 /// After the last block no delimiter is added.

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -65,6 +65,15 @@ Stream &operator<<(Stream &os, const llvm::ArrayRef<E> list) {
   return os;
 }
 
+/// \returns a truncated version of the input string \p str to a maximum
+/// length of \p length. If the string effectively needs truncation then a
+/// given \p suffix will pe appended to the truncated string to signal that
+/// string was actually truncated.
+inline std::string truncateString(const std::string &str, size_t length,
+                                  const std::string &suffix = "...") {
+  return (str.size() > length) ? (str.substr(0, length) + suffix) : str;
+}
+
 /// \returns the escaped content of string \p str.
 /// The char '\n' becomes '\'+'n' and quotes are handled correctly.
 std::string escapeDottyString(const std::string &str);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -85,24 +85,24 @@ Node *Storage::clone() const { llvm_unreachable("Storage can't be cloned."); }
 
 std::string Constant::getDebugDesc(bool skipUsers) const {
   DescriptionBuilder db(getKindName());
-  db.addParam("name", quote(getName().str()))
-      .addParam("layout", getLayout())
-      .addParam("output", *getType());
+  db.addParam("Name", quote(getName().str()))
+      .addParam("Layout", getLayout())
+      .addParam("Output", *getType());
   if (!skipUsers) {
-    db.addParam("users", getNumUsers());
+    db.addParam("Users", getNumUsers());
   }
   return db;
 }
 
 std::string Placeholder::getDebugDesc(bool skipUsers) const {
   DescriptionBuilder db(getKindName());
-  db.addParam("name", quote(getName().str()))
-      .addParam("layout", getLayout())
-      .addParam("output", *getType())
-      .addParam("trainable", isTraining())
-      .addParam("static", isStatic());
+  db.addParam("Name", quote(getName().str()))
+      .addParam("Layout", getLayout())
+      .addParam("Output", *getType())
+      .addParam("Trainable", isTraining())
+      .addParam("Static", isStatic());
   if (!skipUsers) {
-    db.addParam("users", getNumUsers());
+    db.addParam("Users", getNumUsers());
   }
   return db;
 }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -85,7 +85,7 @@ Node *Storage::clone() const { llvm_unreachable("Storage can't be cloned."); }
 
 std::string Constant::getDebugDesc(bool skipUsers) const {
   DescriptionBuilder db(getKindName());
-  db.addParam("Name", quote(getName().str()))
+  db.addParam("Name", separateString(getName(), 100, "\n"))
       .addParam("Layout", getLayout())
       .addParam("Output", *getType());
   if (!skipUsers) {
@@ -96,7 +96,7 @@ std::string Constant::getDebugDesc(bool skipUsers) const {
 
 std::string Placeholder::getDebugDesc(bool skipUsers) const {
   DescriptionBuilder db(getKindName());
-  db.addParam("Name", quote(getName().str()))
+  db.addParam("Name", separateString(getName(), 100, "\n"))
       .addParam("Layout", getLayout())
       .addParam("Output", *getType())
       .addParam("Trainable", isTraining())

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -74,6 +74,31 @@ llvm::raw_ostream &errs() { return llvm::errs(); }
 
 llvm::raw_ostream &dbgs() { return llvm::dbgs(); }
 
+std::string separateString(const std::string &str, size_t length,
+                           const std::string &delimiter) {
+  assert(length > 0 && "Separation block length must be greater than 0!");
+  size_t inpSize = str.size();
+  size_t delSize = delimiter.size();
+  size_t numBlocks = (inpSize + length - 1) / length;
+  size_t outSize = inpSize + (numBlocks - 1) * delSize;
+  std::string sepStr;
+  sepStr.reserve(outSize);
+  for (size_t blockIdx = 0; blockIdx < numBlocks; blockIdx++) {
+    // Append substring block.
+    size_t blockStart = blockIdx * length;
+    size_t blockSize =
+        (inpSize - blockStart) >= length ? length : (inpSize - blockStart);
+    blockSize = (blockSize >= length) ? length : blockSize;
+    sepStr.append(str, blockStart, blockSize);
+    // Append delimiter.
+    if (blockIdx < numBlocks - 1) {
+      sepStr.append(delimiter);
+    }
+  }
+  assert(sepStr.size() == outSize && "Inconsistent string separation!");
+  return sepStr;
+}
+
 std::string escapeDottyString(const std::string &str) {
   std::string out;
   out.reserve(str.capacity());

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -2124,12 +2124,12 @@ TEST(Graph, testDumpStructure) {
   K->dump(osN1);
   std::string mesN = K->toString();
   std::string expectMes = R"(Placeholder
-name : "input"
-layout : *
-output : float<4 x 320 x 200 x 100 x 3>
-trainable : 1
-static : 0
-users : 0
+Name : "input"
+Layout : *
+Output : float<4 x 320 x 200 x 100 x 3>
+Trainable : 1
+Static : 0
+Users : 0
 )";
   EXPECT_EQ(mesN, expectMes);
   EXPECT_EQ(mesN, osN1.str());
@@ -2149,19 +2149,19 @@ users : 0
   std::string mesF = F2->toString();
   std::string expectMesF = R"(Graph structure F2:
 TopK
-name : topk
+Name : topk
 Input : float<10 x 10>
 K : 3
-users : 0
+Users : 0
 Values : float<10 x 3>
 Indices : index64<10 x 3>
 Placeholder
-name : "input__1"
-layout : *
-output : float<10 x 10>
-trainable : 1
-static : 1
-users : 1
+Name : "input__1"
+Layout : *
+Output : float<10 x 10>
+Trainable : 1
+Static : 1
+Users : 1
 )";
   EXPECT_EQ(mesF, expectMesF);
   EXPECT_EQ(mesF, osF1.str());
@@ -2174,18 +2174,18 @@ users : 1
   mesF = F2->toString(/* skipUsersForStorage */ true);
   expectMesF = R"(Graph structure F2:
 TopK
-name : topk
+Name : topk
 Input : float<10 x 10>
 K : 3
-users : 0
+Users : 0
 Values : float<10 x 3>
 Indices : index64<10 x 3>
 Placeholder
-name : "input__1"
-layout : *
-output : float<10 x 10>
-trainable : 1
-static : 1
+Name : "input__1"
+Layout : *
+Output : float<10 x 10>
+Trainable : 1
+Static : 1
 )";
   EXPECT_EQ(mesF, expectMesF);
   EXPECT_EQ(mesF, osF1.str());
@@ -2197,26 +2197,26 @@ static : 1
   std::string mesM = MD.toString();
   std::string expectMesM = R"(Module structure:
 Constant
-name : "dummy"
-layout : *
-output : float<1 x 1>
-users : 0
+Name : "dummy"
+Layout : *
+Output : float<1 x 1>
+Users : 0
 
 Placeholder
-name : "input__1"
-layout : *
-output : float<10 x 10>
-trainable : 1
-static : 1
-users : 1
+Name : "input__1"
+Layout : *
+Output : float<10 x 10>
+Trainable : 1
+Static : 1
+Users : 1
 
 Placeholder
-name : "input"
-layout : *
-output : float<4 x 320 x 200 x 100 x 3>
-trainable : 1
-static : 0
-users : 0
+Name : "input"
+Layout : *
+Output : float<4 x 320 x 200 x 100 x 3>
+Trainable : 1
+Static : 0
+Users : 0
 
 Function : F2
 Function : F

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -2124,7 +2124,7 @@ TEST(Graph, testDumpStructure) {
   K->dump(osN1);
   std::string mesN = K->toString();
   std::string expectMes = R"(Placeholder
-Name : "input"
+Name : input
 Layout : *
 Output : float<4 x 320 x 200 x 100 x 3>
 Trainable : 1
@@ -2156,7 +2156,7 @@ Users : 0
 Values : float<10 x 3>
 Indices : index64<10 x 3>
 Placeholder
-Name : "input__1"
+Name : input__1
 Layout : *
 Output : float<10 x 10>
 Trainable : 1
@@ -2181,7 +2181,7 @@ Users : 0
 Values : float<10 x 3>
 Indices : index64<10 x 3>
 Placeholder
-Name : "input__1"
+Name : input__1
 Layout : *
 Output : float<10 x 10>
 Trainable : 1
@@ -2197,13 +2197,13 @@ Static : 1
   std::string mesM = MD.toString();
   std::string expectMesM = R"(Module structure:
 Constant
-Name : "dummy"
+Name : dummy
 Layout : *
 Output : float<1 x 1>
 Users : 0
 
 Placeholder
-Name : "input__1"
+Name : input__1
 Layout : *
 Output : float<10 x 10>
 Trainable : 1
@@ -2211,7 +2211,7 @@ Static : 1
 Users : 1
 
 Placeholder
-Name : "input"
+Name : input
 Layout : *
 Output : float<4 x 320 x 200 x 100 x 3>
 Trainable : 1

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -305,7 +305,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
 void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
   os << "\nstd::string " << name_ << "Node::getDebugDesc() const {\n"
      << "  DescriptionBuilder db(getKindName());\n"
-     << "  db.addParam(\"name\", getName());\n";
+     << "  db.addParam(\"Name\", truncateString(getName(), 100));\n";
 
   os << "  if (hasPredicate()) db.addParam(\"Predicate\", \"Yes\");\n";
 
@@ -334,7 +334,7 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
          << "())\n";
     }
   }
-  os << "    .addParam(\"users\", getNumUsers());\n";
+  os << "    .addParam(\"Users\", getNumUsers());\n";
 
   for (const auto &mem : members_) {
     if ((mem.first).type != MemberType::VectorNodeValue) {

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -305,7 +305,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
 void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
   os << "\nstd::string " << name_ << "Node::getDebugDesc() const {\n"
      << "  DescriptionBuilder db(getKindName());\n"
-     << "  db.addParam(\"Name\", truncateString(getName(), 100));\n";
+     << "  db.addParam(\"name\", truncateString(getName(), 100));\n";
 
   os << "  if (hasPredicate()) db.addParam(\"Predicate\", \"Yes\");\n";
 
@@ -334,7 +334,7 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
          << "())\n";
     }
   }
-  os << "    .addParam(\"Users\", getNumUsers());\n";
+  os << "    .addParam(\"users\", getNumUsers());\n";
 
   for (const auto &mem : members_) {
     if ((mem.first).type != MemberType::VectorNodeValue) {

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -305,7 +305,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
 void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
   os << "\nstd::string " << name_ << "Node::getDebugDesc() const {\n"
      << "  DescriptionBuilder db(getKindName());\n"
-     << "  db.addParam(\"name\", truncateString(getName(), 100));\n";
+     << "  db.addParam(\"name\", separateString(getName(), 100, \"\\n\"));\n";
 
   os << "  if (hasPredicate()) db.addParam(\"Predicate\", \"Yes\");\n";
 

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -305,7 +305,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
 void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
   os << "\nstd::string " << name_ << "Node::getDebugDesc() const {\n"
      << "  DescriptionBuilder db(getKindName());\n"
-     << "  db.addParam(\"name\", separateString(getName(), 100, \"\\n\"));\n";
+     << "  db.addParam(\"Name\", separateString(getName(), 100, \"\\n\"));\n";
 
   os << "  if (hasPredicate()) db.addParam(\"Predicate\", \"Yes\");\n";
 
@@ -334,7 +334,7 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
          << "())\n";
     }
   }
-  os << "    .addParam(\"users\", getNumUsers());\n";
+  os << "    .addParam(\"Users\", getNumUsers());\n";
 
   for (const auto &mem : members_) {
     if ((mem.first).type != MemberType::VectorNodeValue) {


### PR DESCRIPTION
**Summary**
Wrap very long node names (longer than 100 chars) when dumping the graph. Such nodes make the graph harder to read.
One such example is this:
![image](https://user-images.githubusercontent.com/29785908/111490356-a1ad9b80-8743-11eb-8493-41f5453de48a.png)
After wrapping the name the node looks like this:
![image](https://user-images.githubusercontent.com/29785908/111522536-13491200-8763-11eb-9e09-d171be810592.png)
