### PR TITLE
Put Clip before Tile node to improve performance

### DIFF
--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -121,6 +121,7 @@ Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
     case Kinded::Kind::GatherNodeKind:
     case Kinded::Kind::ReshapeNodeKind:
     case Kinded::Kind::SliceNodeKind:
+    case Kinded::Kind::TileNodeKind:
     case Kinded::Kind::TransposeNodeKind:
       needClip = false;
       break;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5158,6 +5158,18 @@ bool RaiseClipsAboveShapeNodes::run(Function *F,
       changed = true;
       continue;
     }
+
+    // Sink Tile below Clip.
+    if (TileNode *TN = dyn_cast<TileNode>(CN->getInput())) {
+      ClipNode *newCN = F->createClip(CN->getName(), TN->getInput(),
+                                      CN->getMin(), CN->getMax());
+      TileNode *newTN = F->createTile(TN->getName(), newCN->getResult(),
+                                      TN->getCount(), TN->getAxis());
+      CN->getResult().replaceAllUsesOfWith(newTN->getResult());
+      oneLessUser.insert(TN->getInput().getNode());
+      changed = true;
+      continue;
+    }
   } // For all nodes in the graph.
 
   return changed;

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -6041,29 +6041,33 @@ TEST_F(GraphOptz, RaiseClipsAboveShapeNodesTest) {
   ReshapeNode *RN2 = F_->createReshape("reshape2", RN1, {64, 256});
   TransposeNode *TN = F_->createTranspose("transpose", RN2, {1, 0});
   SliceNode *SN = F_->createSlice("slice", TN, {64, 0}, {256, 64});
-  ClipNode *CN = F_->createClip("clip", SN, -0.1, 0.1);
+  TileNode *TiN = F_->createTile("tile", SN, 2, 0);
+  ClipNode *CN = F_->createClip("clip", TiN, -0.1, 0.1);
   SaveNode *save1 = F_->createSave("save1", RN1);
   SaveNode *save2 = F_->createSave("save2", CN);
 
   optimizedF_ =
       optimizeFunctionForTest(F_, {FunctionPassID::RaiseClipsAboveShapeNodes});
 
-  SaveNode *optSave1 =
+  auto *optSave1 =
       llvm::dyn_cast<SaveNode>(optimizedF_->getNodeByName(save1->getName()));
   ASSERT_TRUE(optSave1);
-  SaveNode *optSave2 =
+  auto *optSave2 =
       llvm::dyn_cast<SaveNode>(optimizedF_->getNodeByName(save2->getName()));
   ASSERT_TRUE(optSave2);
 
   // save1 should only have a single untouched Reshape RN1 input which has input
   // input into it, because RN1 has multiple users.
-  ReshapeNode *optRN1 =
-      llvm::dyn_cast<ReshapeNode>(optSave1->getInput().getNode());
+  auto *optRN1 = llvm::dyn_cast<ReshapeNode>(optSave1->getInput().getNode());
   ASSERT_TRUE(optRN1);
   EXPECT_EQ(input, optRN1->getInput().getNode());
 
-  // save2 should have CN it originally saved pushed up above SN, TN, and RN2.
-  SliceNode *newSN = llvm::dyn_cast<SliceNode>(optSave2->getInput());
+  // save2 should have CN it originally saved pushed up above SN, TiN, TN, and
+  // RN2.
+  TileNode *newTiN = llvm::dyn_cast<TileNode>(optSave2->getInput());
+  ASSERT_TRUE(newTiN);
+  EXPECT_EQ(newTiN->getCount(), TiN->getCount());
+  SliceNode *newSN = llvm::dyn_cast<SliceNode>(newTiN->getInput());
   ASSERT_TRUE(newSN);
   EXPECT_EQ(newSN->getStart(), SN->getStart());
   TransposeNode *newTN = llvm::dyn_cast<TransposeNode>(newSN->getInput());


### PR DESCRIPTION
Summary: Swap Tile and Clip operators upon a sequence "X -> Tile -> Clip -> Y" to improve performance.

Differential Revision: D27445190

