### PR TITLE
Add accessors for the LLVMIRGen used by BundleSaver

### DIFF
--- a/include/glow/LLVMIRCodeGen/BundleSaver.h
+++ b/include/glow/LLVMIRCodeGen/BundleSaver.h
@@ -92,6 +92,8 @@ protected:
   /// \returns the weight that the variable \p v is lowered into in one of the
   /// IR functions inside this bundle, or null if the variable is unknown.
   virtual Value *getWeightForNode(const Storage *V) const;
+  /// \returns LLVMIRGen used by the bundle saver.
+  virtual LLVMIRGen *getLLVMIRGen();
   /// Information about allocations.
   AllocationsInfo allocationsInfo_;
   /// The LLVM IR code generator.

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -719,3 +719,5 @@ void BundleSaver::save(llvm::StringRef mainEntryName, const IRFunction *F) {
   irgen_->performCodeGen();
   savedIRFunctions_.back().llvmF = irgen_->getLLVMFunction();
 }
+
+LLVMIRGen *BundleSaver::getLLVMIRGen() { return irgen_.get(); }


### PR DESCRIPTION
Summary: This is useful for some backends.

Reviewed By: shajrawi

Differential Revision: D27299757

