### PR TITLE
GlowIR serialization

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -346,6 +346,9 @@ struct CompilationContext {
   /// Whether to serialize the DAG that has been optimized and partitioned.
   bool serializeCompiledDAG{false};
 
+  /// Whether to save constant data into the serialized DAG.
+  bool saveConstantInSerializeCompiledDAG{false};
+
   /// Whether to call the DAG optimizer after the DAG is created in HostManager.
   bool callDAGOptimizer{false};
 
@@ -405,9 +408,12 @@ struct CompilationContext {
 
     RETURN_ERR_IF_NOT(
         !(serializeCompiledDAG && skipProvisioning &&
-          !optimizationOpts.delayAndRecordConstantModification),
-        "When serializing the compiled DAG while skipping provisioning, must "
-        "also enable delayAndRecordConstantModification.");
+          !optimizationOpts.delayAndRecordConstantModification &&
+          !saveConstantInSerializeCompiledDAG),
+        "When serializing the compiled DAG while skipping provisioning, C2 "
+        "must also enable delayAndRecordConstantModification. PyTorch does not "
+        "enable delayAndRecordConstantModification in this case, but "
+        "saveConstantInSerializeCompiledDAG should be enabled");
 
     RETURN_ERR_IF_NOT(
         !precisionConfig.loadUniquedDummyQParams ||

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -510,8 +510,8 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
       ONNXModelWriter onnxWR(
           loc, nodeList, 7, 9, &writeErr,
           /* textMode */ true, /* zipMode */ false,
-          /* includeConstantData */ false, extraMetadataProps, record,
-          cctx.backendOpts.backendSpecificNodeInfo,
+          /* includeConstantData */ cctx.saveConstantInSerializeCompiledDAG,
+          extraMetadataProps, record, cctx.backendOpts.backendSpecificNodeInfo,
           cctx.skipProvisioning ? &cctx.loadedPHNames : nullptr,
           cctx.skipProvisioning ? &cctx.staticPlaceholderTypesForAOT : nullptr);
       RETURN_IF_ERR(writeErr);

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -95,6 +95,9 @@ DEFINE_bool(dumpFailedInputsToOnnxFiles, false, "See PyTorchLoaderSettings");
 DEFINE_bool(lazyCompile, false, "see PyTorchLoaderSettings");
 DEFINE_bool(enableDeviceTracing, false, "See PyTorchLoaderSettings");
 
+DEFINE_bool(saveGlowIRIntoONNX, false, "See PyTorchLoaderSettings");
+DEFINE_bool(loadGlowIRFromONNX, false, "See PyTorchLoaderSettings");
+
 namespace glow {
 namespace {
 
@@ -329,6 +332,9 @@ void PyTorchLoaderSettings::initSettings() {
   apl_parallelization_alg =
       glow::flags::DAGOptimizerParallelizationTaggingAlgorithm;
   apl_num_parallel_chunks = glow::flags::DAGOptimizerNumParallelChunks;
+  saveGlowIRIntoONNX = FLAGS_saveGlowIRIntoONNX;
+  loadGlowIRFromONNX = FLAGS_loadGlowIRFromONNX;
+  skipProvisioning = glow::flags::SkipProvisioning || saveGlowIRIntoONNX;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -141,6 +141,9 @@ public:
   /// Must be true in twshared hosts.
   bool writeOnnxToTmp = false;
 
+  /// The JSON file name that stores Glow deserialization specs
+  std::string serializationSpecFileName = "serializationSpec.json";
+
   /// Optional prefix for naming of onnx files (otherwise an internal id)
   std::string onnxFileNamePrefix = "";
 
@@ -218,6 +221,19 @@ public:
   /// Additional parameters to DAG optimizer
   std::string apl_parallelization_alg = "ParallelizeCVHeuristicData";
   int32_t apl_num_parallel_chunks = 2;
+
+  // Serialize GlowIR into ONNX txt file during warmCache, this file can be
+  // use for future model loading, which a part of AOT compilation
+  bool saveGlowIRIntoONNX = false;
+
+  // Load GlowIR by deserializing ONNX txt file during warmCache
+  bool loadGlowIRFromONNX = false;
+
+  // Skip provisioning (currently only happens in Glow serialization, in which
+  // we do model partition, DAG optimization, and then serialize the optimized
+  // and partitioned model into ONNX model file. During this process, we do not
+  // need to do provisioning)
+  bool skipProvisioning = false;
 };
 
 /// Represents different possible output types from to_glow modules.


### PR DESCRIPTION
Summary:
This diff enables GlowIR (Glow::Function) serialization in CachingGraphRunner::warmCache. The serialized GlowIR will be used for PyPer A* AOT model loading. Refer to https://fb.quip.com/ABT1A021txMc for details about PyPer A* AOT compilation flow.
Glow serialization has two outputs: ONNX file storing the serialized GlowIR and JSON file storing the necessary info to reproduce model loading. The necessary info includes (1) PyTorchLoaderSettings; (2) Glow function name (3) Input placeholder names & types; (4) Static placeholder names & types; (4) Output placeholder names;

Reviewed By: movefast1990

Differential Revision: D26131545

