### PR TITLE
Allow constants to be marked as having "side-effects" and consider them to be unconditionally used by Functions in this case

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -83,6 +83,9 @@ private:
 class Constant : public Storage {
   /// The tensor payload that the constant holds.
   Tensor payload_;
+  /// Does this constant has "side effects" and thus cannot be eliminated and
+  /// should be included into the low-level IR during IRGen?
+  bool hasSideEffects_{false};
 
 public:
   /// Create a new constant and initialize its payload.
@@ -136,6 +139,13 @@ public:
   }
 
   void setPayloadType(TypeRef ty) { payload_.setType(ty); }
+
+  /// Mark this constant as having side-effects.
+  void setSideEffects();
+
+  /// \returns true if this constant has "side effects" and thus cannot be
+  /// eliminated and should be included into the low-level IR during IRGen?
+  bool hasSideEffects() const;
 
   bool isDataParallel() const { return false; }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5771,6 +5771,10 @@ PlaceholderList Function::findPlaceholders() const {
 ConstList Function::findConstants() {
   ConstList list;
   for (auto &constant : parent_->getConstants()) {
+    if (constant->hasSideEffects()) {
+      list.push_back(constant);
+      continue;
+    }
     for (auto &user : constant->getUsers()) {
       if (user.getUser()->getParent() == this) {
         list.push_back(constant);
@@ -5784,6 +5788,10 @@ ConstList Function::findConstants() {
 ConstList Function::findConstants() const {
   ConstList list;
   for (auto &constant : parent_->getConstants()) {
+    if (constant->hasSideEffects()) {
+      list.push_back(constant);
+      continue;
+    }
     for (auto &user : constant->getUsers()) {
       if (user.getUser()->getParent() == this) {
         list.push_back(constant);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -77,6 +77,10 @@ llvm::StringRef Storage::getOutputName(unsigned idx) const {
 
 bool Storage::hasSideEffects() const { return false; }
 
+void Constant::setSideEffects() { hasSideEffects_ = true; }
+
+bool Constant::hasSideEffects() const { return hasSideEffects_; }
+
 Node *Storage::clone() const { llvm_unreachable("Storage can't be cloned."); }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Summary: We want to add a constant that it is not immediately referred to, for example, add a lookup table that gets referred during the IR generation, so adding this property to the tensor so that it doesn't get optimized out.

Differential Revision: D27209707

