### PR TITLE
[Importer] Fix bug with default min values in Clip operator.

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -3708,7 +3708,8 @@ Error ONNXModelLoader::loadClip(const ONNX_NAMESPACE::NodeProto &op,
   ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
   float cmin = std::numeric_limits<float>::lowest();
-  if (opsetVersion_ > 10 && op.input_size() > 1) {
+  if (opsetVersion_ > 10 && op.input_size() > 1 && !op.input(1).empty()) {
+    // min value is optional and might not be supplied.
     Constant *minC = getConstantByNameOrNull(op.input(1));
     RETURN_ERR_IF_NOT(minC, "Expect constant for min value in Clip operator.");
     cmin = minC->getPayload().getHandle().raw(0);
@@ -3719,7 +3720,8 @@ Error ONNXModelLoader::loadClip(const ONNX_NAMESPACE::NodeProto &op,
   // Windows headers define `max` macro, so have to wrap the function name in
   // parenthesis to avoid compilation error.
   float cmax = (std::numeric_limits<float>::max)();
-  if (opsetVersion_ > 10 && op.input_size() > 2) {
+  if (opsetVersion_ > 10 && op.input_size() > 2 && !op.input(2).empty()) {
+    // max value is optional and might not be supplied.
     Constant *maxC = getConstantByNameOrNull(op.input(2));
     RETURN_ERR_IF_NOT(maxC, "Expect constant for max value in Clip operator.");
     cmax = maxC->getPayload().getHandle().raw(0);

--- a/tests/models/onnxModels/clip_default.onnxtxt
+++ b/tests/models/onnxModels/clip_default.onnxtxt
@@ -1,0 +1,60 @@
+ir_version: 6
+producer_name: "onnx-ex"
+graph {
+  node {
+    input: "X"
+    input: ""
+    input: "max"
+    output: "output0"
+    op_type: "Clip"
+  }
+  name: "graph"
+  initializer {
+    data_type: 1
+    float_data: 2.0
+    name: "max"
+  }
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+          }
+          dim {
+          }
+          dim {
+          }
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}


### PR DESCRIPTION
Summary:
min and max values are optional and might not be supplied for Clip operator. Import Clip operator with default min and max values when they are not provided.
Documentation:

[Optional Fixes #issue]

Test Plan:

Added ONNXImporterTest
