### PR TITLE
[Provisioner] Use mutex for functionReplicaCount_

### DIFF
--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -394,6 +394,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
 
       functionsToCompile.push_back(function);
       optsMap.insert({function->getName(), options});
+      std::lock_guard<std::mutex> functionsLock(functionsLock_);
       functionReplicaCount_.emplace(node->name, node->replicationCount);
       remainingDeviceCount.insert(
           {node->name, node->logicalDevices.size() - 1});


### PR DESCRIPTION
Summary: Use mutex for functionReplicaCount_ too
since add/remove can be called from multiple threads simultaneously.

Documentation:

[Optional Fixes #issue]

Test Plan:
InterpreterHostManagerTest.ConcurrentAddRemoveUnique passes without
asan errors.

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
