### PR TITLE
Hide Glow graph printout behind a flag

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -7844,9 +7844,10 @@ Error PyTorchModelLoader::loadJITGraph(
     const at::ArrayRef<torch::jit::IValue> inputs,
     const InputMetaStack &metaStack) {
   Error error = Error::empty();
+  bool loadGraph = false;
   PyTorchModelLoader loader(F, graph, inputPlaceholders, outputPlaceholders,
                             outputCorrectType, error, settings, inputs,
-                            metaStack);
+                            metaStack, loadGraph);
   return error;
 }
 
@@ -7857,9 +7858,11 @@ PyTorchModelLoader::PyTorchModelLoader(
     std::vector<c10::ScalarType> &outputCorrectType, Error &error,
     const PyTorchLoaderSettings &settings,
     const at::ArrayRef<torch::jit::IValue> inputs,
-    const InputMetaStack &metaStack)
+    const InputMetaStack &metaStack, bool loadGraph)
     : F_(F), settings_(settings), inputs_(inputs) {
-  std::cerr << "loading PyTorch graph\n" << graph << std::endl;
+  if (loadGraph) {
+    std::cerr << "loading PyTorch graph\n" << graph << std::endl;
+  }
   auto loadFn = [&]() -> Error {
     auto graphInputValues = graph.inputs();
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -197,7 +197,8 @@ private:
                      std::vector<c10::ScalarType> &outputCorrectType,
                      Error &error, const PyTorchLoaderSettings &settings,
                      const at::ArrayRef<torch::jit::IValue> inputs,
-                     const InputMetaStack &metaStack = InputMetaStack());
+                     const InputMetaStack &metaStack = InputMetaStack(),
+                     bool loadGraph = false);
 
   /// Build mapping from jit symbols to function that loads nodes of that kind.
   static const MappingOfMemberFunctions buildSymbolsMapping();


### PR DESCRIPTION
Summary:
**Context**
Every time an NNPI model is exported, a huge Glow graph gets dumped into stderr, making it very difficult to read and debug error logs (see https://www.internalfb.com/chronos/job_instance/gp/135107996972992641) as an example.

**Diff**
This diff hides the graph printout behind a flag whose default value is false

Reviewed By: mleshen

Differential Revision: D27756255

