### PR TITLE
[Importer] Fix bug in importing optional params of NMS operator.

### DIFF
--- a/tests/models/onnxModels/NonMaxSuppressionOptionalParams.onnxtxt
+++ b/tests/models/onnxModels/NonMaxSuppressionOptionalParams.onnxtxt
@@ -1,0 +1,106 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       data_type: 7
+       name: "max_output_size"
+       raw_data: "\003\000\000\000\000\000\000\000"
+   }
+   input {
+    name: "boxes"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "boxes"
+       input: "scores"
+       input: "max_output_size"
+       output: "indices"
+       output: "numSelected"
+       name: "NonMaxSuppressionV4"
+       op_type: "NonMaxSuppressionV4"
+       attribute {
+        name: "pad_to_max_output_size"
+        i: 1
+        type: INT
+      }
+       domain: "ai.onnx.converters.tensorflow"
+   }
+
+output {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+output {
+    name: "numSelected"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -391,6 +391,8 @@ TEST(exporter, onnxModels) {
         name.find("upsampleOpset9.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppressionSSD_ONNX.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppression.onnxtxt") != std::string::npos ||
+        name.find("NonMaxSuppressionOptionalParams.onnxtxt") !=
+            std::string::npos ||
         name.find("NonMaxSuppressionSSD.onnxtxt") != std::string::npos ||
         name.find("ROIAlign_onnx.onnxtxt") != std::string::npos ||
         name.find("MatMul4D.onnxtxt") != std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3857,6 +3857,41 @@ TEST_F(OnnxImporterTest, importNMSInitializer) {
   EXPECT_EQ(NMS->getCenterPointBox(), 0);
 }
 
+/// Test loading NMS using optional parameters from an ONNX model.
+TEST_F(OnnxImporterTest, importNMSInitOptionalParams) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(
+      GLOW_DATA_PATH
+      "tests/models/onnxModels/NonMaxSuppressionOptionalParams.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor boxes(ElemKind::FloatTy, {8, 4});
+    boxes.zero();
+
+    Tensor scores(ElemKind::FloatTy, {8});
+    scores.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"boxes", "scores"},
+                           {&boxes.getType(), &scores.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getOutputByName("indices"));
+  }
+
+  auto *save = getSaveNodeFromDest(output);
+  NonMaxSuppressionNode *NMS =
+      llvm::dyn_cast<NonMaxSuppressionNode>(save->getInput().getNode());
+  ASSERT_TRUE(NMS);
+  EXPECT_EQ(NMS->dims(0)[0], 3);
+  EXPECT_EQ(NMS->getCenterPointBox(), 0);
+  EXPECT_EQ(NMS->getMaxOutputBoxesPerClass(), 3);
+  EXPECT_EQ(NMS->getIouThreshold(), 0);
+  EXPECT_EQ(NMS->getScoreThreshold(), 0);
+}
+
 /// Test loading NMS using Constant Tensors op from an ONNX model.
 TEST_F(OnnxImporterTest, importNMSConstTensor) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Summary:
maxOutputBoxesPerClass, iouThreshold and scoreThreshold are optional parameters for NonMaxSupression Operator. Fix a bug in importing NMS operator when the optional parameters are not provided.
Documentation:

[Optional Fixes #issue]

Test Plan:

Added ONNX importer test to check if NonMaxSuppression operator can be imported successfully when optional parameters are not provided.
