### PR TITLE
Extend CustomKernelInjector to DSP kernels

### DIFF
--- a/lib/Backends/NNPI/FXNNPICompiledFunction.cpp
+++ b/lib/Backends/NNPI/FXNNPICompiledFunction.cpp
@@ -71,7 +71,11 @@ Error NNPICompiledFunction::compileFX(
   LOG_NNPI_IF_ERROR_RETURN_LLVMERROR(nnpiGetDefaultCompilationConfig(&config_),
                                      "Failed NNPI API Read Config");
 
-  RETURN_IF_ERR(updateCompilationConfigFromOptions(compilationOptions_));
+  // TODO: look through the nodes in FXIR to determine if a custom DSP op is
+  // need in order to set requiresDSPKernels correctly
+  RETURN_IF_ERR(
+      updateCompilationConfigFromOptions(compilationOptions_,
+                                         /*requiresDSPKernels*/ false));
   // Collect input/output names.
   {
     size_t numInputs, numOutputs;

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -113,6 +113,12 @@ public:
   Expected<double> estimateNodeCost(const glow::Node *node) const override;
   /// @}
 
+#if FACEBOOK_INTERNAL
+  /// Returns a file containing the custom DSP kernels or the empty string if
+  /// there isn't such a file.
+  static const std::string &getDSPKernelsPrivate();
+#endif /* FACEBOOK_INTERNAL */
+
 private:
 #if FACEBOOK_INTERNAL
   /// Performs FB-private transformations on \p F given \p cctx.

--- a/lib/Backends/NNPI/NNPICompiledFunction.h
+++ b/lib/Backends/NNPI/NNPICompiledFunction.h
@@ -198,8 +198,9 @@ private:
   std::vector<std::string> iaExtensionPaths_;
   NNPICompilationInfo compilationInfo_;
 
-  Error updateCompilationConfigFromOptions(
-      NNPICompilationOptions &compilationOptions);
+  Error
+  updateCompilationConfigFromOptions(NNPICompilationOptions &compilationOptions,
+                                     bool requiresDSPKernels);
 
   /// Setup compilation hints for \p F given \p backendSpecificNodeInfo.
   /// \returns an error if some validation issue is found given expected format.


### PR DESCRIPTION
Summary:
* Extend CustomKernelInjector to DSP kernels
* Move IA and DSP injectors out of NNPIPrivateTransforms.cpp
* Set `customDspKernelsFile` from custom DSP kernel file when graph contains DSP nodes

Differential Revision: D27995013

