### PR TITLE
Added check for bad entries in quantization profile

### DIFF
--- a/lib/Quantization/Serialization.cpp
+++ b/lib/Quantization/Serialization.cpp
@@ -175,6 +175,12 @@ bool deserializeProfilingInfosFromYaml(
   // Read profiling info.
   yin >> profilingInfos;
   CHECK(!yin.error()) << profileErrMsg;
+
+  for (auto PI : profilingInfos) {
+    CHECK_LE(PI.min(), PI.max())
+        << "Bad profile for node " << PI.nodeOutputName_.c_str();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Summary: Adding some extra checks in the profile-serialization code to detect bad profile entries and report along with node-name. (Just for better error reporting) 

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
