### PR TITLE
Add glow tracing exporter hooks to CacheGraphRunner

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -236,6 +236,9 @@ public:
   /// Moves all TraceEvents and thread names in \p other into this context.
   /// This will clear in the input TraceContext.
   void merge(std::unique_ptr<TraceContext> other) { merge(other.get()); }
+
+  /// Copies all TraceEvents and thread names in \p other into this context.
+  void copy(TraceContext *other);
 };
 
 /// These macros predicate the logging of a TraceEvent on a validity of the

--- a/include/glow/Runtime/TraceExporter.h
+++ b/include/glow/Runtime/TraceExporter.h
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_TRACEEXPORTER_H
+#define GLOW_RUNTIME_TRACEEXPORTER_H
+
+#include "glow/ExecutionContext/TraceEvents.h"
+
+#include <vector>
+
+namespace glow {
+
+/// Interface for exporting trace events.
+//   TraceExporter provides two functionalities
+//   1) shouldTrace() : a method to determine if the runtimeshould trace a
+//     particular request. This can be used to windowed tracing on-demand on
+//     a production system
+//   2) exportTrace(..) : that passes collected trace events to be exported
+//     in the target format and destination.
+//
+// The base implementation delegates to any subclass registered
+// via `registerTraceExporter`.
+
+class TraceExporter {
+public:
+  /// Dtor.
+  virtual ~TraceExporter() = default;
+
+  /// Determine if this request should be traced.
+  virtual bool shouldTrace() = 0;
+
+  /// Export events from the given TraceContext
+  virtual void exportTrace(TraceContext *context) = 0;
+};
+
+/// Registry of TraceExporters.
+class TraceExporterRegistry final {
+public:
+  /// Determine if this request should be traced.
+  bool shouldTrace();
+
+  /// Export events from the given TraceContext
+  void exportTrace(TraceContext *tcontext);
+
+  /// Register a TraceExporter.
+  void registerTraceExporter(TraceExporter *exporter);
+
+  /// Revoke a TraceExporter.
+  void revokeTraceExporter(TraceExporter *exporter);
+
+  /// Static singleton TraceExporter.
+  static std::shared_ptr<TraceExporterRegistry> getInstance();
+
+private:
+  /// Registered TraceExporters.
+  std::vector<TraceExporter *> exporters_;
+};
+
+} // namespace glow
+
+#endif // GLOW_RUNTIME_TRACEEXPORTER_H

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -210,6 +210,15 @@ void TraceContext::merge(TraceContext *other) {
   names.clear();
 }
 
+void TraceContext::copy(TraceContext *other) {
+  std::lock_guard<std::mutex> l(lock_);
+  auto &newEvents = other->getTraceEvents();
+  std::copy(newEvents.begin(), newEvents.end(),
+            std::back_inserter(getTraceEvents()));
+  auto &names = other->getThreadNames();
+  threadNames_.insert(names.begin(), names.end());
+}
+
 ScopedTraceBlock::ScopedTraceBlock(TraceContext *context, TraceLevel level,
                                    llvm::StringRef name)
     : context_(context), level_(level), name_(name) {

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -6,7 +6,10 @@ add_library(Runtime
   ErrorReporter.cpp
   DeviceHealthMonitor.cpp
   DeferredWeightLoader.cpp
+  TraceExporter.cpp
   StatsExporter.cpp)
 target_link_libraries(Runtime
+  PUBLIC
+    ExecutionContext
   PRIVATE
-  Support)
+    Support)

--- a/lib/Runtime/TraceExporter.cpp
+++ b/lib/Runtime/TraceExporter.cpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/TraceExporter.h"
+
+#include <vector>
+
+namespace glow {
+
+void TraceExporterRegistry::registerTraceExporter(TraceExporter *exporter) {
+  exporters_.push_back(exporter);
+}
+
+void TraceExporterRegistry::revokeTraceExporter(TraceExporter *exporter) {
+  exporters_.erase(std::remove(exporters_.begin(), exporters_.end(), exporter),
+                   exporters_.end());
+}
+
+bool TraceExporterRegistry::shouldTrace() {
+  bool should = false;
+  for (auto const &exporter : exporters_) {
+    should |= exporter->shouldTrace();
+  }
+  return should;
+}
+
+void TraceExporterRegistry::exportTrace(TraceContext *tcontext) {
+  if (!tcontext) {
+    return;
+  }
+  for (auto const &exporter : exporters_) {
+    exporter->exportTrace(tcontext);
+  }
+}
+
+std::shared_ptr<TraceExporterRegistry> TraceExporterRegistry::getInstance() {
+  static auto texp = std::make_shared<TraceExporterRegistry>();
+  return texp;
+}
+
+} // namespace glow

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -349,7 +349,7 @@ target_link_libraries(ImageLoaderTest
 add_glow_test(NAME ImageLoaderTest
                         COMMAND ${GLOW_BINARY_DIR}/tests/ImageLoaderTest
                            --gtest_output=xml:LoaderTest.xml --test_skip_cmd_args
-                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}) 
+                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 if(GLOW_WITH_CPU)
@@ -611,6 +611,18 @@ target_link_libraries(StatsExporterTest
 add_glow_test(StatsExporterTest
               ${GLOW_BINARY_DIR}/tests/StatsExporterTest
                   --gtest_output=xml:StatsExporterTest.xml)
+
+add_executable(TraceExporterTest
+               TraceExporterTest.cpp)
+target_link_libraries(TraceExporterTest
+                      PRIVATE
+                        Runtime
+                        gtest
+                        TestMain
+                        glog::glog)
+add_glow_test(TraceExporterTest
+              ${GLOW_BINARY_DIR}/tests/TraceExporterTest
+                  --gtest_output=xml:TraceExporterTest.xml)
 
 add_executable(TensorsTest
                TensorsTest.cpp)

--- a/tests/unittests/TraceExporterTest.cpp
+++ b/tests/unittests/TraceExporterTest.cpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/TraceExporter.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace glow;
+
+class MockTraceExporter : public TraceExporter {
+  std::shared_ptr<TraceExporterRegistry> traceExporterRegistry_;
+  bool enable_{false};
+
+public:
+  MockTraceExporter()
+      : traceExporterRegistry_(TraceExporterRegistry::getInstance()) {
+    traceExporterRegistry_->registerTraceExporter(this);
+
+    mergedTraceContext_ = std::make_unique<TraceContext>(TraceLevel::STANDARD);
+  }
+
+  ~MockTraceExporter() override {
+    traceExporterRegistry_->revokeTraceExporter(this);
+  }
+
+  bool shouldTrace() override { return enable_; }
+
+  void enableTrace() { enable_ = true; }
+
+  void disableTrace() { enable_ = false; }
+
+  void exportTrace(TraceContext *tcontext) override {
+    // create a copy of trace events
+    mergedTraceContext_->copy(tcontext);
+  }
+
+  std::unique_ptr<TraceContext> mergedTraceContext_;
+};
+
+TEST(TraceExporter, shouldTrace) {
+
+  // if no trace exporter is registered should not have any side effects
+  auto traceExporter = TraceExporterRegistry::getInstance();
+  EXPECT_FALSE(traceExporter->shouldTrace());
+
+  MockTraceExporter mockExporter;
+
+  mockExporter.disableTrace();
+  EXPECT_FALSE(traceExporter->shouldTrace());
+
+  mockExporter.enableTrace();
+  EXPECT_TRUE(traceExporter->shouldTrace());
+
+  mockExporter.disableTrace();
+  EXPECT_FALSE(traceExporter->shouldTrace());
+}
+
+TEST(TraceExporter, traceEvents) {
+
+  auto traceExporter = TraceExporterRegistry::getInstance();
+  MockTraceExporter mockExporter;
+
+  TraceContext glowTrace{TraceLevel::STANDARD};
+
+  glowTrace.logTraceEvent("foo_function", TraceLevel::RUNTIME, 'B');
+  glowTrace.logTraceEvent("bar_function", TraceLevel::RUNTIME, 'B');
+  glowTrace.logTraceEvent("bar_function", TraceLevel::RUNTIME, 'E');
+  glowTrace.logTraceEvent("foo_function", TraceLevel::RUNTIME, 'E');
+  glowTrace.logCompleteTraceEvent("alice", TraceLevel::RUNTIME,
+                                  TraceEvent::now() - 100);
+
+  if (traceExporter->shouldTrace()) {
+    traceExporter->exportTrace(&glowTrace);
+  }
+
+  mockExporter.enableTrace();
+  if (traceExporter->shouldTrace()) {
+    traceExporter->exportTrace(&glowTrace);
+  }
+
+  // add two traces
+  if (traceExporter->shouldTrace()) {
+    traceExporter->exportTrace(&glowTrace);
+  }
+
+  auto traceEvents = mockExporter.mergedTraceContext_->getTraceEvents();
+  EXPECT_EQ(traceEvents.size(), 10);
+}


### PR DESCRIPTION
Summary:
Add the hooks for trace exporter into CacheGraphRunner
* determines when to enable traces in context
* exports traces to trace exporter registry

Reviewed By: jackm321

Differential Revision: D27773456

