### PR TITLE
Skip fp16 conversion for float BatchNorm

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1195,6 +1195,47 @@ void BoundInterpreterFunction::fwdBatchNormalizationI8Impl(
     isCMinor = (channelIdx == 2);
   }
 
+  /*
+  auto str_arrayref = [](auto handle) {
+    std::ostringstream ss;
+    for (dim_t i=0; i<handle.size(); i++) {
+      ss << handle[i] << " ";
+    }
+    return ss.str();
+  };
+
+  auto str_raw = [](auto handle) {
+    std::ostringstream ss;
+    int sz = (handle.size() < 16)? handle.size() : 16;
+    for (dim_t i=0; i<sz; i++) {
+      ss << int(handle.raw(i)) << " ";
+    }
+    return ss.str();
+  };
+
+  auto str_1d = [](auto handle) {
+    std::ostringstream ss;
+    for (dim_t i=0; i<handle.size(); i++) {
+      ss << handle.at({i}) << " ";
+    }
+    return ss.str();
+  };
+
+  llvm::outs() << "----------------\n";
+  llvm::outs() << "name: " << I->getName() << "\n";
+  llvm::outs() << "idim: " << str_arrayref(inH.dims()) << "\n";
+  llvm::outs() << "inScale: " << inScale << "\n";
+  llvm::outs() << "inZero: " << inZero << "\n";
+  llvm::outs() << "outScale: " << outScale << "\n";
+  llvm::outs() << "outZero: " << outZero << "\n";
+  llvm::outs() << "weights: " << str_1d(scaleH) << "\n";
+  llvm::outs() << "bias: " << str_1d(biasH) << "\n";
+  llvm::outs() << "mean: " << str_1d(meanH) << "\n";
+  llvm::outs() << "var: " << str_1d(varH) << "\n";
+  llvm::outs() << "epsilon: " << epsilon << "\n";
+  llvm::outs() << "input: " << str_raw(inH) << "\n";
+  */
+
   // See qbatch_norm.cpp/compute_fused_params() for FBGEMM implementation
   std::vector<ParamTy> alpha(C), beta(C);
   for (dim_t c = 0; c < C; c++) {

--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -408,7 +408,7 @@ bool glow::NNPIImporter::isVariableUsingAlternativeLayout(Storage *v) {
     case Kinded::Kind::Convolution3DNodeKind:
     case Kinded::Kind::AvgPoolNodeKind:
     case Kinded::Kind::MaxPoolNodeKind:
-    case Kinded::Kind::BatchNormalizationNodeKind:
+    //case Kinded::Kind::BatchNormalizationNodeKind:
     case Kinded::Kind::ResizeNearestNodeKind:
       return true;
     case Kinded::Kind::FullyConnectedNodeKind:

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -48,8 +48,12 @@ bool TypeAToTypeBFunctionConverter::canConvert(const Node &node) const {
     if (N->getBias().getType()->getElementType() == ElemKind::FloatTy &&       \
         (N->getInput().getType()->isQuantizedType() ||                         \
          N->getInput().getType()->getElementType() == ElemKind::Float16Ty)) {  \
+         llvm::outs() << "BN: " << node.getName() << ": disable fp16 conversion\n"; \
       return false;                                                            \
     }                                                                          \
+    else {\
+         llvm::outs() << "BN: " << node.getName() << ": enable fp16 conversion\n"; \
+    }\
     break;                                                                     \
   }
 

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -86,7 +86,7 @@ DEFINE_string(backendSpecificOpts, "",
               "Comma separated list of key=value for building the "
               "BackendSpecificOptions map in BackendOptions in "
               "CompilationContext.");
-DEFINE_bool(debugContinuouslyVerifyDuringModelLoading, false,
+DEFINE_bool(debugContinuouslyVerifyDuringModelLoading, true,
             "See PyTorchLoaderSettings");
 DEFINE_int32(nominalBatchIdx, -1, "See PyTorchLoaderSettings");
 DEFINE_bool(dumpFailedInputsToOnnxFiles, false, "See PyTorchLoaderSettings");


### PR DESCRIPTION
Summary: Fix: float BatchNorm ops should mandate float params

Differential Revision: D27137452

