### PR TITLE
Add backend torch_glow tests

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -212,7 +212,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::AsinNodeKind:
   case Kinded::Kind::AtanNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Int8QTy});
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
 
   case Kinded::Kind::PowNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -259,18 +259,24 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::XorNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::BoolTy});
 
-  case Kinded::Kind::AbsNodeKind:
   case Kinded::Kind::SignNodeKind:
   case Kinded::Kind::CeilNodeKind:
   case Kinded::Kind::RoundNodeKind:
   case Kinded::Kind::SqrtNodeKind:
   case Kinded::Kind::RsqrtNodeKind:
   case Kinded::Kind::ReciprocalNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy});
+
   case Kinded::Kind::SinNodeKind:
   case Kinded::Kind::CosNodeKind:
   case Kinded::Kind::ErfNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Int8QTy});
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
+
+  case Kinded::Kind::AbsNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
 
   case Kinded::Kind::NegNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/torch_glow/tests/nodes/abs_test.py
+++ b/torch_glow/tests/nodes/abs_test.py
@@ -17,7 +17,7 @@ class TestAbs(utils.TorchGlowTestCase):
         """Basic test of the PyTorch Abs Node on Glow."""
 
         x = torch.randn(10)
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAbsModule(),
             x,
             fusible_ops={"aten::abs"},
@@ -27,7 +27,7 @@ class TestAbs(utils.TorchGlowTestCase):
         """Test multidimensional tensor for the PyTorch Abs Node on Glow."""
 
         x = torch.randn(2, 3, 5)
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAbsModule(),
             x,
             fusible_ops={"aten::abs"},

--- a/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
+++ b/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
@@ -19,7 +19,7 @@ class TestAdaptiveAvgPool2d(utils.TorchGlowTestCase):
         """Basic test of PyTorch adaptive_avg_pool2d Node."""
         inputs = torch.randn(3, 6, 14, 14)
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAdapativeAvgPool2dModule((5, 5)),
             inputs,
             fusible_ops={"aten::adaptive_avg_pool2d"},
@@ -30,7 +30,7 @@ class TestAdaptiveAvgPool2d(utils.TorchGlowTestCase):
 
         inputs = torch.randn(3, 6, 13, 14)
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAdapativeAvgPool2dModule((3, 3)),
             inputs,
             fusible_ops={"aten::adaptive_avg_pool2d"},
@@ -41,7 +41,7 @@ class TestAdaptiveAvgPool2d(utils.TorchGlowTestCase):
 
         inputs = torch.randn(3, 6, 14, 14)
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAdapativeAvgPool2dModule((5, 3)),
             inputs,
             fusible_ops={"aten::adaptive_avg_pool2d"},

--- a/torch_glow/tests/nodes/add_test.py
+++ b/torch_glow/tests/nodes/add_test.py
@@ -66,10 +66,8 @@ class TestAdd(utils.TorchGlowTestCase):
         ]
     )
     def test_add(self, _, module, a, b, skip_to_glow=False):
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             module,
-            a,
-            b,
-            skip_to_glow=skip_to_glow,
+            (a, b),
             fusible_ops={"aten::add_"} if module.inplace else {"aten::add"},
         )

--- a/torch_glow/tests/nodes/addmm_test.py
+++ b/torch_glow/tests/nodes/addmm_test.py
@@ -17,24 +17,26 @@ class SimpleAddMmModule(torch.nn.Module):
 class TestAddMM(utils.TorchGlowTestCase):
     def test_addmm_basic(self):
         """Basic test of the PyTorch addmm Node on Glow."""
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAddMmModule(),
-            torch.randn(6, 4),
-            torch.randn(6, 10),
-            torch.randn(10, 4),
+            (torch.randn(6, 4), torch.randn(6, 10), torch.randn(10, 4)),
+            fusible_ops={"aten::add", "aten::mm"},
+            fp16vfp16_atol=1e-3,
+            fp16vfp16_rtol=1e-3,
         )
 
     def test_addmm_broadcast(self):
         """Test of the PyTorch addmm with broadcasting add on Glow."""
-        utils.compare_tracing_methods(
-            SimpleAddMmModule(), torch.randn(4), torch.randn(6, 10), torch.randn(10, 4)
+        utils.run_comparison_tests(
+            SimpleAddMmModule(),
+            (torch.randn(4), torch.randn(6, 10), torch.randn(10, 4)),
+            fusible_ops={"aten::add", "aten::mm"},
         )
 
     def test_addmm_broadcast_with_alpha_and_beta(self):
         """Test of the PyTorch addmm with broadcasting add on Glow."""
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAddMmModule(2.0, 3.0),
-            torch.randn(4),
-            torch.randn(6, 10),
-            torch.randn(10, 4),
+            (torch.randn(4), torch.randn(6, 10), torch.randn(10, 4)),
+            fusible_ops={"aten::add", "aten::mm"},
         )

--- a/torch_glow/tests/nodes/and_test.py
+++ b/torch_glow/tests/nodes/and_test.py
@@ -34,10 +34,9 @@ class TestAnd(utils.TorchGlowTestCase):
         ]
     )
     def test_and(self, _, a, b, skip_to_glow=False):
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAndModule(),
-            a,
-            b,
+            (a, b),
             fusible_ops={"aten::__and__"},
             skip_to_glow=skip_to_glow,
         )

--- a/torch_glow/tests/nodes/arange_test.py
+++ b/torch_glow/tests/nodes/arange_test.py
@@ -56,4 +56,4 @@ class TestArange(utils.TorchGlowTestCase):
     )
     def test_arange(self, _, module, dummy):
         """Testing arange with minimum parameters"""
-        utils.compare_tracing_methods(module, dummy, fusible_ops={"aten::arange"})
+        utils.run_comparison_tests(module, dummy, fusible_ops={"aten::arange"})

--- a/torch_glow/tests/nodes/arg_min_max_test.py
+++ b/torch_glow/tests/nodes/arg_min_max_test.py
@@ -38,7 +38,7 @@ class TestArgMin(utils.TorchGlowTestCase):
     )
     def test_argmin_node(self, _, module, tensor):
         """Test of the PyTorch ArgMin node on Glow."""
-        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::argmin"})
+        utils.run_comparison_tests(module, tensor, fusible_ops={"aten::argmin"})
 
 
 class TestArgMax(utils.TorchGlowTestCase):
@@ -51,4 +51,4 @@ class TestArgMax(utils.TorchGlowTestCase):
     )
     def test_argmax_node(self, _, module, tensor):
         """Test of the PyTorch ArgMax node on Glow."""
-        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::argmax"})
+        utils.run_comparison_tests(module, tensor, fusible_ops={"aten::argmax"})

--- a/torch_glow/tests/nodes/avgpool2d_test.py
+++ b/torch_glow/tests/nodes/avgpool2d_test.py
@@ -14,17 +14,20 @@ class SimpleAvgPool2dModule(torch.nn.Module):
 
     def forward(self, inputs):
         return F.avg_pool2d(
-            inputs, self.kernel_size, padding=self.padding, stride=self.stride
+            inputs + inputs, self.kernel_size, padding=self.padding, stride=self.stride
         )
 
 
 class TestAvgPool2d(utils.TorchGlowTestCase):
     def test_avg_pool2d_basic(self):
         """Basic test of the PyTorch avg_pool2d Node on Glow."""
+
         inputs = torch.randn(1, 4, 5, 5)
 
-        utils.compare_tracing_methods(
-            SimpleAvgPool2dModule(3), inputs, fusible_ops={"aten::avg_pool2d"}
+        utils.run_comparison_tests(
+            SimpleAvgPool2dModule(2),
+            inputs,
+            fusible_ops={"aten::avg_pool2d"},
         )
 
     def test_avg_pool2d_with_args(self):
@@ -32,6 +35,9 @@ class TestAvgPool2d(utils.TorchGlowTestCase):
 
         inputs = torch.randn(1, 4, 10, 10)
 
-        utils.compare_tracing_methods(
-            SimpleAvgPool2dModule(3, stride=7), inputs, fusible_ops={"aten::avg_pool2d"}
+        utils.run_comparison_tests(
+            SimpleAvgPool2dModule(3, stride=7),
+            inputs,
+            fusible_ops={"aten::avg_pool2d"},
+            fp16vfp16_atol=1e-3,
         )

--- a/torch_glow/tests/nodes/avgpool3d_test.py
+++ b/torch_glow/tests/nodes/avgpool3d_test.py
@@ -21,7 +21,7 @@ class TestAvgPool3d(utils.TorchGlowTestCase):
 
         inputs = torch.randn(1, 4, 5, 5, 5)
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAvgPool3dModule(3), inputs, fusible_ops={"aten::avg_pool3d"}
         )
 
@@ -29,7 +29,7 @@ class TestAvgPool3d(utils.TorchGlowTestCase):
         """Test of the PyTorch avg_pool3d Node with arguments on Glow."""
         inputs = torch.randn(1, 4, 10, 10, 10)
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleAvgPool3dModule(3, (4, 7, 7)),
             inputs,
             fusible_ops={"aten::avg_pool3d"},

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -96,6 +96,7 @@ class TestDiv(utils.TorchGlowTestCase):
                 SimpleDivModule(),
                 torch.tensor([4]),
                 torch.tensor([10]),
+                {"NNPI"},  # skip_for_backends
             ),
             # This one will go through (a * a) / b.item() and b.item() is an integer.
             lambda: (
@@ -103,14 +104,21 @@ class TestDiv(utils.TorchGlowTestCase):
                 SimpleDivModule(),
                 torch.tensor([4]),
                 torch.tensor(10),
+                {"NNPI"},  # skip_for_backends
             ),
             lambda: (
                 "int64",
                 SimpleDivModule(),
                 torch.torch.randint(-10, 10, (2, 4), dtype=torch.int64),
                 torch.torch.randint(-10, 10, (2, 4), dtype=torch.int64),
+                {"NNPI"},  # skip_for_backends
             ),
         ]
     )
-    def test_div(self, _, module, a, b):
-        utils.compare_tracing_methods(module, a, b, fusible_ops={"aten::div"})
+    def test_div(self, _, module, a, b, skip_for_backends={}):
+        utils.run_comparison_tests(
+            module,
+            (a, b),
+            fusible_ops={"aten::div"},
+            skip_for_backends=skip_for_backends,
+        )

--- a/torch_glow/tests/nodes/floor_div_test.py
+++ b/torch_glow/tests/nodes/floor_div_test.py
@@ -84,6 +84,9 @@ class TestFloorDiv(utils.TorchGlowTestCase):
         ]
     )
     def test_floor_div(self, _, module, left, right):
-        utils.compare_tracing_methods(
-            module, left, right, fusible_ops={"aten::floor_divide"}
+        utils.run_comparison_tests(
+            module,
+            (left, right),
+            fusible_ops={"aten::floor_divide"},
+            skip_for_backends="NNPI",
         )

--- a/torch_glow/tests/nodes/mul_test.py
+++ b/torch_glow/tests/nodes/mul_test.py
@@ -21,7 +21,7 @@ class TestMul(utils.TorchGlowTestCase):
             lambda: ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(1, 2)),
             lambda: ("broadcast", torch.randn(4, 2), torch.randn(8, 3, 4, 2)),
             lambda: ("float", torch.randn(4, 2), torch.tensor(3.2)),
-            lambda: ("int", torch.randn(4, 2), torch.tensor(22), True),
+            lambda: ("int", torch.randn(4, 2), torch.tensor(22)),
             lambda: (
                 "int64",
                 torch.torch.randint(-10, 10, (2, 4), dtype=torch.int64),
@@ -32,10 +32,9 @@ class TestMul(utils.TorchGlowTestCase):
     def test_mul(self, _, left, right, skip_to_glow=False):
         """Basic test of the PyTorch mul Node on Glow."""
 
-        utils.compare_tracing_methods(
+        utils.run_comparison_tests(
             SimpleMulModule(),
-            left,
-            right,
+            (left, right),
             fusible_ops={"aten::mul"},
             skip_to_glow=skip_to_glow,
         )

--- a/torch_glow/tests/nodes/sub_test.py
+++ b/torch_glow/tests/nodes/sub_test.py
@@ -44,7 +44,6 @@ class TestSub(utils.TorchGlowTestCase):
                 SimpleSubtractModel(),
                 torch.randn(4),
                 torch.tensor(20),
-                True,
             ),
             lambda: (
                 "int64",
@@ -54,5 +53,5 @@ class TestSub(utils.TorchGlowTestCase):
             ),
         ]
     )
-    def test_subtract(self, _, module, tensor, other, skip_to_glow=False):
-        utils.compare_tracing_methods(module, tensor, other, skip_to_glow=skip_to_glow)
+    def test_subtract(self, _, module, tensor, other):
+        utils.run_comparison_tests(module, (tensor, other), fusible_ops={"aten::sub"})


### PR DESCRIPTION
Summary:
Add `run_comparison_tests()`, a modification on `compare_tracing_methods()`, that has an `other` backend that is set to the default to_glow backend. `run_comparison_tests()` will run a series of tests to compare accuracy for PyTorch tests various backends and precisions.

By default it will compare PyTorch in fp32 <-> Glow Interpreter backend in fp32, Glow Interpreter backend in fp32 <-> Glow Interpreter backend in fp16, and Glow Interpreter backend in fp16 <-> Glow other backend in fp16.

This diff makes `run_comparison_tests()` available and migrates a few example tests to this function. Will migrate more tests in followup diffs.

`run_comparison_tests()` also mandates that `fusible_ops` is provided to ensure that fusion results are being tested as expected. Several torch_glow unit tests don't currently have those so this will need to be added to those tests.

Reviewed By: 842974287

Differential Revision: D26463811

