### PR TITLE
Add command line option for legal name max_length

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -39,6 +39,7 @@ extern std::string BackendSpecificOpts;
 extern bool EnableLoadBalancedPartitioning;
 extern bool SkipProvisioning;
 extern bool DisableLayoutVerifying;
+extern int32_t LegalNameMaxLength;
 
 // FP16 Constants
 extern bool ConvertToFP16;

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -50,6 +50,7 @@ std::string BackendSpecificOpts = "";
 bool EnableLoadBalancedPartitioning = true;
 bool SkipProvisioning = false;
 bool DisableLayoutVerifying = false;
+int32_t LegalNameMaxLength = 0;
 
 // FP16 Constants
 bool ConvertToFP16 = false;
@@ -426,6 +427,12 @@ DEFINE_bool(glow_skip_provisioning, glow::flags::SkipProvisioning,
             "Skip provisioning. Used for AOT opts or debugging.");
 DEFINE_validator(glow_skip_provisioning, [](const char *, bool val) {
   glow::flags::SkipProvisioning = val;
+  return true;
+});
+DEFINE_int32(glow_legal_name_max_length, glow::flags::LegalNameMaxLength,
+             "Maximum length for legal name.");
+DEFINE_validator(glow_legal_name_max_length, [](const char *, int32_t val) {
+  glow::flags::LegalNameMaxLength = val;
   return true;
 });
 DEFINE_bool(glow_save_onnxifi_model, glow::onnxifi::flags::SaveModel,

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Support/Support.h"
+#include "glow/Flags/Flags.h"
 #include "llvm/Support/Debug.h"
 
 #include "llvm/Support/FileSystem.h"
@@ -191,6 +192,11 @@ const std::string &staticStrFormat(const char *format, ...) {
 
 std::string legalizeName(llvm::StringRef name, size_t maxLength) {
   std::string legalName;
+
+  // If command line option --glow_legal_name_max_length is set, take it.
+  if (flags::LegalNameMaxLength > 0) {
+    maxLength = flags::LegalNameMaxLength;
+  }
 
   // Legalize the name.
   for (const char c : name) {


### PR DESCRIPTION
Summary: Add new command line option "--glow_legal_name_max_length" for legal name max_length. This is needed for debugging for models with long names for the nodes.

Reviewed By: jfix71, opti-mix

Differential Revision: D27747706

