### PR TITLE
Extending data parallel heuristic to ShopNet

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -6293,7 +6293,7 @@ parallelizeAndReplaceNode(Function *F, Node *curNode, dim_t numOfChunksNode,
                          currInput, sliceDimsStart, sliceDimsEnd);
       clone->setNthInput(j, inputSlice);
 
-      newNodes[i] = clone;
+      newNodes[i] = NodeValue(clone, resultIdx);
     }
   }
 
@@ -6451,6 +6451,14 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
                 ChannelwiseQuantizedConvolutionNode::ResultIdx, splitDims, 0));
         break;
       }
+      case Kinded::Kind::ConvolutionNodeKind: {
+        splitDims[ConvolutionNode::InputIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, ConvolutionNode::InputIdx,
+                    ConvolutionNode::ResultIdx, splitDims, 0));
+        break;
+      }
       case Kinded::Kind::AdaptiveAvgPoolNodeKind: {
         splitDims[AdaptiveAvgPoolNode::InputIdx] = 0;
         ASSIGN_VALUE_OR_RETURN_ERR(
@@ -6466,6 +6474,14 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
             CN, parallelizeAndReplaceNode(
                     F, curNode, curNumOfChunks, ROIAlignNode::BoxesIdx,
                     ROIAlignNode::ResultIdx, splitDims, 0));
+        break;
+      }
+      case Kinded::Kind::MaxPoolNodeKind: {
+        splitDims[MaxPoolNode::InputIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, MaxPoolNode::InputIdx,
+                    MaxPoolNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::ReshapeNodeKind: {
@@ -6520,6 +6536,15 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
                                           splitDims, 0));
         break;
       }
+      case Kinded::Kind::PowNodeKind: {
+        splitDims[PowNode::LHSIdx] = 0;
+        splitDims[PowNode::RHSIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          PowNode::LHSIdx, PowNode::ResultIdx,
+                                          splitDims, 0));
+        break;
+      }
       case Kinded::Kind::SelectNodeKind: {
         splitDims[SelectNode::LHSIdx] = 0;
         splitDims[SelectNode::RHSIdx] = 0;
@@ -6568,6 +6593,24 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
             CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
                                           SwishNode::InputIdx,
                                           SwishNode::ResultIdx, splitDims, 0));
+        break;
+      }
+      case Kinded::Kind::MaxNodeKind: {
+        splitDims[MaxNode::LHSIdx] = 0;
+        splitDims[MaxNode::RHSIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          MaxNode::LHSIdx, MaxNode::ResultIdx,
+                                          splitDims, 0));
+        break;
+      }
+      case Kinded::Kind::MinNodeKind: {
+        splitDims[MinNode::LHSIdx] = 0;
+        splitDims[MinNode::RHSIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          MinNode::LHSIdx, MinNode::ResultIdx,
+                                          splitDims, 0));
         break;
       }
       case Kinded::Kind::TransposeNodeKind: {
@@ -6624,6 +6667,22 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
             CN, parallelizeAndReplaceNode(
                     F, curNode, curNumOfChunks, BatchedReduceAddNode::BatchIdx,
                     BatchedReduceAddNode::ResultIdx, splitDims, 0));
+        break;
+      }
+      case Kinded::Kind::BatchedReduceMeanNodeKind: {
+        auto *BR = llvm::cast<BatchedReduceMeanNode>(curNode);
+        const auto &BRaxes = BR->getAxes();
+        if (std::find(BRaxes.begin(), BRaxes.end(), 0) != BRaxes.end()) {
+          LOG(INFO)
+              << "BatchedReduceMean along the first dimension not parallelized";
+        } else {
+          splitDims[BatchedReduceMeanNode::BatchIdx] = 0;
+          ASSIGN_VALUE_OR_RETURN_ERR(
+              CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                            BatchedReduceMeanNode::BatchIdx,
+                                            BatchedReduceMeanNode::ResultIdx,
+                                            splitDims, 0));
+        }
         break;
       }
       case Kinded::Kind::ConcatNodeKind: {

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -5346,6 +5346,219 @@ TEST_F(GraphOptz, ParallelizeGraph_Sub) {
   checkNumericalEquivalence();
 }
 
+/// Test Splitting Pow into multiple Pows.
+TEST_F(GraphOptz, ParallelizeGraph_Pow) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(1.0, 2.0,
+                                                           mod_.getPRNG());
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input2", false);
+  bindings_.allocate(input2)->getHandle<float>().randomize(0.0, 5.0,
+                                                           mod_.getPRNG());
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "output", false);
+  bindings_.allocate(output);
+
+  auto *Pow1 = F_->createPow("Pow1", input1, input2);
+  F_->createSave("save", Pow1, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[Pow1] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 12 Pows from Pow1
+  EXPECT_EQ(12, countNodeKind(F_, Kinded::Kind::PowNodeKind));
+
+  // Each input of the 12 Pows are sliced.
+  EXPECT_EQ(24, countNodeKind(F_, Kinded::Kind::SliceNodeKind));
+
+  // One concat to bring all of the parallelized sliced Pows together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
+/// Test Splitting Max into multiple Maxs.
+TEST_F(GraphOptz, ParallelizeGraph_Max) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input2", false);
+  bindings_.allocate(input2)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "output", false);
+  bindings_.allocate(output);
+
+  auto *Max1 = F_->createMax("Max1", input1, input2);
+  F_->createSave("save", Max1, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[Max1] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 12 Maxs from Max1
+  EXPECT_EQ(12, countNodeKind(F_, Kinded::Kind::MaxNodeKind));
+
+  // Each input of the 12 Maxs are sliced.
+  EXPECT_EQ(24, countNodeKind(F_, Kinded::Kind::SliceNodeKind));
+
+  // One concat to bring all of the parallelized sliced Maxs together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
+/// Test Splitting Min into multiple Mins.
+TEST_F(GraphOptz, ParallelizeGraph_Min) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "input2", false);
+  bindings_.allocate(input2)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "output", false);
+  bindings_.allocate(output);
+
+  auto *Min1 = F_->createMin("Min1", input1, input2);
+  F_->createSave("save", Min1, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[Min1] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 12 Mins from Min1
+  EXPECT_EQ(12, countNodeKind(F_, Kinded::Kind::MinNodeKind));
+
+  // Each input of the 12 Mins are sliced.
+  EXPECT_EQ(24, countNodeKind(F_, Kinded::Kind::SliceNodeKind));
+
+  // One concat to bring all of the parallelized sliced Mins together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
+/// Test Splitting BatchedReduceMean into multiple BatchedReduceMeans.
+TEST_F(GraphOptz, ParallelizeGraph_BatchedReduceMean) {
+  auto *input1 = mod_.createPlaceholder(ElemKind::FloatTy, {32, 16, 2048},
+                                        "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {32, 2048}, "output", false);
+  bindings_.allocate(output);
+
+  auto *BatchedReduceMean1 =
+      F_->createBatchedReduceMean("BatchedReduceMean1", input1, {1});
+  F_->createSave("save", BatchedReduceMean1, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[BatchedReduceMean1] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 12 BatchedReduceMeans from BatchedReduceMean1
+  EXPECT_EQ(12, countNodeKind(F_, Kinded::Kind::BatchedReduceMeanNodeKind));
+
+  // Each input of the 12 BatchedReduceMeans are sliced.
+  EXPECT_EQ(12, countNodeKind(F_, Kinded::Kind::SliceNodeKind));
+
+  // One concat to bring all of the parallelized sliced BatchedReduceMeans
+  // together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
+/// Test Splitting BatchedReduceMean into multiple BatchedReduceMeans.
+/// Failure case with first dimension in reduction
+TEST_F(GraphOptz, ParallelizeGraph_BatchedReduceMean_failure) {
+  auto *input1 = mod_.createPlaceholder(ElemKind::FloatTy, {32, 16, 2048},
+                                        "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(-1.0, 1.0,
+                                                           mod_.getPRNG());
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16, 2048}, "output", false);
+  bindings_.allocate(output);
+
+  auto *BatchedReduceMean1 =
+      F_->createBatchedReduceMean("BatchedReduceMean1", input1, {0});
+  F_->createSave("save", BatchedReduceMean1, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[BatchedReduceMean1] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), 0); // Nothing changes
+  runDCEPass(F_, cctx_);
+
+  // We now have only 1 BatchedReduceMean since parallelization is disabled
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::BatchedReduceMeanNodeKind));
+
+  // No concats
+  EXPECT_EQ(0, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
 /// Test Splitting Transpose into multiple Transposes.
 TEST_F(GraphOptz, ParallelizeGraph_Transpose) {
   auto *input =
@@ -5724,6 +5937,41 @@ TEST_F(GraphOptz, ParallelizeData_RoIAlign) {
   checkNumericalEquivalence();
 }
 
+/// Test Splitting MaxPool into multiple MaxPools.
+TEST_F(GraphOptz, ParallelizeData_MaxPool) {
+  auto *input1 = mod_.createPlaceholder(ElemKind::Int8QTy, {3, 5, 5, 8}, 1.0, 0,
+                                        "input1", false);
+  bindings_.allocate(input1)->getHandle<int8_t>().randomize(-1.0, 1.0,
+                                                            mod_.getPRNG());
+
+  auto *maxp = F_->createMaxPool("MaxPool1", input1, 5, 1, 0);
+  F_->createSave("save", maxp->getResult());
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[maxp] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap,
+      ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(), parOpts, 3));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 3 MaxPools
+  EXPECT_EQ(3, countNodeKind(F_, Kinded::Kind::MaxPoolNodeKind));
+
+  // One concat to bring all of the parallelized sliced MaxPools
+  // together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
 /// Test Splitting ChannelwiseQuantizedConvolution into multiple
 /// ChannelwiseQuantizedConvolutions.
 TEST_F(GraphOptz, ParallelizeData_ChannelwiseQuantizedConvolution) {
@@ -5765,6 +6013,49 @@ TEST_F(GraphOptz, ParallelizeData_ChannelwiseQuantizedConvolution) {
 
   // One concat to bring all of the parallelized sliced
   // ChannelwiseQuantizedConvolutions together.
+  EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
+
+  checkNumericalEquivalence();
+}
+
+/// Test Splitting Convolution into multiple Convolutions.
+TEST_F(GraphOptz, ParallelizeData_Convolution) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {3, 5, 5, 8}, "input1", false);
+  bindings_.allocate(input1)->getHandle<float>().randomize(-4, 4,
+                                                           mod_.getPRNG());
+  auto *filter =
+      mod_.createConstant(ElemKind::FloatTy, {6, 1, 1, 8}, "weights");
+  auto *bias = mod_.createConstant(ElemKind::FloatTy, {6}, "bias");
+  auto *output =
+      mod_.createPlaceholder(ElemKind::FloatTy, {3, 5, 5, 6}, "output", false);
+  bindings_.allocate(output);
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {3, 5, 5, 6});
+
+  auto *conv =
+      F_->createConv("Convolution1", input1, filter, bias, outTy, 1, 1, 0, 1);
+  F_->createSave("save", conv, output);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // This is F_ but without the parallel transformation below.
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+
+  llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
+  parOpts[conv] = ParallelTransformKind::Data;
+
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap,
+      ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(), parOpts, 3));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
+  runDCEPass(F_, cctx_);
+
+  // We now have 3 Convolutions
+  EXPECT_EQ(3, countNodeKind(F_, Kinded::Kind::ConvolutionNodeKind));
+
+  // One concat to bring all of the parallelized sliced
+  // Convolutions together.
   EXPECT_EQ(1, countNodeKind(F_, Kinded::Kind::ConcatNodeKind));
 
   checkNumericalEquivalence();


### PR DESCRIPTION
Summary:
Adding data parallel split support for more ops. The list of ops are:
Convolution, Pow, Max, Min, BatchedReduceMean, MaxPool.

Differential Revision: D27538872

