### PR TITLE
Disable quantizing layernorm scale and bias on NNPI backend

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -410,6 +410,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Int8BatchNorm3D/0",
     "LayerNorm_Float16/0",
     "LayerNorm_Float16_StrongNormShape/0",
+    "LayerNorm_Int8_With_Float16_Scale_Bias/0",
     "LayerNorm_Int8_With_Float_Scale_Bias/0",
     "DynamicQuantizedFullyConnectedBasic/0",
     "DynamicQuantizedFullyConnectedStrongWeights/0",

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -21,6 +21,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
     "LayerNorm_Int8/0",
+    "LayerNorm_Int8_With_Float16_Scale_Bias/0",
     "RepeatedSLSWithPartialTensors_int32/0",
     "RepeatedSLSWithPartialTensors_int64/0",
     "RepeatedSLWSWithPartialTensors/0",

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -2012,7 +2012,12 @@ Expected<bool> NNPIBackend::transformPostLowering(
   changed |= removeClipsBlockingFusion(F);
   changed |= padKernelToStride(F);
   changed |= lowerEmbeddingToGather(F);
+
+// NNPI support fp16 scale and bias after 1.5
+#if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION < 5
   changed |= quantizeLayernormScaleAndBias(F);
+#endif
+
   changed |= replaceInefficientConcat(F);
   auto it =
       cctx.backendOpts.backendSpecificOpts.find("NNPI_ZeroScaleFP16Replace");

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -125,6 +125,8 @@ struct BlacklistInitializer {
       {"CumSum3D_int32_t_Dim0/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_int32_t_Dim1/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_int32_t_Dim2/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"LayerNorm_Int8_With_Float_Scale_Bias/0",
+       TestBlacklist::AnyDeviceAnyEngine},
       {"LayerNorm_BFloat16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"LayerNorm_Float/0", TestBlacklist::AnyDeviceAnyEngine},
       // Known issue of normshape for LayerNorm on NNPI

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -506,6 +506,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "LayerNorm_Float16/0",
     "LayerNorm_Float16_StrongNormShape/0",
     "LayerNorm_Int8_With_Int8_Scale_Bias/0",
+    "LayerNorm_Int8_With_Float16_Scale_Bias/0",
     "LayerNorm_Int8_With_Float_Scale_Bias/0",
     "DequantizeFRWQ_Float/0",
     "DequantizeFRWQ_Float16/0",

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -20261,6 +20261,13 @@ TEST_P(OperatorTest, LayerNorm_Int8_With_Int8_Scale_Bias) {
   QuantizedLayerNormTest<int8_t>(bindings_, mod_, F_, EE_, ElemKind::Int8QTy);
 }
 
+TEST_P(OperatorTest, LayerNorm_Int8_With_Float16_Scale_Bias) {
+  CHECK_IF_ENABLED();
+
+  QuantizedLayerNormTest<float16_t>(bindings_, mod_, F_, EE_,
+                                    ElemKind::Float16Ty);
+}
+
 TEST_P(OperatorTest, LayerNorm_Int8_With_Float_Scale_Bias) {
   CHECK_IF_ENABLED();
 


### PR DESCRIPTION
Summary: NNPI 1.5 supports quantized layernorm with fp16 scale and bias. We don't need this pass anymore.

Differential Revision: D27601524

