### PR TITLE
LayerNorm Opeartor Test using stronger norm_shape

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -406,6 +406,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FP16BatchNorm3D/0",
     "Int8BatchNorm3D/0",
     "LayerNorm_Float16/0",
+    "LayerNorm_Float16_StrongNormShape/0",
     "LayerNorm_Int8_With_Float_Scale_Bias/0",
     "DynamicQuantizedFullyConnectedBasic/0",
     "DynamicQuantizedFullyConnectedStrongWeights/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -123,6 +123,9 @@ struct BlacklistInitializer {
       {"CumSum3D_int32_t_Dim2/0", TestBlacklist::AnyDeviceAnyEngine},
       {"LayerNorm_BFloat16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"LayerNorm_Float/0", TestBlacklist::AnyDeviceAnyEngine},
+      // Known issue of normshape for LayerNorm on NNPI
+      {"LayerNorm_Float16_StrongNormShape/0",
+       TestBlacklist::AnyDeviceAnyEngine},
       {"LengthsSum/0", TestBlacklist::AnyDeviceAnyEngine},
       {"LengthsToRanges/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ModuloInt64NoSignFollow/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -497,6 +497,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FP16BatchNorm3D/0",
     "Int8BatchNorm3D/0",
     "LayerNorm_Float16/0",
+    "LayerNorm_Float16_StrongNormShape/0",
     "LayerNorm_Int8_With_Int8_Scale_Bias/0",
     "LayerNorm_Int8_With_Float_Scale_Bias/0",
     "DequantizeFRWQ_Float/0",


### PR DESCRIPTION
Summary:
In this unit test, we have strong norm_shape which
a) has more than 1 dim
b) not eltwise identical

Differential Revision: D27488091

