### PR TITLE
Add support for LookupTable node and instruction in Glow

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1583,6 +1583,14 @@ public:
                                            std::function<float(float)> func,
                                            TypeRef outTy);
 
+  /// Create lookup table for operator \p lutOperator using the provided lookup
+  /// \p table.
+  LookupTableNode *createLookupTable(llvm::StringRef name, NodeValue input,
+                                     LUTOperator lutOperator,
+                                     std::vector<float> &lutOperatorArgs,
+                                     NodeValue table, NodeValue idxTable,
+                                     TypeRef outTy);
+
   /// Create quantized log.
   IntLookupTableNode *createIntLog(llvm::StringRef name, NodeValue input,
                                    TypeRef outTy);

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -282,11 +282,22 @@ enum FusedActivation {
   LEAKY_RELU,
 };
 
+/// LUT Operators (not supported on all backends).
+enum class LUTOperator {
+  NONE = 0,
+  RELU,
+  CLIP,
+  TANH,
+  SIGMOID,
+  LEAKY_RELU,
+};
+
 /// Define output operators.
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, ConvolutionLayout layout);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               FusedActivation fusedActivation);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, LengthsMode lengthsMode);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, LUTOperator lutOperator);
 
 /// Support for hashing the Nodes. This is required for using
 /// llvm::hash_combine.

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -6218,6 +6218,10 @@ void BoundInterpreterFunction::fwdIntLookupTableInst(
   }
 }
 
+void BoundInterpreterFunction::fwdLookupTableInst(const LookupTableInst *I) {
+  llvm_unreachable("LookupTable instruction is not supported yet");
+}
+
 void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
   Tensor *source = getTensor(I->getInput());
   Tensor *dest = getTensor(I->getResult());

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -2430,6 +2430,25 @@ Error ONNXModelWriter::writeIntLookupTable(const IntLookupTableNode *node,
   return writeAllWithNode("IntLookupTable", node, graph, proto);
 }
 
+Error ONNXModelWriter::writeLookupTable(const LookupTableNode *node,
+                                        GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "shape", node->getResult().dims());
+  NodeValue table = node->getTable();
+  if (Constant *c = llvm::dyn_cast<Constant>(table.getNode())) {
+    auto handle = c->getHandle<int8_t>();
+    auto begin = &handle.raw(0);
+    addValueAttribute(
+        proto, "values",
+        llvm::ArrayRef<int8_t>(begin, begin + handle.actualSize()));
+  } else {
+    return MAKE_ERR("Mapping must be a constant type.");
+  }
+
+  return writeAllWithNode("LookupTable", node, graph, proto);
+}
+
 Error ONNXModelWriter::writeLengthsRangeFill(const LengthsRangeFillNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2717,6 +2717,14 @@ Function::createIntLookupTable(llvm::StringRef name, NodeValue input,
   }
 }
 
+LookupTableNode *Function::createLookupTable(
+    llvm::StringRef name, NodeValue input, LUTOperator lutOperator,
+    std::vector<float> &lutOperatorArgs, NodeValue table, NodeValue idxTable,
+    TypeRef outTy) {
+  return addNode(new LookupTableNode(name, outTy, input, table, idxTable,
+                                     lutOperator, lutOperatorArgs));
+}
+
 IntLookupTableNode *Function::createIntLog(llvm::StringRef name,
                                            NodeValue input, TypeRef outTy) {
   auto inputRange = input.getType()->getQuantizedValueRange();

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1895,6 +1895,11 @@ bool IntLookupTableNode::verify() const {
   return isValid;
 }
 
+bool LookupTableNode::verify() const {
+  bool isValid = true;
+  return isValid;
+}
+
 bool QuantizeNode::verify() const {
   bool isValid =
       expectCompareTrue("Dest must be quantized",
@@ -2888,6 +2893,30 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     os << "TANH";
     break;
   case FusedActivation::LEAKY_RELU:
+    os << "LEAKY_RELU";
+    break;
+  }
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, LUTOperator lutOperator) {
+  switch (lutOperator) {
+  case LUTOperator::NONE:
+    os << "NONE";
+    break;
+  case LUTOperator::RELU:
+    os << "RELU";
+    break;
+  case LUTOperator::CLIP:
+    os << "CLIP";
+    break;
+  case LUTOperator::SIGMOID:
+    os << "SIGMOID";
+    break;
+  case LUTOperator::TANH:
+    os << "TANH";
+    break;
+  case LUTOperator::LEAKY_RELU:
     os << "LEAKY_RELU";
     break;
   }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -332,6 +332,30 @@ template <> struct AttributeRetriever<false, FusedActivation> {
   }
 };
 
+/// Specialization for FusedActivation.
+template <> struct AttributeRetriever<false, LUTOperator> {
+  static Expected<LUTOperator> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                                   const ProtobufLoader & /* unused */) {
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+    if (str == "NONE") {
+      return LUTOperator::NONE;
+    } else if (str == "RELU") {
+      return LUTOperator::RELU;
+    } else if (str == "CLIP") {
+      return LUTOperator::CLIP;
+    } else if (str == "TANH") {
+      return LUTOperator::TANH;
+    } else if (str == "SIGMOID") {
+      return LUTOperator::SIGMOID;
+    } else if (str == "LEAKY_RELU") {
+      return LUTOperator::LEAKY_RELU;
+    } else {
+      return MAKE_ERR("Invalid LUTOperator");
+    }
+  }
+};
+
 /// Specialization for ConvolutionLayout.
 template <> struct AttributeRetriever<false, ConvolutionLayout> {
   static Expected<ConvolutionLayout>

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1394,6 +1394,21 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::NoVerify);
 
   //===--------------------------------------------------------------------===//
+  //                Lookup Table Operators
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("LookupTable")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Table", OperandKind::In)
+      .addOperand("TableIdx", OperandKind::In)
+      .addMember(MEMBER_TYPE_INFO(glow::LUTOperator), "Operator")
+      .addMember(MemberType::VectorFloat, "OperatorArgs")
+      .dataParallel()
+      .autoIRGen()
+      .autoVerify(VerifyKind::NoVerify);
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1617,6 +1617,27 @@ int main(int argc, char **argv) {
           "RpnPostNmsTopN should be greater than zero");
 
   //===--------------------------------------------------------------------===//
+  //                Lookup Table Operators
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("LookupTable")
+      // Input to the function.
+      .addInput("Input")
+      // Table containing the coefficients for interpolation.
+      .addInput("Table")
+      // Table containing the index mapping to find the right entry in the main
+      // table.
+      .addInput("TableIdx")
+      .addMember(MEMBER_TYPE_INFO(glow::LUTOperator), "Operator")
+      .addMember(MemberType::VectorFloat, "OperatorArgs")
+      .addResultFromCtorArg()
+      .dataParallel()
+      .setDocstring(
+          "LookupTable based data-parallel operation."
+          "Given an interpolation table and and index table, "
+          "return interpolated approximations for arbitrary functions.");
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary: Define LookupTable node and instruction to represent operations that could be implemented by means of a table lookup (e.g. tanh, sigmoid, etc).

Differential Revision: D27974042

