### PR TITLE
Add shape inference support for fb::xl_embedding_bag_byte_rowwise_offsets and fb::xl_embedding_bag_4bit_rowwise_offsets

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -194,6 +194,11 @@ private:
   quantizedGlowEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for fb::xl_embedding_bag
   static Expected<TensorOutput> xlEmbeddingBag(const MetaStack &variableMetas);
+  static Expected<TensorOutput>
+  quantizedXLEmbeddingBagByteRowwiseOffsets(const MetaStack &variableMetas);
+  // Shape inference for fb::glow_embedding_bag_4bit_rowwise_offsets
+  static Expected<TensorOutput>
+  quantizedXLEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for aten::chuck
   static Expected<TensorListOutput> chunk(const MetaStack &variableMetas);
   // Shape inference for aten::stack


### PR DESCRIPTION
Summary:
Context:
As titled, this operator is in recent models.
Change
Add shape inference function

Reviewed By: movefast1990

Differential Revision: D27217854

