### PR TITLE
Add flag for dumping custom kernels to file

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -102,6 +102,7 @@ extern bool EnableCustomDSPKernels;
 extern bool DumpCompilerData;
 extern bool UsePerPartitionIcetConfig;
 extern std::string InjectedIAOpKernelPath;
+extern bool DumpCustomKernelFiles;
 } // namespace flags
 } // namespace nnpi
 } // namespace glow

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -109,6 +109,7 @@ bool EnableCustomDSPKernels = false;
 bool DumpCompilerData = false;
 bool UsePerPartitionIcetConfig = false;
 std::string InjectedIAOpKernelPath = "";
+bool DumpCustomKernelFiles = false;
 
 } // namespace flags
 } // namespace nnpi
@@ -561,6 +562,14 @@ DEFINE_validator(glow_injected_ia_op_kernel_path,
                    glow::nnpi::flags::InjectedIAOpKernelPath = val;
                    return true;
                  });
+
+DEFINE_bool(glow_dump_custom_kernel_files,
+            glow::nnpi::flags::DumpCustomKernelFiles,
+            "Enable dumping the compiled custom IA and DSP kernels to file.");
+DEFINE_validator(glow_dump_custom_kernel_files, [](const char *, bool val) {
+  glow::nnpi::flags::DumpCustomKernelFiles = val;
+  return true;
+});
 
 DEFINE_bool(glow_nnpi_lower_all_batch_matmul,
             glow::nnpi::flags::LowerAllBatchMatMul,

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -181,12 +181,19 @@ PYBIND11_MODULE(_torch_glow, m) {
   });
 
   /// Enable write Glow graph to onnx after model loading finishes.
-  m.def("enable_write_to_onnx",
-        []() { getGlobalPyTorchLoaderSettingsMutable().writeToOnnx = true; });
+  m.def("enable_write_to_onnx", []() {
+    // Also enable dumping out any custom kernel files that are used so that
+    // these can used with the onnx model.
+    glow::nnpi::flags::DumpCustomKernelFiles = true;
+    getGlobalPyTorchLoaderSettingsMutable().writeToOnnx = true;
+  });
 
   /// Disable write Glow graph to onnx after model loading finishes.
-  m.def("disable_write_to_onnx",
-        []() { getGlobalPyTorchLoaderSettingsMutable().writeToOnnx = false; });
+  m.def("disable_write_to_onnx", []() {
+    // Also disable dumping custom kernel files in case it was enabled.
+    glow::nnpi::flags::DumpCustomKernelFiles = false;
+    getGlobalPyTorchLoaderSettingsMutable().writeToOnnx = false;
+  });
 
   /// Enable zip mode when writing ONNX model to file
   m.def("enable_onnx_zip_mode",


### PR DESCRIPTION
Summary:
Add a flag for dumping to file any custom NNPI kernels used during compilation.
Will dump to `dsp_kernels_binary` and `ia_kernels_binary` in pwd.

These kernels can then be used later instead of the default kernels by using the `--glow_injected_ia_op_kernel_path=ia_kernels_binary` flag for IA kernels and `NNPI_CustomDSPLib=dsp_kernels_binary` environment variable for DSP kernels.

Differential Revision: D28036403

