### PR TITLE
add glow_scan_devices flag to glow runtime

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -312,6 +312,9 @@ public:
     unsigned numDevices() const override {                                     \
       return BackendClass::numDevices();                                       \
     }                                                                          \
+    std::vector<unsigned> scanDeviceIDs() const override {                     \
+      return BackendClass::scanDeviceIDs();                                    \
+    }                                                                          \
   };                                                                           \
   static RegisterFactory<std::string, FactoryName, Backend>                    \
       FactoryName##_REGISTERED;
@@ -330,6 +333,9 @@ public:
     }                                                                          \
     unsigned numDevices() const override {                                     \
       return BackendClass::numDevices();                                       \
+    }                                                                          \
+    std::vector<unsigned> scanDeviceIDs() const override {                     \
+      return BackendClass::scanDeviceIDs();                                    \
     }                                                                          \
                                                                                \
   private:                                                                     \

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -111,7 +111,7 @@ public:
   /// Device discovery for a given backend kind. Returns a vector of configs for
   /// all found devices.
   static std::vector<std::unique_ptr<runtime::DeviceConfig>>
-  generateDeviceConfigs(llvm::StringRef backendName);
+  generateDeviceConfigs(llvm::StringRef backendName, bool scanDevices = false);
 
   /// Initialize the device.
   virtual Error init() { return Error::success(); }

--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -21,6 +21,9 @@
 
 #include "glow/Backend/Backend.h"
 
+#include <numeric>
+#include <vector>
+
 namespace glow {
 
 /// This is the IR-interpreter. It owns the IR, and the heap, and is able to
@@ -41,6 +44,11 @@ public:
   }
   static std::string getName() { return "Interpreter"; }
   static unsigned numDevices() { return std::thread::hardware_concurrency(); }
+  static std::vector<unsigned> scanDeviceIDs() {
+    std::vector<unsigned> deviceIDs(Interpreter::numDevices());
+    std::iota(std::begin(deviceIDs), std::end(deviceIDs), 0);
+    return deviceIDs;
+  }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;

--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -25,6 +25,7 @@ namespace flags {
 
 // Generic Constants
 extern int32_t NumDevices;
+extern bool ScanDevices;
 extern bool SaturateHost;
 extern bool EnableQuantParamChanges;
 extern size_t MaxActiveRequests;

--- a/include/glow/Support/Register.h
+++ b/include/glow/Support/Register.h
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <map>
+#include <vector>
 
 namespace glow {
 
@@ -35,6 +36,8 @@ public:
   virtual Key getRegistrationKey() const = 0;
   /// Number of devices available for the registered factory.
   virtual unsigned numDevices() const = 0;
+  /// Scan devices available and return their ids.
+  virtual std::vector<unsigned> scanDeviceIDs() const = 0;
 };
 
 /// General registry for implementation factories.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -29,6 +29,8 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 
+#include <numeric>
+
 using namespace glow;
 
 CPUBackend::CPUBackend() {
@@ -110,6 +112,12 @@ bool CPUBackend::supportsFusedActivation(Node *parent, Node *activation) const {
 
 unsigned CPUBackend::numDevices() {
   return std::thread::hardware_concurrency();
+}
+
+std::vector<unsigned> CPUBackend::scanDeviceIDs() {
+  std::vector<unsigned> deviceIDs(CPUBackend::numDevices());
+  std::iota(std::begin(deviceIDs), std::end(deviceIDs), 0);
+  return deviceIDs;
 }
 
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -25,6 +25,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/IRBuilder.h"
 
+#include <vector>
+
 namespace glow {
 
 class NodeInfo;
@@ -43,6 +45,7 @@ public:
   }
   static std::string getName() { return "CPU"; }
   static unsigned numDevices();
+  static std::vector<unsigned> scanDeviceIDs();
 
   Expected<bool> transformPostLowering(
       Function *F, CompilationContext &cctx,

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <fstream>
 #include <glog/logging.h>
+#include <numeric>
 #include <unordered_map>
 
 using namespace glow;
@@ -1524,4 +1525,10 @@ unsigned HabanaBackend::numDevices() {
     }
   }
   return count;
+}
+
+std::vector<unsigned> HabanaBackend::scanDeviceIDs() {
+  std::vector<unsigned> deviceIDs(HabanaBackend::numDevices());
+  std::iota(std::begin(deviceIDs), std::end(deviceIDs), 0);
+  return deviceIDs;
 }

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -26,6 +26,7 @@
 #include "synapse.h"
 
 #include <string>
+#include <vector>
 
 namespace glow {
 
@@ -42,6 +43,7 @@ public:
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "Habana"; }
   static unsigned numDevices();
+  static std::vector<unsigned> scanDeviceIDs();
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -30,9 +30,11 @@
 
 #include "llvm/Support/CommandLine.h"
 
+#include <cstdio>
 #include <fstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 using namespace glow;
 
@@ -56,6 +58,20 @@ unsigned NNPIBackend::numDevices() {
   LOG_NNPI_INF_IF_ERROR(nnpiAdapterDestroy(adapter),
                         "Failed to destroy NNPI Adapter");
   return adapterInfo.numDevices;
+}
+
+std::vector<unsigned> NNPIBackend::scanDeviceIDs() {
+  std::vector<unsigned> devices;
+  for (int i = 0; i < NNPIBackend::numDevices(); ++i) {
+    std::string devPath = "/dev/nnpi" + std::to_string(i);
+    if (FILE *devFile = fopen(devPath.c_str(), "r")) {
+      fclose(devFile);
+      devices.push_back(i);
+    } else {
+      continue;
+    }
+  }
+  return devices;
 }
 
 /// \returns whether \p type is 2 dimensional and unary. Usually the data input

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -20,6 +20,7 @@
 #include "NNPIOptions.h"
 #include "glow/Backend/Backend.h"
 #include <folly/dynamic.h>
+#include <vector>
 
 namespace glow {
 
@@ -37,6 +38,7 @@ public:
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "NNPI"; }
   static unsigned numDevices();
+  static std::vector<unsigned> scanDeviceIDs();
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -27,7 +27,9 @@
 
 #include "llvm/ADT/ArrayRef.h"
 
+#include <numeric>
 #include <unordered_map>
+#include <vector>
 
 #if defined(__APPLE__) || defined(__MACOSX)
 #include "OpenCL/opencl.h"
@@ -224,6 +226,11 @@ public:
   }
   static std::string getName() { return "OpenCL"; }
   static unsigned numDevices() { return 1; }
+  static std::vector<unsigned> scanDeviceIDs() {
+    std::vector<unsigned> deviceIDs(numDevices());
+    std::iota(std::begin(deviceIDs), std::end(deviceIDs), 0);
+    return deviceIDs;
+  }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -36,6 +36,7 @@ namespace flags {
 
 // Generic Constants
 int32_t NumDevices = 1;
+bool ScanDevices = false;
 bool SaturateHost = false;
 bool EnableQuantParamChanges = true;
 size_t MaxActiveRequests = 48;
@@ -170,6 +171,8 @@ DEFINE_validator(glow_num_devices, [](const char *, int32_t val) {
   glow::flags::NumDevices = val;
   return true;
 });
+DEFINE_bool(glow_scan_devices, glow::flags::ScanDevices,
+            "Scan available devices for Glow backend");
 DEFINE_int32(glow_snn_partitioning_num_cards,
              glow::flags::SparseNNPartitioningSchemeNumCards,
              "Number of devices to distribute tables across in SparseNN "

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -108,7 +108,8 @@ HostManagerBackend::createHostManager(llvm::StringRef backendName) {
       configs.push_back(std::move(config));
     }
   } else {
-    configs = runtime::DeviceManager::generateDeviceConfigs(backendName);
+    configs = runtime::DeviceManager::generateDeviceConfigs(
+        backendName, glow::flags::ScanDevices);
   }
 
   runtime::HostConfig hostConfig;

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -170,6 +170,9 @@ public:
   /// Number of Glow devices to use.
   int32_t numDevices = -1;
 
+  /// Whether to scan devices to get available ones in torch backend
+  bool scanDevices = false;
+
   // Whether to run shape inference of meta input
   bool runShapeInference = false;
 


### PR DESCRIPTION
Summary:
The direct motivation of this diff is to allow tw tasks to stack on NNPI hosts. When multiple tasks are allocated into same host, each task will be randomly assigned subset of devices. HostManager must be aware of what devices are actually available.
The changes added includes:
1. added a gflag "--torch_glow_scan_devices" to decide if should use available devices to create hostmanager in torch glow backend.
2. added a gflag "--glow_nnpi_device_check_scan_devices" to control if nnpi device checker should exclude devices that's not available
3. added a gflag "--glow_scan_devices" to control if HostManagerBackend should scan devices to get available ones
4. added ScanDeviceIDs method to Backend as well as NNPI Backend
5. added ScanDevices method to DeviceManager, which will call ScanDeviceIDs and set up devices accordingly
More context can be found at https://fb.workplace.com/groups/527892364588452/permalink/758916324819387/ and https://docs.google.com/document/d/1Rp7qUCgR0sSB0YNjmPtFxq7uCtXs9UPO27ICf7-2guI/edit?usp=sharing

Differential Revision: D27615809

