### PR TITLE
Unitest for operator LogSoftMax in AI Compiler

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -672,13 +672,6 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
             {SoftMaxNode::SelectedIdx}) &&
         (NI.getInElemTy(SoftMaxNode::SelectedIdx) == ElemKind::Int64ITy);
     break;
-  case Kinded::Kind::LogSoftMaxNodeKind:
-    isNodePrecisionSupported =
-        NI.allInputsAndOutputsHaveSameElemKind(
-            {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
-            {LogSoftMaxNode::SelectedIdx}) &&
-        (NI.getInElemTy(LogSoftMaxNode::SelectedIdx) == ElemKind::Int64ITy);
-    break;
   case Kinded::Kind::LengthsRangeFillNodeKind:
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});


### PR DESCRIPTION
Summary: Add test coverage for LogSoftMax. Used same inputs as for SoftMax tests. Had to enable test for only CPU and Interpreter since LogSoftMax is not available from NNPI.

Differential Revision: D27548040

