### PR TITLE
Support op fb::quantized_linear_unpacked_weight in shape inference and PyTorch model loader

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -349,6 +349,8 @@ bool isQParamWeightNode(const torch::jit::Node *node) {
       torch::jit::Symbol::fromQualString("quantized::conv3d"),
       torch::jit::Symbol::fromQualString("quantized::conv3d_relu"),
       torch::jit::Symbol::fromQualString("glow::unpacked_quantized_linear"),
+      torch::jit::Symbol::fromQualString(
+          "fb::quantized_linear_unpacked_weight"),
       torch::jit::Symbol::fromQualString("glow::unpacked_quantized_conv2d"),
       torch::jit::Symbol::fromQualString(
           "glow::unpacked_quantized_conv2d_relu"),
@@ -704,6 +706,7 @@ struct QuantizedMulInputs {
 };
 
 /// Indexes of glow::unpacked_quantized_linear inputs.
+/// Also used for fb::quantized_linear_unpacked_weight
 struct QuantizedUnpackedLinearInputs {
   enum {
     input = 0,
@@ -1284,7 +1287,8 @@ PyTorchModelLoader::buildSymbolsMapping() {
        &PyTorchModelLoader::loadQuantizedConvReluUnpacked},
       {{"glow::unpacked_quantized_conv2d_relu"},
        &PyTorchModelLoader::loadQuantizedConvReluUnpacked},
-      {{"glow::unpacked_quantized_linear"},
+      {{"glow::unpacked_quantized_linear",
+        "fb::quantized_linear_unpacked_weight"},
        &PyTorchModelLoader::loadQuantizedLinearUnpacked},
       {{"glow::fused_split"}, &PyTorchModelLoader::loadFusedSplit},
       {{"aten::linear"}, &PyTorchModelLoader::loadLinear},

--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -170,6 +170,8 @@ ShapeInferenceEngine::buildShapeSymbolMapping() {
        ShapeInference(&embeddingBag4BitRowwiseOffsets, &SI::addShapeDefault)},
       {"glow::unpacked_quantized_linear",
        ShapeInference(&glowUnpackedQuantizedLinear, &SI::addShapeDefault)},
+      {"fb::quantized_linear_unpacked_weight",
+       ShapeInference(&glowUnpackedQuantizedLinear, &SI::addShapeDefault)},
       {"fb::lengths_to_offsets",
        ShapeInference(&lengthsToOffsets, &SI::addShapeDefault)},
       {"fb::simple_embedding_bag_sum",
@@ -1699,6 +1701,8 @@ ShapeInferenceEngine::chunk(const MetaStack &variableMetas) {
 /*
  * glow::unpacked_quantized_linear(Tensor a_quant, Tensor w_quant, Tensor "
       "b, float r_scale, int r_zero_point) -> Tensor";
+ * fb::quantized_linear_unpacked_weight(Tensor a_quant, Tensor w_quant, "
+      "Tensor b, float r_scale, int r_zero_point) -> Tensor";
 
 Input: (N, *, in_features) where * means any number of
 additional dimensions


### PR DESCRIPTION
Summary:
Context
fb::quantized_linear_unpacked_weight is a new op when INT8 FC quantization is enabled. We need to support it in shape inference and PyTorch model loader. Its API and functionality is exactly the same as op glow::unpacked_quantized_linear so this diff is mostly renaming.

Differential Revision: D27548736

