### PR TITLE
Temporarily skip torch_glow test of DQFC

### DIFF
--- a/torch_glow/tests/nodes/dynamic_qlinear_test.py
+++ b/torch_glow/tests/nodes/dynamic_qlinear_test.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import unittest
+
 import torch
 from tests import utils
 
@@ -29,6 +31,9 @@ class SimpleDynQLinearPerChannelModule(torch.nn.Module):
 
 
 class TestLinear(utils.TorchGlowTestCase):
+    @unittest.skip(
+        reason="By default it is asymmetric in PyTorch but symmetric in Glow. Will re-enable it once Glow side diff is landed."
+    )
     def test_linear_basic(self):
         """Basic test of the PyTorch aten::linear op on Glow."""
 
@@ -48,6 +53,9 @@ class TestLinear(utils.TorchGlowTestCase):
             atol=1e-1,
         )
 
+    @unittest.skip(
+        reason="By default it is asymmetric in PyTorch but symmetric in Glow. Will re-enable it once Glow side diff is landed."
+    )
     def test_linear_per_channel(self):
         """Basic test of the PyTorch channel wise aten::linear op on Glow."""
 


### PR DESCRIPTION
Summary:
This test has been flaky for a while, after investigation we found DQFC in PyTorch only asymmetric is supported, but in Glow it is by default symmetric.
We think the flakyness is related to the difference of this quantized scheme, and will re-enabled these test after they are fixed in D27689034
The DQFC is still being tested by its operatorTest.

Reviewed By: spaugh

Differential Revision: D28020871

