### PR TITLE
Fix embedding dims for quantized xl embedding bags in PyTorch model loader

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -194,6 +194,11 @@ private:
   quantizedGlowEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for fb::xl_embedding_bag
   static Expected<TensorOutput> xlEmbeddingBag(const MetaStack &variableMetas);
+  static Expected<TensorOutput>
+  quantizedXLEmbeddingBagByteRowwiseOffsets(const MetaStack &variableMetas);
+  // Shape inference for fb::glow_embedding_bag_4bit_rowwise_offsets
+  static Expected<TensorOutput>
+  quantizedXLEmbeddingBag4BitRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for aten::chuck
   static Expected<TensorListOutput> chunk(const MetaStack &variableMetas);
   // Shape inference for aten::stack


### PR DESCRIPTION
Summary:
Context
As titled, the embedding dims for quantized xl embedding bags need to be scaled (as we did in quantized glow embedding bags)

Reviewed By: allwu

Differential Revision: D27331693

