### PR TITLE
[circleci] Use release 7.1.3 of fmt instead of master

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -45,7 +45,7 @@ install_pocl() {
 }
 
 install_fmt() {
-    git clone https://github.com/fmtlib/fmt
+    git clone https://github.com/fmtlib/fmt --branch 7.1.3
     pushd fmt
     mkdir build
     cd build


### PR DESCRIPTION
Looks like fmt is broken on master for our build. Peg to release/tag 7.1.3, which is seemingly the most recent.