### PR TITLE
T88462104: Add support for fusion nodes in method to find unsupported symbols

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -428,23 +428,36 @@ bool ShapeInferenceEngine::isSupportedNodeSymbol(const torch::jit::Node *node) {
 }
 
 std::unordered_set<std::string>
-ShapeInferenceEngine::findUnsupportedGraphSymbols(
-    const torch::jit::Graph &graph) {
-
+ShapeInferenceEngine::findUnsupportedGraphSymbols(bool skipLastFusionNode) {
   std::unordered_set<std::string> unsupportedSymbols;
-  findUnsupportedGraphSymbols(graph, unsupportedSymbols);
+  findUnsupportedGraphSymbols(graph_, unsupportedSymbols, skipLastFusionNode);
   return unsupportedSymbols;
 }
 
 void ShapeInferenceEngine::findUnsupportedGraphSymbols(
     const torch::jit::Graph &graph,
-    std::unordered_set<std::string> &unsupportedSymbols) {
+    std::unordered_set<std::string> &unsupportedSymbols,
+    bool skipLastFusionNode) {
+
+  int totalFusionNodes = 0;
+  for (auto *node : graph.nodes()) {
+    if (node->kind().toQualString() == fusionNodeSymbol_) {
+      totalFusionNodes += 1;
+    }
+  }
+  int fusionNodeIndex = 0;
   for (auto *node : graph.nodes()) {
     if (node->hasAttribute(torch::jit::attr::Subgraph)) {
       auto subgraph = node->g(torch::jit::attr::Subgraph);
-      findUnsupportedGraphSymbols(*subgraph, unsupportedSymbols);
+      findUnsupportedGraphSymbols(*subgraph, unsupportedSymbols, false);
+      fusionNodeIndex += 1;
     } else {
-      if (!isSupportedNodeSymbol(node)) {
+      if (fusionNodeIndex == totalFusionNodes && skipLastFusionNode) {
+        LOG(INFO)
+            << "Skip shape inference for node after fusion groups with kind: "
+            << node->kind().toQualString();
+        continue;
+      } else if (!isSupportedNodeSymbol(node)) {
         unsupportedSymbols.insert(node->kind().toQualString());
       }
     }

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -82,8 +82,8 @@ public:
 
   /// Collects the list of unsupported symbols present in a \p graph
   /// \returns a set of symbols
-  static std::unordered_set<std::string>
-  findUnsupportedGraphSymbols(const torch::jit::Graph &graph);
+  std::unordered_set<std::string>
+  findUnsupportedGraphSymbols(bool skipLastFusionNode = false);
 
 private:
   /// Graph that needs to be run shape inference.
@@ -122,8 +122,10 @@ private:
                     const at::ArrayRef<torch::jit::IValue> &);
 
   /// Collects the list of unsupported symbols present in a \p graph
-  static void findUnsupportedGraphSymbols(const torch::jit::Graph &graph,
-                                          std::unordered_set<std::string> &);
+  /// populates the provided set of symbol names
+  void findUnsupportedGraphSymbols(const torch::jit::Graph &,
+                                   std::unordered_set<std::string> &,
+                                   bool skipLastFusionNode = false);
 
   /// \return true if the node's symbol is supported for shape inference
   static bool isSupportedNodeSymbol(const torch::jit::Node *);

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -464,14 +464,24 @@ PYBIND11_MODULE(_torch_glow, m) {
 
   m.def(
       "glow_shape_inference_find_unsupported_symbols",
-      [](std::shared_ptr<torch::jit::Graph> graph,
-         std::vector<std::string> &blocklist) {
+      [](std::shared_ptr<torch::jit::Graph> graph, const py::tuple &args,
+         std::vector<std::string> &blocklist, bool skip_last_fusion_node) {
+        std::vector<c10::IValue> inputs;
+        for (const auto &arg : args) {
+          inputs.emplace_back(
+              torch::jit::toIValue(arg, c10::TensorType::get()));
+        }
+        const at::ArrayRef<torch::jit::IValue> inputRefs(inputs);
+
+        // The base symbol of all.
+        std::string baseSymbol = glow::getGlowSymbol(nullptr).toQualString();
+
         // There could be multiple glow fusion nodes created.
         glowCustomFuse(graph, getGlobalPyTorchLoaderSettingsMutable());
 
+        ShapeInferenceEngine shapeInf(*graph, inputRefs, baseSymbol, true);
         auto unsupported =
-            ShapeInferenceEngine::findUnsupportedGraphSymbols(*graph);
-
+            shapeInf.findUnsupportedGraphSymbols(skip_last_fusion_node);
         std::unordered_set<std::string> blockset;
         std::copy(blocklist.begin(), blocklist.end(),
                   std::inserter(blockset, blockset.end()));
@@ -485,5 +495,6 @@ PYBIND11_MODULE(_torch_glow, m) {
 
         return result;
       },
-      py::arg("graph"), py::arg("blocklist") = py::list());
+      py::arg("graph"), py::arg("args"), py::arg("blocklist") = py::list(),
+      py::arg("skip_last_fusion_node") = false);
 }

--- a/torch_glow/tests/functionality/shape_inference_test.py
+++ b/torch_glow/tests/functionality/shape_inference_test.py
@@ -61,7 +61,11 @@ class TestGlowShapeInference(utils.TorchGlowTestCase):
         jit_f = torch.jit.trace(f, (a))
         jit_f_graph = jit_f.graph_for(a)
 
-        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(jit_f_graph)
+        args = (a,)
+
+        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(
+            jit_f_graph, args
+        )
         expected = []
         self.assertEqual(set(expected), set(actual))
 
@@ -77,13 +81,67 @@ class TestGlowShapeInference(utils.TorchGlowTestCase):
         jit_f = torch.jit.trace(f, (a))
         jit_f_graph = jit_f.graph_for(a)
 
-        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(jit_f_graph)
+        args = (a,)
+
+        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(
+            jit_f_graph, args
+        )
         expected = ["aten::chain_matmul", "aten::linalg_matrix_power"]
         self.assertEqual(set(expected), set(actual))
 
         blocklist = ["aten::chain_matmul"]
         actual = torch_glow.glow_shape_inference_find_unsupported_symbols(
-            jit_f_graph, blocklist
+            jit_f_graph, args, blocklist
         )
         expected = ["aten::linalg_matrix_power"]
+        self.assertEqual(set(expected), set(actual))
+
+    def test_shape_inference_unsupported_symbols_skip_fusion_group(self):
+        """Test Glow shape inference unsupported symbols including skipping of
+        symbols after a secondary fusion group."""
+
+        def f(a, b):
+            x1 = a * b
+            x2 = x1 * b
+            x3 = x2 * a
+            x4 = x3 / b
+            x5 = x4 / a
+            x6 = x5 / b
+            x7 = x6 * a
+            x8 = x7 * b
+            return x8 * torch.chain_matmul(x8, x8)
+
+        torch_glow.enableFusionPass()
+        torch_glow.setFusionStartIndex(3)
+        torch_glow.setFusionEndIndex(6)
+
+        a = torch.randn(5, 5)
+        b = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a, b))
+
+        jit_f_graph = jit_f.graph_for(a, b)
+
+        torch_glow.clearFusionIndices()
+
+        args = (a, b)
+
+        # Don't skip nodes after the last fusion node.
+        # in this case, one of the nodes (chain_matmul) following the last fusion node
+        # is not supported, and should be reported.
+        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(
+            jit_f_graph, args, skip_last_fusion_node=False
+        )
+        expected = [
+            "aten::chain_matmul",
+        ]
+        self.assertEqual(set(expected), set(actual))
+
+        # DO skip nodes after the last fusion node.
+        # in this case, one of the nodes (chain_matmul) following the last fusion node
+        # is not supported, but is suppressed due to the skip_last_fusion_node flag.
+        actual = torch_glow.glow_shape_inference_find_unsupported_symbols(
+            jit_f_graph, args, skip_last_fusion_node=True
+        )
+        expected = []
         self.assertEqual(set(expected), set(actual))


### PR DESCRIPTION
Summary:
Requested updates to related diff D27633906 (https://github.com/pytorch/glow/commit/4c919d60b3c33296c4109aec8020a1733c98f5b5) from hwwang:
It would be very useful if we could add function to skip checking the operators after the last fusion group. Similar function could be found
here https://fburl.com/diffusion/ebigtdo0.
Since the operators after last fusion group should not affect lower result and can be skipped. We could add a flag for this function.

Reviewed By: JasonHanwen

Differential Revision: D27729280

