### PR TITLE
Don't check GlowError with no errorValue_ set

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -437,7 +437,7 @@ class GlowError : protected detail::CheckState<detail::enableCheckingErrors> {
              "Trying to skip state check on an Error that "
              "contains an ErrorValue is a bug because this should only happen "
              "in a constructor and then no ErrorValue should be contained.");
-    } else {
+    } else if (hasErrorValue()) {
       ensureChecked();
     }
 


### PR DESCRIPTION
Don't check GlowError with no errorValue_ set

Summary:
There is no need to check void GlowError. This will fail when a void GlowError is allocated by default, using the default constructor, then it is overwritten by other GlowError. An example of such cases is here:
> 1. std::promise<Error> devPromise;
> 2. auto err = Error::success();
> 3. devPromise.set_value(std::move(err));

When using Visual Studio 2017 (v141), line 1 will use default constructor, then line 3 will use operator=, which will fail because the initial GlowError is unchecked.

Signed-off-by: Mihai Despotovici <mihai.despotovici@nxp.com>