### PR TITLE
Optionally expand SLS surrounding area to include Tiles

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -72,6 +72,7 @@ extern bool UseSparseNNPartitioningScheme;
 extern bool SparseNNPartitioningAddSLSConcats;
 extern bool SparseNNPartitioningBalancePerfModel;
 extern bool SparseNNPartitioningPairLNWithSLS;
+extern bool SparseNNPartitioningPairTileWithSLS;
 
 // Dag Optimizer Constants
 extern bool UseDAGOptimizer;

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -207,6 +207,10 @@ struct OptimizationOptions {
   /// nodes immediately following SLS into SLS partitions
   bool sparseNNPartitioningPairLNWithSLS{false};
 
+  /// If true, SparseNN partiitoning scheme will move Tile
+  /// nodes immediately following SLS for user embeddings into SLS partitions
+  bool sparseNNPartitioningPairTileWithSLS{false};
+
   /// The number of cards over which to split SLS tables when using SparseNN
   /// partitioning scheme
   unsigned int sparseNNPartitioningSchemeNumCards{1};

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -83,6 +83,7 @@ bool UseSparseNNPartitioningScheme = false;
 bool SparseNNPartitioningAddSLSConcats = false;
 bool SparseNNPartitioningBalancePerfModel = false;
 bool SparseNNPartitioningPairLNWithSLS = false;
+bool SparseNNPartitioningPairTileWithSLS = false;
 
 // Dag Optimizer Constants
 bool UseDAGOptimizer = false;
@@ -317,6 +318,16 @@ DEFINE_bool(glow_sparsenn_partitioning_pair_ln_with_sls,
 DEFINE_validator(glow_sparsenn_partitioning_pair_ln_with_sls,
                  [](const char *, bool val) {
                    glow::flags::SparseNNPartitioningPairLNWithSLS = val;
+                   return true;
+                 });
+DEFINE_bool(
+    glow_sparsenn_partitioning_pair_tile_with_sls,
+    glow::flags::SparseNNPartitioningPairTileWithSLS,
+    "Put tile nodes immediately following SLS for user embeddings into SLS "
+    "Partitions");
+DEFINE_validator(glow_sparsenn_partitioning_pair_tile_with_sls,
+                 [](const char *, bool val) {
+                   glow::flags::SparseNNPartitioningPairTileWithSLS = val;
                    return true;
                  });
 DEFINE_bool(glow_clip_fp16, glow::flags::ClipToFP16,

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -90,6 +90,11 @@ static llvm::cl::opt<bool, true> GlowSparseNNPartitioningPairLNWithSLSOpt(
     llvm::cl::desc("Place layer normalization nodes immediately following SLS "
                    "into SLS partition"),
     llvm::cl::location(glow::flags::SparseNNPartitioningPairLNWithSLS));
+static llvm::cl::opt<bool, true> GlowSparseNNPartitioningPairTileWithSLSOpt(
+    "glow_sparsenn_partitioning_pair_tile_with_sls",
+    llvm::cl::desc("Place Tile nodes immediately following SLS "
+                   "for user embeddings into SLS partition"),
+    llvm::cl::location(glow::flags::SparseNNPartitioningPairTileWithSLS));
 
 std::unique_ptr<runtime::HostManager>
 HostManagerBackend::createHostManager(llvm::StringRef backendName) {
@@ -221,6 +226,8 @@ onnxStatus HostManagerBackend::addNetwork(
         glow::flags::SparseNNPartitioningBalancePerfModel;
     cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
         glow::flags::SparseNNPartitioningPairLNWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
+        glow::flags::SparseNNPartitioningPairTileWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         glow::flags::SparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -712,7 +712,7 @@ static void createSimpleModule(Module &mod) {
 }
 
 static void createSimpleSparseNNModule(Module &mod, bool shareSplatInputs,
-                                       bool addClipAndLayerNorm,
+                                       bool addClipAndLayerNorm, bool addTile,
                                        dim_t numFCLayers) {
   mod.clear();
   auto *F = mod.createFunction("test");
@@ -770,6 +770,11 @@ static void createSimpleSparseNNModule(Module &mod, bool shareSplatInputs,
       lengths = mod.createPlaceholder(ElemKind::Int32ITy, {batchSize},
                                       "lengths", false)
                     ->getOutput();
+      if (addTile && table == 0) {
+        lengths =
+            mod.createPlaceholder(ElemKind::Int32ITy, {1}, "lengths", false)
+                ->getOutput();
+      }
     }
     float avgLength = (table % 2) ? 12.0f : 10.0f;
     auto *slsOutput = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
@@ -797,9 +802,13 @@ static void createSimpleSparseNNModule(Module &mod, bool shareSplatInputs,
       /* Clip */
       auto *layerNormedClipped =
           F->createClip("LN_clipped", layerNormed, 0.0f, 70.0f);
-      slsOutputs.push_back(layerNormedClipped);
+      slsOutputs.emplace_back(layerNormedClipped);
+    } else if (addTile && table == 0) {
+      /* Tile */
+      auto *tiled = F->createTile("SLS_tiled", slsOutput, batchSize, 0);
+      slsOutputs.emplace_back(tiled);
     } else {
-      slsOutputs.push_back(slsOutput);
+      slsOutputs.emplace_back(slsOutput);
     }
   }
 
@@ -842,13 +851,15 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList,
                                         uint64_t deviceMemory, Module &mod,
                                         bool shareSplatInputs,
                                         bool addClipAndLayerNorm,
-                                        bool pairLNWithSLS) {
+                                        bool pairLNWithSLS, bool addTile,
+                                        bool pairTileWithSLS) {
   int numOfCPUBackends = 0;
   int numOfSLSNodes = 0;
   int numOfFCNodes = 0;
   std::unordered_set<uint64_t> slsPartitionSizes;
   uint64_t nonSlsPartitionSize = 0;
   for (auto &dag : dagList) {
+    auto tileAdded = false;
     for (auto &node : dag.nodes) {
       ASSERT_TRUE(node->backendName == "CPU");
       numOfCPUBackends++;
@@ -889,6 +900,9 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList,
               func, Kinded::Kind::LayerNormalizationNodeKind));
           EXPECT_TRUE(findNodeInFunction(func, Kinded::Kind::ClipNodeKind));
         }
+        if (addTile && pairTileWithSLS) {
+          tileAdded |= findNodeInFunction(func, Kinded::Kind::TileNodeKind);
+        }
       } else if (findNodeInFunction(func,
                                     Kinded::Kind::FullyConnectedNodeKind)) {
         nonSlsPartitionSize = memInfo.getTotalMemSize();
@@ -903,6 +917,9 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList,
         FAIL() << "Unexpected partition";
       }
     }
+    if (addTile && pairTileWithSLS) {
+      EXPECT_TRUE(tileAdded);
+    }
   }
 
   // 4 partitions (3 SLS + 1 FC)
@@ -914,14 +931,12 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList,
   }
 }
 
-static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatInputs,
-                                           bool concatSLSOutputs,
-                                           bool balancePerfModel,
-                                           bool addClipAndLayerNorm,
-                                           bool pairLNWithSLS,
-                                           bool forceFailure = false) {
+static void testSimpleSparseNNPartitioning(
+    Module &mod, bool shareSplatInputs, bool concatSLSOutputs,
+    bool balancePerfModel, bool addClipAndLayerNorm, bool pairLNWithSLS,
+    bool addTile, bool pairTileWithSLS, bool forceFailure = false) {
   createSimpleSparseNNModule(mod, shareSplatInputs, addClipAndLayerNorm,
-                             forceFailure ? 5 : 4);
+                             addTile, forceFailure ? 5 : 4);
   BackendWithoutSub backend1, backend2, backend3;
   std::vector<Backend *> backends;
   backends.emplace_back(&backend1);
@@ -937,9 +952,14 @@ static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatInputs,
   cctx.optimizationOpts.sparseNNPartitioningAddSLSConcats = concatSLSOutputs;
   cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel = balancePerfModel;
   cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS = pairLNWithSLS;
+  cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS = pairTileWithSLS;
   Expected<DAGListTy> dagList = partitioner.partition(cctx);
   bool failed = ERR_TO_BOOL(dagList.takeError());
   if (forceFailure) {
+    EXPECT_TRUE(failed);
+    return;
+  }
+  if (concatSLSOutputs && addTile && !pairTileWithSLS) {
     EXPECT_TRUE(failed);
     return;
   }
@@ -947,7 +967,8 @@ static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatInputs,
   EXPECT_EQ(dagList->size(), 1);
   ASSERT_TRUE(checkSaveNode(mod));
   sparseNNPartitionValidation(*dagList, deviceMemory, mod, shareSplatInputs,
-                              addClipAndLayerNorm, pairLNWithSLS);
+                              addClipAndLayerNorm, pairLNWithSLS, addTile,
+                              pairTileWithSLS);
   mod.clear();
 }
 
@@ -957,7 +978,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioning) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ false,
-                                 /*pairLNWithSLS*/ false);
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test that this flag is a NOP when LN doesn't exist
@@ -966,7 +989,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioningPairLNNOP) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ false,
-                                 /*pairLNWithSLS*/ true);
+                                 /*pairLNWithSLS*/ true,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition.
@@ -975,7 +1000,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioningClipAndLayerNormInNonSLS) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ false);
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition.
@@ -984,7 +1011,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioningClipAndLayerNormInSLS) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ true);
+                                 /*pairLNWithSLS*/ true,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 TEST_F(PartitionerTest, SimpleSparseNNPartitioning_ConcatSLSOutputs) {
@@ -992,7 +1021,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioning_ConcatSLSOutputs) {
                                  /*concatSLSOutputs*/ true,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ false);
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition when inputs are
@@ -1002,7 +1033,9 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioning_SharedSplatInputs) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ false);
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition when inputs are
@@ -1013,7 +1046,9 @@ TEST_F(PartitionerTest,
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ true);
+                                 /*pairLNWithSLS*/ true,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition.
@@ -1022,7 +1057,57 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioningBalancePerfModel) {
                                  /*concatSLSOutputs*/ false,
                                  /*balancePerfModel*/ true,
                                  /*addClipAndLayerNorm*/ true,
-                                 /*pairLNWithSLS*/ false);
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false);
+}
+
+/// Test pairTileWithSLS is NOP when Tile doesn't exist
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningPairTileNOP) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatInputs*/ false,
+                                 /*concatSLSOutputs*/ true,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ true);
+}
+
+/// Test concatting SLS nodes where one node has first dimension = 1 without
+/// concatSLSOutputs works
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningTileAndConcatSLSOutputs) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatInputs*/ false,
+                                 /*concatSLSOutputs*/ false,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ true,
+                                 /*pairTileWithSLS*/ false);
+}
+
+/// Test concatSLSOutputs on SLS nodes w/ first dimension = 1 while other nodes
+/// have the same first dimension without pairTileWithSLS flag fails
+TEST_F(PartitionerTest,
+       SimpleSparseNNPartitioningTileAndConcatSlsOutputsFails) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatInputs*/ false,
+                                 /*concatSLSOutputs*/ true,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ true,
+                                 /*pairTileWithSLS*/ false);
+}
+
+/// Test concatSLSOutputs on SLS nodes w/ first dimension = 1 while other nodes
+/// have the same first dimension with pairTileWithSLS flag works
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningPairTileAndConcatSlsOutputs) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatInputs*/ false,
+                                 /*concatSLSOutputs*/ true,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ false,
+                                 /*addTile*/ true,
+                                 /*pairTileWithSLS*/ true);
 }
 
 /// This test checks that we fail partitioning when we have a SLSPartition and
@@ -1033,6 +1118,8 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioningExpectFailure) {
                                  /*balancePerfModel*/ false,
                                  /*addClipAndLayerNorm*/ true,
                                  /*pairLNWithSLS*/ true,
+                                 /*addTile*/ false,
+                                 /*pairTileWithSLS*/ false,
                                  /*forceFailure*/ true);
 }
 

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -514,6 +514,8 @@ int run() {
         glow::flags::SparseNNPartitioningBalancePerfModel;
     cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
         glow::flags::SparseNNPartitioningPairLNWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
+        glow::flags::SparseNNPartitioningPairTileWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         glow::flags::SparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -99,6 +99,8 @@ void initializeCompiliationContextFromSettings(
         glow::flags::SparseNNPartitioningBalancePerfModel;
     cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
         glow::flags::SparseNNPartitioningPairLNWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
+        glow::flags::SparseNNPartitioningPairTileWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         glow::flags::SparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =


### PR DESCRIPTION
Summary: Add an extra flag `--glow_sparsenn_partitioning_pair_tile_with_sls` into Glow to allow attaching succeeding Tiles to SLS nodes if the first dim of the SLS node is 1.

Reviewed By: khabinov

Differential Revision: D27781184

