### PR TITLE
Add Support for Embedding Pooling Quantization Operator

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -270,6 +270,9 @@ private:
   // Shape inference for fb::lengths_to_offsets
   static Expected<TensorOutput>
   lengthsToOffsets(const MetaStack &variableMetas);
+  // Shape inference for fb::Fused8BitRowwiseQuantizedToFloat
+  static Expected<TensorOutput>
+  fused8BitRowwiseQuantizedToFloat(const MetaStack &variableMetas);
   // Shape inference for prim::dtype
   static Expected<TensorOutput> primDtype(const MetaStack &variableMetas);
   // Shape inference for fb::fast_gather


### PR DESCRIPTION
Summary:
## Context:
The operator is used for embedding pooling quantization, add shape inference support for the operator.

Reviewed By: movefast1990

Differential Revision: D27535842

