### PR TITLE
return an error that scuba can catch for sanitize

### DIFF
--- a/lib/Backends/NNPI/InferenceContext.cpp
+++ b/lib/Backends/NNPI/InferenceContext.cpp
@@ -380,8 +380,8 @@ void InferenceContext::execute(RunIdentifierTy runId,
                          tracePreProcessContextName_, attributes);
 
   // Sanitize inputs before running inference
-  LOG_AND_FAIL_EXECUTE_CALLBACK_IF_NOT(
-      ERROR, sanitize(bindings), "Failed santization.", runId, ctx, resultCB);
+  FATAL_CALLBACK_IF_NOT(sanitize(bindings), "Failed santization.", runId, ctx,
+                        resultCB);
 
   // Pre-inference
   std::vector<void *> rawInputs, rawOutputs;


### PR DESCRIPTION
Summary: return RUNTIME_DEVICE_NONRECOVERABLE so that the rest of the infrastructure can catch it

Differential Revision: D27557187

