### PR TITLE
[Type] Add support for Float64 (double).

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -670,6 +670,8 @@ public:
       return isEqualImpl<float16_t>(other, allowedError, verbose);
     case ElemKind::BFloat16Ty:
       return isEqualImpl<bfloat16_t>(other, allowedError, verbose);
+    case ElemKind::Float64Ty:
+      return isEqualImpl<double>(other, allowedError, verbose);
     case ElemKind::Int8QTy:
       return isEqualImpl<int8_t>(other, allowedError, verbose);
     case ElemKind::UInt8QTy:

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -405,6 +405,8 @@ enum class ElemKind : unsigned char {
   Float16Ty,
   // 16-bit float type (bfloat16)
   BFloat16Ty,
+  // 64-bit float type (double)
+  Float64Ty,
   // 8-bit quantized type (int8_t)
   Int8QTy,
   // unsigned 8-bit quantized type (uint8_t)
@@ -444,7 +446,7 @@ inline bool isQuantizedElemKind(ElemKind e) {
 /// \returns whether \p e is a float ElemKind.
 inline bool isFloatElemKind(ElemKind e) {
   return e == ElemKind::FloatTy || e == ElemKind::Float16Ty ||
-         e == ElemKind::BFloat16Ty;
+         e == ElemKind::BFloat16Ty || e == ElemKind::Float64Ty;
 }
 
 /// \returns whether \p e is a non-quantized integer ElemKind.
@@ -690,6 +692,8 @@ struct Type final {
       return std::is_same<ElemTy, float16_t>::value;
     case ElemKind::BFloat16Ty:
       return std::is_same<ElemTy, bfloat16_t>::value;
+    case ElemKind::Float64Ty:
+      return std::is_same<ElemTy, double>::value;
     case ElemKind::Int8QTy:
       return std::is_same<ElemTy, int8_t>::value;
     case ElemKind::UInt8QTy:
@@ -763,6 +767,8 @@ struct Type final {
       return sizeof(float16_t);
     case ElemKind::BFloat16Ty:
       return sizeof(bfloat16_t);
+    case ElemKind::Float64Ty:
+      return sizeof(double);
     case ElemKind::Int8QTy:
       return sizeof(int8_t);
     case ElemKind::UInt8QTy:
@@ -799,9 +805,10 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float",    "float16",      "bfloat16",     "i8",       "ui8",
-        "i16",      "i32",          "uindex8",      "index32",  "index64",
-        "ui8fused", "ui8fusedfp16", "ui4fusedfp16", "ui4fused", "bool",
+        "float",        "float16",      "bfloat16", "float64",
+        "i8",           "ui8",          "i16",      "i32",
+        "uindex8",      "index32",      "index64",  "ui8fused",
+        "ui8fusedfp16", "ui4fusedfp16", "ui4fused", "bool",
     };
     return names[(int)Ty];
   }
@@ -814,6 +821,8 @@ struct Type final {
       return ElemKind::FloatTy;
     } else if (str == Type::getElementName(ElemKind::Float16Ty)) {
       return ElemKind::Float16Ty;
+    } else if (str == Type::getElementName(ElemKind::Float64Ty)) {
+      return ElemKind::Float64Ty;
     } else if (str == Type::getElementName(ElemKind::BFloat16Ty)) {
       return ElemKind::BFloat16Ty;
     } else if (str == Type::getElementName(ElemKind::Int8QTy)) {

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -427,6 +427,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<float16_t>(), os);
   case ElemKind::BFloat16Ty:
     return dumpAsciiGenericImpl(T->getHandle<bfloat16_t>(), os);
+  case ElemKind::Float64Ty:
+    return dumpAsciiGenericImpl(T->getHandle<double>(), os);
   case ElemKind::Int8QTy:
     return dumpAsciiGenericImpl(T->getHandle<int8_t>(), os);
   case ElemKind::UInt8QTy:
@@ -465,6 +467,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
     return dumpGenericImpl(T->getHandle<float16_t>(), os, maxNumElem);
   case ElemKind::BFloat16Ty:
     return dumpGenericImpl(T->getHandle<bfloat16_t>(), os, maxNumElem);
+  case ElemKind::Float64Ty:
+    return dumpGenericImpl(T->getHandle<double>(), os, maxNumElem);
   case ElemKind::Int8QTy:
     return dumpGenericImpl(T->getHandle<int8_t>(), os, maxNumElem);
   case ElemKind::UInt8QTy:
@@ -583,6 +587,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
   case ElemKind::BFloat16Ty: {
     auto srcH = src->getHandle<bfloat16_t>();
     auto destH = dest->getHandle<bfloat16_t>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
+  case ElemKind::Float64Ty: {
+    auto srcH = src->getHandle<double>();
+    auto destH = dest->getHandle<double>();
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
@@ -710,6 +720,10 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     }
     case ElemKind::BFloat16Ty: {
       getHandle<bfloat16_t>().clear(bfloat16_t(val));
+      break;
+    }
+    case ElemKind::Float64Ty: {
+      getHandle<double>().clear(val);
       break;
     }
     case ElemKind::Int8QTy: {

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1117,6 +1117,8 @@ ONNXModelWriter::convertType(const Type &glowType) {
     return TensorType::FLOAT16;
   case ElemKind::BFloat16Ty:
     return TensorType::BFLOAT16;
+  case ElemKind::Float64Ty:
+    return TensorType::DOUBLE;
   case ElemKind::Int8QTy:
     return TensorType::INT8;
   case ElemKind::UInt8FusedQTy:

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1005,6 +1005,8 @@ Expected<ElemKind> ONNXModelLoader::convertTensorProtoDataType(
     return ElemKind::Float16Ty;
   case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
     return ElemKind::BFloat16Ty;
+  case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+    return ElemKind::Float64Ty;
   case ONNX_NAMESPACE::TensorProto_DataType_INT32:
     return ElemKind::Int32ITy;
   case ONNX_NAMESPACE::TensorProto_DataType_INT64:

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -242,6 +242,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     llvm_unreachable("Not implemented");
   case ElemKind::BFloat16Ty:
     llvm_unreachable("Not implemented");
+  case ElemKind::Float64Ty:
+    return builder.getDoubleTy();
   case ElemKind::Int8QTy:
     return builder.getInt8Ty();
   case ElemKind::UInt8QTy:
@@ -636,6 +638,9 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
     llvm_unreachable("Not implemented");
   case ElemKind::BFloat16Ty:
     llvm_unreachable("Not implemented");
+  case ElemKind::Float64Ty:
+    return llvm::ConstantFP::get(llvm::Type::getDoubleTy(getLLVMContext()),
+                                 val);
   case ElemKind::Int64ITy:
     return builder.getInt64(static_cast<int64_t>(val));
   case ElemKind::Int8QTy:

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3739,6 +3739,8 @@ static size_t numSignificantBits(ElemKind kind) {
     return std::numeric_limits<int16_t>::digits;
   case ElemKind::FloatTy:
     return std::numeric_limits<float>::digits;
+  case ElemKind::Float64Ty:
+    return std::numeric_limits<double>::digits;
   case ElemKind::Int32QTy:
   case ElemKind::Int32ITy:
     return std::numeric_limits<int32_t>::digits;

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -354,6 +354,7 @@ template <typename Ty> void testAssignment(const Type &ty) {
 TEST(Tensor, assignment) {
   dim_t dim[] = {320, 200, 64};
   testAssignment<float>(Type{ElemKind::FloatTy, dim});
+  testAssignment<double>(Type{ElemKind::Float64Ty, dim});
   testAssignment<int8_t>(Type{ElemKind::Int8QTy, dim, 1., 0});
   testAssignment<uint8_t>(Type{ElemKind::UInt8QTy, dim, 1., 0});
   testAssignment<int16_t>(Type{ElemKind::Int16QTy, dim, 1., 0});
@@ -1338,6 +1339,7 @@ TEST(Tensor, typeSerialization) {
   };
   testType(Type(ElemKind::FloatTy, {1}));
   testType(Type(ElemKind::Float16Ty, {1, 2}));
+  testType(Type(ElemKind::Float64Ty, {1}));
   testType(Type(ElemKind::Int8QTy, {1, 2, 3}, 1.1, 1));
   testType(Type(ElemKind::UInt8QTy, {1, 2, 3}, 1.2, 2));
   testType(Type(ElemKind::Int16QTy, {1, 2, 3}, 1.3, 3));

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -192,6 +192,7 @@ c10::ScalarType elemKindToScalarType(glow::ElemKind ty) {
     return at::kBool;
   case ElemKind::Int8QTy:
     return at::kQInt8;
+  case ElemKind::Float64Ty:
   case ElemKind::UInt8FusedQTy:
   case ElemKind::UInt8FusedFP16QTy:
   case ElemKind::UInt4FusedFP16QTy:


### PR DESCRIPTION
Summary:
Add support for Float64 type.

Co-authored-by: Max Kazantsev <maximkaz@cadence.com>

Documentation:
N/A

Test Plan:
Extended TensorTest unit test.