### PR TITLE
saturateKDevices and enable available_devices in compile spec

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -269,6 +269,10 @@ struct CompilationContext {
   /// If true the HostManager will try to use all available devices on the host.
   bool saturateHost{false};
 
+  // If greater than zero, this is the number of available devices that are
+  // used when saturateHost is enabled.
+  unsigned saturateKDevices{0};
+
   /// Number of max active requests per instance of this network.
   unsigned maxActiveRequestsPerInstance{48};
 

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -92,12 +92,16 @@ class Partitioner final : public PartitionerBase {
   NodeToFunctionMap selectPartitions(Function *F, uint64_t availableMemory,
                                      llvm::StringRef backendName);
 
-  /// Duplicates \p partitions in the module order to saturate the Host. \p
-  /// logicalDeviceCount is the number of logical devices used by the current
-  /// partitions. For example: If a network is partitioned into two parts (\p
-  /// logicalDeviceCount) and there are six devices this would duplicate the
-  /// network three times.
-  void saturateHost(unsigned logicalDeviceCount, const DAGListTy &partitions);
+  /// Duplicates \p partitions in the module order to saturate the Host.
+  /// \p logicalDeviceCount is the number of logical devices used by the
+  /// current partitions. \p availableLogicalDevices is the total number of
+  /// devices to saturate (if zero than the number of found devices is used).
+  /// For example: If a network is partitioned into two parts (\p
+  /// logicalDeviceCount) and there are six devices this would duplicate
+  /// the network three times. If \p availableLogicalDevices is set to four,
+  /// the network would be duplicated only twice.
+  void saturateHost(unsigned logicalDeviceCount, const DAGListTy &partitions,
+                    size_t availableLogicalDevices);
 
   /// Partition a function \p F based on backends \p backends. \returns the
   /// final partition result(or an err) and a map between partitions and backend

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -303,6 +303,9 @@ public:
   /// \returns the number of devices the HostManager owns.
   size_t numDevices() const { return devices_.size(); }
 
+  /// \returns current available devices.
+  std::vector<DeviceIDTy> availableDevices() const { return availableDevices_; }
+
   ~HostManager();
 
   /// String const for logging current queue size in glow

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -73,6 +73,10 @@ void initializeCompiliationContextFromSettings(
     cctx.saturateHost = settings.saturateHost;
   }
 
+  if (settings.saturateKDevices > 0) {
+    cctx.saturateKDevices = settings.saturateKDevices;
+  }
+
   if (settings.use_dag_optimizer) {
     cctx.callDAGOptimizer = true;
     cctx.optimizationOpts.DAGOptimizerParallelizationTaggingAlgorithm =

--- a/torch_glow/src/GlowCompileSpec.cpp
+++ b/torch_glow/src/GlowCompileSpec.cpp
@@ -85,6 +85,8 @@ void registerPyTorchGlowCustomClasses() {
   ADD_BASIC_FIELD_DEFS(CompilationGroupSettings_registry,
                        CompilationGroupSettings, num_devices_to_use);
   ADD_BASIC_FIELD_DEFS(CompilationGroupSettings_registry,
+                       CompilationGroupSettings, available_devices);
+  ADD_BASIC_FIELD_DEFS(CompilationGroupSettings_registry,
                        CompilationGroupSettings, replication_count);
   ADD_MAP_FIELD_DEFS(CompilationGroupSettings_registry,
                      CompilationGroupSettings, backend_specific_opts);

--- a/torch_glow/src/GlowCompileSpec.h
+++ b/torch_glow/src/GlowCompileSpec.h
@@ -382,6 +382,7 @@ struct CompilationGroupSettings : public JsonSerializableCustomClass {
   ADD_BOOL_FIELD(convert_to_fp16, false)
   // -1 indicates use all available devices
   ADD_INT_FIELD(num_devices_to_use, -1)
+  ADD_VECTOR_FIELD(available_devices, int64_t)
   ADD_INT_FIELD(replication_count, 1)
   ADD_MAP_FIELD(backend_specific_opts, std::string, std::string)
 
@@ -389,6 +390,7 @@ struct CompilationGroupSettings : public JsonSerializableCustomClass {
     folly::dynamic obj = folly::dynamic::object();
     obj["convert_to_fp16"] = convert_to_fp16;
     obj["num_devices_to_use"] = num_devices_to_use;
+    obj["available_devices"] = dynArrayFromVec(available_devices);
     obj["replication_count"] = replication_count;
     obj["backend_specific_opts"] = dynArrayFromMap(backend_specific_opts);
     return obj;
@@ -409,6 +411,13 @@ struct CompilationGroupSettings : public JsonSerializableCustomClass {
     if (dyn.count("num_devices_to_use")) {
       ASSIGN_INT_FROM_DYN_FIELD_OR_RETURN_ERR(dyn, num_devices_to_use,
                                               "num_devices_to_use");
+    }
+
+    if (dyn.count("available_devices")) {
+      CHECK_DYN_CONTAINS_ARRAY(dyn, "available_devices");
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          available_devices,
+          (dynArrayToVec<int64_t>(dyn.at("available_devices"))));
     }
 
     if (dyn.count("replication_count")) {

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -149,6 +149,10 @@ public:
   /// adding networks to HostManager.
   bool saturateHost = false;
 
+  /// If saturateHost is enabled and saturateKDevices is greater than zero,
+  /// this is the number of devices that will be saturated.
+  unsigned saturateKDevices{0};
+
   /// If true then randomize the Constants in the Function loaded by
   /// PyTorchModelLoader.
   bool randomizeConstants = false;

--- a/torch_glow/tests/functionality/to_glow_num_devices_to_use_test.py
+++ b/torch_glow/tests/functionality/to_glow_num_devices_to_use_test.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch_glow
+from tests import utils
+
+
+class SimpleModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleModule, self).__init__()
+
+    def forward(self, x):
+        y = x + x
+        y = y + 2
+        return y
+
+
+class TestToGlowNumDevicesToUse(utils.TorchGlowTestCase):
+    def devices_to_use_test_helper(self, input, num_replications):
+        model = SimpleModule()
+
+        spec = torch_glow.CompilationSpec()
+        spec.get_settings().set_glow_backend("Interpreter")
+        # Init with total number of devices.
+        torch_glow.setGlowBackendNumDevices(6)
+
+        compilation_group = torch_glow.CompilationGroup()
+        spec.compilation_groups_append(compilation_group)
+
+        input_spec = torch_glow.InputSpec()
+        input_spec.set_same_as(input)
+        compilation_group.input_sets_append([input_spec])
+        compilation_group_settings = compilation_group.get_settings()
+        compilation_group_settings.set_num_devices_to_use(3)
+        compilation_group_settings.set_replication_count(num_replications)
+
+        traced_mod = torch.jit.trace(model, input)
+        lowered_model = torch_glow.to_glow(traced_mod, {"forward": spec})
+
+        g = lowered_model(input)
+        t = model(input)
+
+        self.assertEqual(type(g), type(t))
+        self.assertEqual(len(g), len(t))
+        for (gi, ti) in zip(g, t):
+            self.assertTrue(torch.allclose(gi, ti))
+
+    def devices_to_use_test(self):
+        self.devices_to_use_test_helper(input=torch.randn(4), num_replications=2)


### PR DESCRIPTION
Summary:
Enabling compiling a net on a specific number of devices - instead of saturating the entire host, if saturateKDevices is specified, only K devices will be used (Decision which physical device to use is made by Provisioner).
Adding available_devices to CompilationGroupSpec and using it to set_available_devices on compile flow.

Differential Revision: D26782089

