### PR TITLE
Shape inference whilelist and better error messaging

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -130,7 +130,7 @@ private:
   Error generateGraphOutputShape();
 
   /// Extract shape info of node inputs from \p shapeMap_.
-  void getNodeInputShape(const torch::jit::Node *node, MetaStack &inputMetas);
+  bool getNodeInputShape(const torch::jit::Node *node, MetaStack &inputMetas);
 
   /// Infer shapes of node outputs
   Error shapeOnNode(const torch::jit::Node *node);


### PR DESCRIPTION
Summary:
Making sure compile-time shape inference doesn't error out when the supported nodes are sufficient to infer fusion node input shapes.
Also add initial white list to avoid arbitrarily specify block list from cmdline.

Reviewed By: movefast1990

Differential Revision: D27093480

