### PR TITLE
Print placeholder details that don't have corresponding inputs/outputs

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -836,13 +836,19 @@ Error ONNXModelWriter::finalizeAndWriteProto(llvm::StringRef name) {
   // in inputValueInfos_ and outputValueInfos_. Now we write it all out in order
   // according to indices provided in loadedPHNames_.
   if (loadedPHNames_) {
-    RETURN_ERR_IF_NOT(
-        inputValueInfos_.size() + outputValueInfos_.size() ==
-            loadedPHNames_->size(),
-        strFormat("Number of buffered inputs and outputs %lu didn't match the "
-                  "number of loadedPHNames %lu",
-                  inputValueInfos_.size() + outputValueInfos_.size(),
-                  loadedPHNames_->size()));
+    const bool ioNumMismatch =
+        (inputValueInfos_.size() + outputValueInfos_.size() !=
+         loadedPHNames_->size());
+
+    // If total number of inputs and outputs doesn't match the number of
+    // placeholders, then log an error message and let the next for-loop find
+    // the culprits.
+    if (ioNumMismatch) {
+      LOG(ERROR) << "Number of buffered inputs and outputs "
+                 << (inputValueInfos_.size() + outputValueInfos_.size())
+                 << " didn't match the number of loadedPHNames "
+                 << loadedPHNames_->size();
+    }
 
     // If we have the loaded PH names map, then we need to reorder the inputs
     // and outputs to follow the same order as provided in the loadedPHNames_.
@@ -859,6 +865,12 @@ Error ONNXModelWriter::finalizeAndWriteProto(llvm::StringRef name) {
         return MAKE_ERR("PH must either be in inputs or outputs: " +
                         PH->getName().str());
       }
+    }
+
+    // If didn't find bad placeholders, then it must be some bad inputs/outputs.
+    if (ioNumMismatch) {
+      return MAKE_ERR("Found some inputs/outputs that don't have corresponding "
+                      "placeholders");
     }
 
     // Now have IO in order matching loadedPHNames_, so finally write them out.


### PR DESCRIPTION
Summary: If detected number of inputs/outputs and number of placeholder mismatch, then don't fail immediately, but let some culprits to be logged into output.

Differential Revision: D27865905

