### PR TITLE
Add Per Tensor Quantization Support to FXIRImporter

### DIFF
--- a/lib/Backends/NNPI/FXIRImporter.cpp
+++ b/lib/Backends/NNPI/FXIRImporter.cpp
@@ -135,9 +135,10 @@ public:
 
 class BatchNormalizationNodeImporter : public INNPIFXNodeImporter {
 public:
-  NNPIErrorCode importNode(const folly::dynamic &node,
-                           const std::function<string(string)> &getQualName,
-                           FXNNPIImporter &importer) override {
+  NNPIErrorCode
+  importNode(const folly::dynamic &node,
+             const std::function<string(string)> & /* getQualName */,
+             FXNNPIImporter &importer) override {
     const auto &name = node["name"].getString();
     const auto &kwargs = node["kwargs"];
     const auto &inputName = importer.getInputNodeName(kwargs["input"]);
@@ -301,28 +302,52 @@ public:
   }
 };
 
-static std::unordered_map<std::string,
-                          std::unique_ptr<INNPIFXNodeImporter>>::value_type
-    FXImporterInit[] = {
-        {"acc_ops.add",
-         std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_ADD>>()},
-        {"acc_ops.sub",
-         std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_SUB>>()},
-        {"acc_ops.mul",
-         std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_MUL>>()},
-        {"acc_ops.div",
-         std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_DIV>>()},
-        {"acc_ops.reshape", std::make_unique<ReshapeNodeImporter>()},
-        {"acc_ops.linear", std::make_unique<LinearNodeImporter>()},
-        {"acc_ops.conv2d", std::make_unique<ConvolutionNodeImporter<2>>()},
-        {"acc_ops.batch_norm",
-         std::make_unique<BatchNormalizationNodeImporter>()},
-        {"acc_ops.relu", std::make_unique<ReluNodeImporter>()},
-        {"acc_ops.adaptive_avg_pool2d",
-         std::make_unique<AdaptivePoolNodeImporter<NNPI_POOL_AVG>>()},
-        {"acc_ops.embedding_bag", std::make_unique<EmbeddingBagNodeImporter>()},
-        {"acc_ops.max_pool2d",
-         std::make_unique<PoolNodeImporter<NNPI_POOL_MAX, 2>>()},
+class ConvertNodeImporter : public INNPIFXNodeImporter {
+public:
+  NNPIErrorCode
+  importNode(const folly::dynamic &node,
+             const std::function<string(string)> & /* getQualName */,
+             FXNNPIImporter &importer) override {
+    const auto &args = node["args"];
+    const auto &kwargs = node["kwargs"];
+    const auto &name = node["name"].getString();
+
+    const auto &inputName = kwargs.count("input")
+                                ? importer.getInputNodeName(kwargs["input"])
+                                : importer.getInputNodeName(args[0]);
+
+    importer.setUsedTensors({inputName}, {name});
+
+    return nnpiNetworkAddConvertOp(importer.getNetwork(), finalize(name),
+                                   finalize(inputName), finalize(name));
+  }
+};
+
+static std::unordered_map<
+    std::string,
+    std::unique_ptr<INNPIFXNodeImporter>>::value_type FXImporterInit[] = {
+    {"acc_ops.add",
+     std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_ADD>>()},
+    {"acc_ops.quantized_add",
+     std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_ADD>>()},
+    {"acc_ops.sub",
+     std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_SUB>>()},
+    {"acc_ops.mul",
+     std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_MUL>>()},
+    {"acc_ops.div",
+     std::make_unique<BinaryEltwiseNodeImporter<NNPI_ELTWISE_DIV>>()},
+    {"acc_ops.reshape", std::make_unique<ReshapeNodeImporter>()},
+    {"acc_ops.linear", std::make_unique<LinearNodeImporter>()},
+    {"acc_ops.conv2d", std::make_unique<ConvolutionNodeImporter<2>>()},
+    {"acc_ops.batch_norm", std::make_unique<BatchNormalizationNodeImporter>()},
+    {"acc_ops.relu", std::make_unique<ReluNodeImporter>()},
+    {"acc_ops.adaptive_avg_pool2d",
+     std::make_unique<AdaptivePoolNodeImporter<NNPI_POOL_AVG>>()},
+    {"acc_ops.embedding_bag", std::make_unique<EmbeddingBagNodeImporter>()},
+    {"acc_ops.max_pool2d",
+     std::make_unique<PoolNodeImporter<NNPI_POOL_MAX, 2>>()},
+    {"acc_ops.quantize_per_tensor", std::make_unique<ConvertNodeImporter>()},
+    {"acc_ops.dequantize", std::make_unique<ConvertNodeImporter>()},
 };
 
 static const std::unordered_map<std::string,
@@ -400,13 +425,13 @@ const std::string &FXNNPIImporter::getInputNodeName(const folly::dynamic &node,
   return it != getattrs_.end() ? it->second : name;
 }
 
-void FXNNPIImporter::updateDescQuantFromFX(const DTYPE &dtype,
-                                           NNPITensorDesc &desc,
-                                           const std::string &scaleTensor,
-                                           const std::string &offsetTensor,
-                                           bool forceSymlowp) {
-  desc.quantParams.params.gemlowp.scale = 1.f;
-  desc.quantParams.params.gemlowp.offset = 0;
+void FXNNPIImporter::updateDescQuantFromFX(
+    const DTYPE &dtype, NNPITensorDesc &desc, const float &scale,
+    const int32_t &offset, const std::string &scaleTensor,
+    const std::string &offsetTensor, bool forceSymlowp) {
+  desc.quantParams.params.gemlowp.scale = scale;
+  desc.quantParams.params.gemlowp.offset = offset;
+
   switch (dtype) {
   case DTYPE::FLOAT32:
     LOG_ERROR_IF_NOT((scaleTensor.empty() && offsetTensor.empty()))
@@ -425,6 +450,25 @@ void FXNNPIImporter::updateDescQuantFromFX(const DTYPE &dtype,
         << "Scales and offsets provided for Int64";
     desc.quantParams.precision = NNPI_PRECISION_INT32;
     desc.quantParams.type = NNPI_QUANTIZATION_NONE;
+    break;
+  case DTYPE::QINT8:
+    LOG_ERROR_IF_NOT((scaleTensor.empty() && offsetTensor.empty()))
+        << "Don't support PCQ yet";
+    desc.quantParams.precision = NNPI_PRECISION_INT8;
+    desc.quantParams.type = NNPI_QUANTIZATION_GEMMLOWP;
+    if (forceSymlowp) {
+      LOG_ERROR_IF_NOT(offset == 0) << "Offset is not 0 when forcing symlowp";
+      desc.quantParams.type = NNPI_QUANTIZATION_SYMLOWP;
+      desc.quantParams.params.symlowp.scale = scale;
+    }
+    break;
+  case DTYPE::QUINT8:
+    LOG_ERROR_IF_NOT((scaleTensor.empty() && offsetTensor.empty()))
+        << "Don't support PCQ yet";
+    desc.quantParams.precision = NNPI_PRECISION_UINT8;
+    desc.quantParams.type = NNPI_QUANTIZATION_GEMMLOWP;
+    desc.quantParams.params.gemlowp.scale = scale;
+    desc.quantParams.params.gemlowp.offset = offset;
     break;
   default:
     LOG(FATAL) << "Unhandled tensor data type";
@@ -461,7 +505,8 @@ void FXNNPIImporter::updateDescDimsFromFX(
 NNPIErrorCode
 FXNNPIImporter::addTensor(const std::string &name, const string &dtypeStr,
                           const llvm::ArrayRef<glow::dim_t> dims, bool input,
-                          bool output, const std::string &scaleTensor,
+                          bool output, const float &scale,
+                          const int32_t &offset, const std::string &scaleTensor,
                           const std::string &offsetTensor, bool forceSymlowp) {
   const auto &dtypeElt = stringToDTYPE.find(dtypeStr);
   LOG_ERROR_IF_NOT(dtypeElt != stringToDTYPE.end())
@@ -480,7 +525,7 @@ FXNNPIImporter::addTensor(const std::string &name, const string &dtypeStr,
   desc.attributes.value = 0;
   desc.attributes.input = input;
   desc.attributes.output = output;
-  updateDescQuantFromFX(dtype, desc, scaleTensor, offsetTensor,
+  updateDescQuantFromFX(dtype, desc, scale, offset, scaleTensor, offsetTensor,
                         forceSymlowp || compileOptions_.useSymlowp);
   updateDescDimsFromFX(dims, desc);
 
@@ -516,6 +561,29 @@ FXNNPIImporter::addTensor(const std::string &name, const string &dtypeStr,
   return nnpiNetworkAddTensor(network_, finalize(name), &desc, pRawData);
 }
 
+NNPIErrorCode FXNNPIImporter::addTensor(const folly::dynamic &node, bool input,
+                                        bool output, bool forceSymlowp) {
+  float scale = 1.0f;
+  int32_t zero_point = 0;
+
+  if (node["is_quantized"].getBool()) {
+    CHECK(node.count("q_scale")) << "Missing key q_scale for node " +
+                                        node["name"].getString() +
+                                        ", this probably due to node having "
+                                        "per channel quantized output.";
+
+    scale = node["q_scale"].getDouble();
+    zero_point = node["q_zero_point"].getInt();
+  }
+
+  return addTensor(node["name"].getString(), node["dtype"].getString(),
+                   toIntegerArray<glow::dim_t>(node["shape"].getString()),
+                   /* input */ input, /* output */ output,
+                   /* scale */ scale,
+                   /* offset */ zero_point, /* scaleTensor */ {},
+                   /* offsetTensor */ {}, /* forceSymlowp */ forceSymlowp);
+}
+
 NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
                                            const std::string &submodule) {
   const auto &mod = submodule.empty() ? FXIR : FXIR["modules"][submodule];
@@ -533,11 +601,26 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
     const auto &name = key.getString();
     DBG("Importing Constant: " << name);
     CHECK(constants_.count(name)) << "Constant not found for weight " << name;
-    LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
-        addTensor(
-            name, weights[name]["dtype"].getString(),
-            toIntegerArray<glow::dim_t>(weights[name]["shape"].getString())),
-        "Failed to add constant");
+
+    if (weights[name]["is_quantized"].getBool()) {
+      // TODO: Add support of PCQ.
+      CHECK(weights[name].count("q_scale"))
+          << "We only support PTQ now, weight " + name + " is PCQ.";
+      LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
+          addTensor(
+              name, weights[name]["dtype"].getString(),
+              toIntegerArray<glow::dim_t>(weights[name]["shape"].getString()),
+              /* input */ false, /* output */ false,
+              /* scale */ weights[name]["q_scale"].getDouble(),
+              /* offset */ weights[name]["q_zero_point"].getInt()),
+          "Failed to add intermediate");
+    } else {
+      LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
+          addTensor(
+              name, weights[name]["dtype"].getString(),
+              toIntegerArray<glow::dim_t>(weights[name]["shape"].getString())),
+          "Failed to add intermediate");
+    }
   }
 
   // Add ops node.
@@ -550,11 +633,10 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
       continue;
     }
     DBG("Importing Node: " << nodeName);
+
     // Add node outputs.
-    LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
-        addTensor(nodeName, node["dtype"].getString(),
-                  toIntegerArray<glow::dim_t>(node["shape"].getString())),
-        "Failed to add intermediate");
+    LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(addTensor(node),
+                                            "Failed to add intermediate");
 
     // Track what Constant each get_attr points to.
     if (opCode == "get_attr") {
@@ -588,7 +670,7 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
         "Failed to import node");
   }
 
-  // Add placeholder.
+  // Add placeholder and output node
   for (const auto &node : mod["nodes"]) {
     const auto &opCode = node["op_code"].getString();
 
@@ -599,11 +681,10 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
       CHECK(!writeTensors_.count(name)) << "Placeholder can't be written";
 
       if (readTensors_.count(name)) {
-        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
-            addTensor(name, node["dtype"].getString(),
-                      toIntegerArray<glow::dim_t>(node["shape"].getString()),
-                      /* input */ true, /* output */ false),
-            "Failed to add placeholder");
+        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(addTensor(node,
+                                                          /* input */ true,
+                                                          /* output */ false),
+                                                "Failed to add placeholder");
       } else {
         DBG("[--IO--] Unused Placeholder: " << name);
       }
@@ -617,11 +698,10 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
         CHECK(writeTensors_.count(outputName))
             << "output must be in writeTensors_";
 
-        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
-            addTensor(outputName, arg["dtype"].getString(),
-                      toIntegerArray<glow::dim_t>(arg["shape"].getString()),
-                      /* input */ false, /* output */ true),
-            "Failed to add output");
+        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(addTensor(arg,
+                                                          /* input */ false,
+                                                          /* output */ true),
+                                                "Failed to add output");
       }
     }
   }

--- a/lib/Backends/NNPI/FXIRImporter.h
+++ b/lib/Backends/NNPI/FXIRImporter.h
@@ -16,6 +16,7 @@
 #ifndef FX_NNPI_IMPORTER_H
 #define FX_NNPI_IMPORTER_H
 
+#include "folly/dynamic.h"
 #include "glow/fb/fx/nnpi_importer/Utils.h"
 #include "glow/lib/Backends/NNPI/NNPIOptions.h"
 #include "nnpi_network_builder.h"
@@ -51,9 +52,14 @@ public:
   NNPIErrorCode addTensor(const std::string &name, const string &dtypeStr,
                           const llvm::ArrayRef<glow::dim_t> dims,
                           bool input = false, bool output = false,
+                          const float &scale = 1.f, const int32_t &offset = 0,
                           const std::string &scaleTensor = {},
                           const std::string &offsetTensor = {},
                           bool forceSymlowp = false);
+
+  /// Add Tensor to the network by node.
+  NNPIErrorCode addTensor(const folly::dynamic &node, bool input = false,
+                          bool output = false, bool forceSymlowp = false);
 
   /// Set given tensor names as inputs/outputs.
   void
@@ -75,6 +81,8 @@ public:
 
   /// Update the NNPITensorDesc \p desc quantization params by \p dtype.
   void updateDescQuantFromFX(const utils::DTYPE &dtype, NNPITensorDesc &desc,
+                             const float &scale = 1.f,
+                             const int32_t &offset = 0,
                              const std::string &scaleTensor = {},
                              const std::string &offsetTensor = {},
                              bool forceSymlowp = false);


### PR DESCRIPTION
Summary:
Allows FXIRImport to import quantized model.

This diff doesn't include the supports for per-channel weights, linear and conv. Will address them in the next diff.

Reviewed By: jackm321

Differential Revision: D27313543

