### PR TITLE
Fix test failures caused by upgrade to Googletest 1.10.x

### DIFF
--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -599,42 +599,21 @@ TEST(RuntimeBundle, ContiguousPlaceholder) {
 }
 
 TEST_P(BackendExecTest, simpleInference) {
-  Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
   PlaceholderBindings bindings;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  F->setName("interpret");
   auto *input =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3}, "input", false);
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
+  auto *conv = F->createConv(bindings, "conv", input, 10, 5, 1, 0, 1);
+  auto *res = F->createSave("save", conv);
 
-  auto *ex = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
+  ::glow::convertPlaceholdersToConstants(F, bindings,
+                                         {input, res->getPlaceholder()});
+  bindings.allocate(input)->getHandle().randomize(-1.0, 1.0, mod.getPRNG());
+  bindings.allocate(res->getPlaceholder());
 
-  auto *CV0 = F->createConv(bindings, "conv1", input, 16, 5, 1, 2, 1);
-  auto *RL0 = F->createRELU("relu1", CV0);
-  auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
-
-  auto *CV1 =
-      F->createConv(bindings, "conv2", MP0->getResult(), 20, 5, 1, 2, 1);
-  auto *RL1 = F->createRELU("relu2", CV1);
-  auto *MP1 = F->createMaxPool("pool2", RL1, 2, 2, 0);
-
-  auto *CV2 =
-      F->createConv(bindings, "conv3", MP1->getResult(), 20, 5, 1, 2, 1);
-  auto *RL2 = F->createRELU("relu3", CV2);
-  auto *MP2 = F->createMaxPool("pool3", RL2, 2, 2, 0);
-
-  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP2->getResult(), 10);
-  auto *RL3 = F->createRELU("relu4", FCL1);
-  auto *SM = F->createSoftMax("sm", RL3, ex);
-  auto *S = F->createSave("ret", SM);
-
-  bindings.allocate(input);
-  bindings.allocate(ex);
-  bindings.allocate(S->getPlaceholder());
   EE_.compile(CompilationMode::Infer);
-
-  updateInputPlaceholders(bindings, {input}, {&inputs});
   EE_.run(bindings);
 }
 
@@ -1118,12 +1097,9 @@ TEST_P(BackendExecTest, compileThenAddNetwork) {
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
 
-  auto *ex = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
-
   auto *FC = F->createFullyConnected(bindings1, "FC", input, 30);
   auto *RL = F->createRELU("RL2", FC);
-  auto *SM = F->createSoftMax("sm", RL, ex);
-  auto *S = F->createSave("ret", SM);
+  auto *S = F->createSave("ret", RL);
 
   Placeholder *FC_weights =
       llvm::dyn_cast<Placeholder>(FC->getWeights().getNode());
@@ -1133,7 +1109,6 @@ TEST_P(BackendExecTest, compileThenAddNetwork) {
   auto *input2 =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
 
-  auto *ex2 = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
   auto *FC2 = F2->createFullyConnected(bindings2, "FC", input2, 30);
 
   // FC2 now has random weights we replace with FC1's weights so the output is
@@ -1143,9 +1118,10 @@ TEST_P(BackendExecTest, compileThenAddNetwork) {
   bindings2.get(FC2_weights)->assign(bindings1.get(FC_weights));
 
   auto *RL2 = F2->createRELU("RL2", FC2);
-  auto *SM2 = F2->createSoftMax("sm", RL2, ex2);
-  auto *S2 = F2->createSave("ret", SM2);
+  auto *S2 = F2->createSave("ret", RL2);
 
+  convertPlaceholdersToConstants(F, bindings1, {input, S->getPlaceholder()});
+  convertPlaceholdersToConstants(F2, bindings2, {input2, S2->getPlaceholder()});
   EE_.compile(CompilationMode::Infer);
 
   // Allocate all placeholders.
@@ -1231,5 +1207,5 @@ TEST(BackendExecTest, dumpType) {
   EXPECT_EQ(mesA, os.str());
 }
 
-INSTANTIATE_BACKEND_TEST(BackendTest);
+INSTANTIATE_BACKEND_TEST(BackendExecTest);
 INSTANTIATE_BACKEND_TEST(BackendExecStatelessTest);

--- a/tests/unittests/NumericsTest.cpp
+++ b/tests/unittests/NumericsTest.cpp
@@ -18,7 +18,8 @@
 
 using namespace glow;
 
-INSTANTIATE_BACKEND_TEST(NumericsTest);
+// Placeholder until tests are added
+/* INSTANTIATE_BACKEND_TEST(NumericsTest); */
 
 // NOTE: Specify generic numerics tests below that should be supported by all
 // backends (and blacklisted explicitly if not supported).

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -35,7 +35,7 @@ namespace glow {
 
 using llvm::cast;
 
-class Quantization : public ::testing::TestWithParam<std::string> {};
+class Quantization : public ::testing::Test {};
 
 class Operator
     : public ::testing::TestWithParam<::std::tuple<std::string, std::string>> {
@@ -51,8 +51,6 @@ protected:
     backendSpecificEE.setBackendName(backend2);
   }
 };
-
-class InterpAndCPU : public Operator {};
 
 bool operator==(const std::vector<float> &lhs, const std::vector<float> &rhs) {
   return std::equal(lhs.begin(), lhs.end(), rhs.begin());
@@ -2996,19 +2994,10 @@ TEST(Quantization, QuantizationZeroUsersResult) {
   EXPECT_TRUE(qTK->getValues().getType()->isQuantizedType());
 }
 
-GLOW_INSTANTIATE_TEST_SUITE_P(Interpreter, Quantization,
-                              ::testing::Values("Interpreter"));
-
 #ifdef GLOW_WITH_CPU
-GLOW_INSTANTIATE_TEST_SUITE_P(CPU, Quantization, ::testing::Values("CPU"));
 
 GLOW_INSTANTIATE_TEST_SUITE_P(
     InterpAndCPUProfAndQuant, Operator,
-    ::testing::Combine(::testing::Values("Interpreter", "CPU"),
-                       ::testing::Values("Interpreter", "CPU")));
-
-GLOW_INSTANTIATE_TEST_SUITE_P(
-    InterpAndCPUProfAndQuant, InterpAndCPU,
     ::testing::Combine(::testing::Values("Interpreter", "CPU"),
                        ::testing::Values("Interpreter", "CPU")));
 
@@ -3018,10 +3007,6 @@ GLOW_INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(::testing::Values("Interpreter"),
                        ::testing::Values("Interpreter")));
 
-GLOW_INSTANTIATE_TEST_SUITE_P(
-    Interpreter, InterpAndCPU,
-    ::testing::Combine(::testing::Values("Interpreter"),
-                       ::testing::Values("Interpreter")));
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL


### PR DESCRIPTION
Summary:
Glow some problems in its unit tests that are surfaced by updating googletest to the latest version.

# 1. Uninstantiated BackendExecTest

Googletest tells me that `BackendExecTest` is never instantiated, which is correct. I see that `BackendTest` and `BackendStatlessExecTest` are instantiated, but not `BackendExecTest`.

When I replace
```
INSTANTIATE_BACKEND_TEST(BackendTest);
```
with
```
INSTANTIATE_BACKEND_TEST(BackendExecTest);
```
Then I get test failures from `BackendTest_NNPI`. Then, with help from jfix71, the tests are fixed.

It seems like the `TEST_P(BackendExecTest, ...)` tests weren't running before, and now they are.

# 2. Uninstantiated InterpAndCPU

It seems like InterpAndCPU is just a child of Operator, so it's redundant, so I deleted it.

# 3. NumericsTest instantiated with no `TEST_P`

This isn't being used, so I commented it out.

# 4. Quantization instantiated with no `TEST_P`

This shouldn't be a parameterized test, since it uses `TEST`, not `TEST_P`. I removed the instantiation and made it a normal `Test`.

# 5. Uninstantiated BackendTest

This error went away after I switched out `INSTANTIATE_BACKEND_TEST(BackendTest);`

Differential Revision: D27351091

