### PR TITLE
[GLOW] Add CPU support for Cast from Float to Int32

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -317,7 +317,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_BFloat16Ty_To_Int64ITy_AndBack/0",
     "ConvertFrom_FloatTy_To_BFloat16Ty/0",
     "ConvertFrom_FloatTy_To_Float16Ty/0",
-    "ConvertFrom_FloatTy_To_Int32ITy/0",
     "ConvertFrom_FloatTy_To_Int64ITy/0",
     "ConvertFrom_Float16Ty_To_BFloat16Ty/0",
     "ConvertFrom_Float16Ty_To_FloatTy/0",

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -540,6 +540,9 @@ bool LLVMBackend::isOpSupported(const NodeInfo &NI) const {
              ElemKind::Int64ITy)) ||
            ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::FloatTy) &&
             (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::BoolTy)) ||
+           ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::FloatTy) &&
+            (NI.getOutElemTy(ConvertToNode::ResultIdx) ==
+             ElemKind::Int32ITy)) ||
            ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::BoolTy) &&
             (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::Int32ITy));
 

--- a/lib/LLVMIRCodeGen/libjit/libjit.cpp
+++ b/lib/LLVMIRCodeGen/libjit/libjit.cpp
@@ -3194,6 +3194,12 @@ void libjit_convertTo_i32_b(int32_t *dstPtr, const bool *srcPtr,
                                                     numDims);
 }
 
+void libjit_convertTo_i32_f(int32_t *dstPtr, const float *srcPtr,
+                            const dim_t *dims, dim_t numDims) {
+  libjit_copy_kernel_with_conversion<int32_t, float>(dstPtr, srcPtr, dims,
+                                                     numDims);
+}
+
 /// Update min/max values \p compInfo and histogram \p existingHistogram with
 /// data collected from tensor \p inputTensor.
 /// Note: code ported from Profile.cpp: generateTensorHistogram


### PR DESCRIPTION
Summary:
Add CPU support for casting from float to int32.
Documentation:

[Optional Fixes #issue]

Test Plan:

Added CPUOperatorTest
