### PR TITLE
[Importer] Fix Flatten to accept negative axis values.

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -955,6 +955,10 @@ protected:
       ASSIGN_VALUE_OR_RETURN_ERR(axis,
                                  loadAxis<int>(dict["axis"], in.dims().size()));
     }
+    if (axis < 0) {
+      // Negative value means counting dimensions from the back.
+      axis = in.dims().size() + axis;
+    }
     auto *node = G_->createFlatten(opName, in, axis);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return Error::success();

--- a/tests/models/onnxModels/flatten.onnxtxt
+++ b/tests/models/onnxModels/flatten.onnxtxt
@@ -1,0 +1,57 @@
+ir_version: 7
+producer_name: "onnx-flatten"
+graph {
+  node {
+    input: "data"
+    output: "output"
+    op_type: "Flatten"
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  name: "flatten_graph"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 24
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 12
+}
+


### PR DESCRIPTION
Summary:
Negative axis value means counting dimensions from the back. Fix Flatten to accept negative axis values.

Documentation:

[Optional Fixes #issue]

Test Plan:

Added OnnxImporter test to test loading Flatten node with negative axis.
