### PR TITLE
Replace inefficient Concat Nodes with Reshape->Concat->Transpose

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1862,6 +1862,67 @@ static bool removeClipsBlockingFusion(Function *F) {
   return changed;
 }
 
+// Replace inefficient Concat Nodes with Reshape->Concat->Transpose.
+// For Concat Nodes concatenating inputs on the innermost dimension, if the
+// innermost dimension size of the inputs is small (e.g., 1), the corresponding
+// memory access is inefficient. Therefore, those Concat Nodes need to be
+// replaced by Reshape->Concat->Transpose.
+// Example:
+//   Original: Inputs[4096x1]->Concat[4096x50]
+//   New:      Inputs[4096x1]->Reshape[1x4096]->Concat[50x4096]
+//                           ->Transpose[4096x50]
+static bool replaceInefficientConcat(Function *F) {
+  bool changed = false;
+  // This optimization is applied conservatively to avoid causing potential
+  // perf regression on other models.
+  const int targetInputNumDims = 2;
+  const int targetInputLastDim = 1;
+  const int targetInputOtherDim = 4096;
+  for (auto &N : F->getNodes()) {
+    auto *CN = llvm::dyn_cast<ConcatNode>(&N);
+    if (!CN) {
+      continue;
+    }
+    bool isTargetConcat = true;
+    auto origInputs = CN->getInputs();
+    // Check whether the Concat Node is a target
+    if ((origInputs[0].dims().size() != targetInputNumDims) ||
+        (CN->getDim() != (targetInputNumDims - 1)) ||
+        (origInputs[0].dims()[0] < targetInputOtherDim)) {
+      isTargetConcat = false;
+    } else {
+      for (auto &input : origInputs) {
+        const auto &origInputDims = input.dims();
+        if (origInputDims[origInputDims.size() - 1] != targetInputLastDim) {
+          isTargetConcat = false;
+          break;
+        }
+      }
+    }
+    if (!isTargetConcat) {
+      continue;
+    }
+    // Insert Reshape Nodes
+    std::vector<NodeValue> reshapes(origInputs.size());
+    for (int idx = 0; idx < origInputs.size(); ++idx) {
+      const std::vector<dim_t> newInputDims = {origInputs[idx].dims()[1],
+                                               origInputs[idx].dims()[0]};
+      DCHECK(idx < reshapes.size()) << "out-of-range idx";
+      reshapes[idx] = F->createReshape(
+          origInputs[idx].getNode()->getName().str() + "_reshaped",
+          origInputs[idx].getNode(), newInputDims);
+    }
+    // Create new Concat Node
+    auto *newCN =
+        F->createConcat(CN->getName().str() + "_for_tranpose", reshapes, 0);
+    // Insert Transpose Node
+    auto *newTN = F->createTranspose(CN->getName().str(), newCN, {1, 0});
+    CN->getResult().replaceAllUsesOfWith(newTN->getResult());
+    changed = true;
+  }
+  return changed;
+}
+
 Expected<bool>
 NNPIBackend::transformPostOptPipeline(Function *F,
                                       CompilationContext &cctx) const {
@@ -1917,6 +1978,7 @@ Expected<bool> NNPIBackend::transformPostLowering(
   changed |= padKernelToStride(F);
   changed |= lowerEmbeddingToGather(F);
   changed |= quantizeLayernormScaleAndBias(F);
+  changed |= replaceInefficientConcat(F);
   auto it =
       cctx.backendOpts.backendSpecificOpts.find("NNPI_ZeroScaleFP16Replace");
   if (it != cctx.backendOpts.backendSpecificOpts.end() && it->second == "1") {


### PR DESCRIPTION
Summary:
For ```Concat``` Nodes concatenating inputs on the innermost dimension, if the innermost dimension size of the inputs is small (e.g., 1), the corresponding memory access is inefficient. Therefore, those ```Concat``` Nodes need to be replaced by ```Reshape->Concat->Transpose```.

Example:
Original: ```Inputs[4096x1]->Concat[4096x50]```
New:      ```Inputs[4096x1]->Reshape[1x4096]->Concat[50x4096]->Transpose[4096x50]```

Reviewed By: jfix71, khabinov

Differential Revision: D27152011

