### PR TITLE
Implement BatchSparseToDense with output's second dim=1

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -341,6 +341,8 @@ private:
   template <typename ElemTy>
   void fwdElementSignInstFloatImpl(const ElementSignInst *I);
 
+  template <typename ElemTy> void fwdNonZeroInstImpl(const NonZeroInst *I);
+
   template <typename ElemTy>
   void fwdElementSelectInstFloatImpl(const ElementSelectInst *I);
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1199,6 +1199,8 @@ public:
 
   PowNode *createPow(llvm::StringRef name, NodeValue base, float exp);
 
+  NonZeroNode *createNonZero(llvm::StringRef name, NodeValue Cond);
+
   SelectNode *createSelect(llvm::StringRef name, NodeValue Cond, NodeValue LHS,
                            NodeValue RHS);
 

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -59,6 +59,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "batchedReduceMinMultiAxis_Int8/0",
     "batchedReduceMax_Int8/0",
     "batchedReduceMaxMultiAxis_Int8/0",
+    "NonZero/0",
     "ReluSimple_BFloat16/0",
     "ReluSimple_Float16/0",
     "PReluSimple_BFloat16/0",

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -245,7 +245,9 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty,
          ElemKind::Int8QTy, ElemKind::Int32ITy, ElemKind::Int64ITy,
          ElemKind::BoolTy});
-
+  case Kinded::Kind::NonZeroNodeKind:
+    return NI.getInElemTy(NonZeroNode::CondIdx) == ElemKind::BoolTy &&
+           NI.getOutElemTy(NonZeroNode::ResultIdx) == ElemKind::Int32ITy;
   case Kinded::Kind::SelectNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -3935,11 +3935,22 @@ void BoundInterpreterFunction::fwdElementExpInst(const ElementExpInst *I) {
                             I->getSrc()->getElementType(), I);
 }
 
+void BoundInterpreterFunction::fwdNonZeroInst(const NonZeroInst *I) {
+  auto outW = getWeightHandle<int32_t>(I->getDest());
+  auto condW = getWeightHandle<bool>(I->getCond());
+  for (size_t condIdx = 0, outIdx = 0, n = condW.size(); condIdx < n;
+       condIdx++) {
+    if (condW.raw(condIdx)) {
+      outW.raw(outIdx) = condIdx;
+      outIdx++;
+    }
+  }
+}
+
 template <typename ElemTy>
 void BoundInterpreterFunction::fwdElementSelectInstFloatImpl(
     const glow::ElementSelectInst *I) {
   staticAssertFloatingPointType(ElemTy);
-
   auto outW = getWeightHandle<ElemTy>(I->getDest());
   auto condW = getWeightHandle<bool>(I->getCond());
   auto lhsW = getWeightHandle<ElemTy>(I->getLHS());

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -360,10 +360,10 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
       case ElemKind::Int32ITy:
         switch (kindTo) {
         case ElemKind::Int64ITy:
+        case ElemKind::Float16Ty:
         case ElemKind::FloatTy:
         case ElemKind::Int8QTy:
           return true;
-        case ElemKind::Float16Ty:
         case ElemKind::BoolTy:
           return glow::nnpi::flags::EnableCustomIAKernels;
         default:

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -499,6 +499,10 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
             {}, {CmpEQNode::ResultIdx}) &&
         (NI.getOutElemTy(CmpEQNode::ResultIdx) == ElemKind::BoolTy);
     break;
+  case Kinded::Kind::NonZeroNodeKind:
+    isNodePrecisionSupported =
+        (NI.getOutElemTy(CmpEQNode::ResultIdx) == ElemKind::Int32ITy);
+    break;
   case Kinded::Kind::SelectNodeKind:
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -251,8 +251,6 @@ struct BlacklistInitializer {
       {"ConvertFrom_FloatTy_To_Int64ITy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ConvertFrom_FloatTy_To_Int64ITy_AndBack/0",
        TestBlacklist::AnyDeviceAnyEngine},
-      {"ConvertFrom_Int32ITy_To_Float16Ty/0",
-       TestBlacklist::AnyDeviceAnyEngine},
       {"ConvertFrom_Int32ITy_To_FloatTy_AndBack/0",
        TestBlacklist::AnyDeviceAnyEngine},
       {"ConvertFrom_Int64ITy_To_Float16Ty/0",

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -2349,6 +2349,7 @@ DEF_ALL_WRITER_NODE(EmbeddingBag)
 DEF_ALL_WRITER_NODE(Embedding)
 DEF_ALL_WRITER_NODE(BitwiseNot)
 DEF_ALL_WRITER_NODE(GaussianFill)
+DEF_ALL_WRITER_NODE(NonZero)
 
 // Glow nodes with default exporting algorithm.
 DEF_ALL_WRITER_NODE(CmpNEQ)

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1974,6 +1974,11 @@ LogitNode *Function::createLogit(llvm::StringRef name, NodeValue input,
   return addNode(new LogitNode(name, input.getType(), input, eps));
 }
 
+NonZeroNode *Function::createNonZero(llvm::StringRef name, NodeValue Cond) {
+  auto outTy = getParent()->uniqueType(ElemKind::Int32ITy, {Cond.dims()[0], 1});
+  return addNode(new NonZeroNode(name, outTy, Cond));
+}
+
 SelectNode *Function::createSelect(llvm::StringRef name, TypeRef outTy,
                                    NodeValue Cond, NodeValue LHS,
                                    NodeValue RHS) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2564,6 +2564,11 @@ bool ReplaceNaNNode::verify() const {
   return checkSameType(getResult(), getInput(), this);
 }
 
+bool NonZeroNode::verify() const {
+  return checkType(getCond(), ElemKind::BoolTy, this) &&
+         checkType(getResult(), ElemKind::Int32ITy, this);
+}
+
 bool SelectNode::verify() const {
   bool isValid = checkSameShape(getResult(), getLHS(), this);
   isValid &= checkSameShape(getResult(), getRHS(), this);

--- a/tests/models/caffe2Models/batch_sparse_to_dense_last_dim_1.pbtxt
+++ b/tests/models/caffe2Models/batch_sparse_to_dense_last_dim_1.pbtxt
@@ -1,0 +1,21 @@
+name: "batchSparseToDense"
+op {
+  input: "lengths"
+  input: "indices"
+  input: "values"
+  output: "output"
+  name: ""
+  type: "BatchSparseToDense"
+  arg {
+    name: "dense_last_dim"
+    i: 1
+  }
+  arg {
+    name: "default_value"
+    f: 0
+  }
+}
+external_input: "lengths"
+external_input: "indices"
+external_input: "values"
+external_output: "output"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -2259,6 +2259,77 @@ TEST_F(Caffe2ImporterTest, SparseToDenseMask) {
   EXPECT_TRUE(N->getMask().equals({42, 100, 300, 1, 0, 312}));
 }
 
+// Test loading a BatchSparseToDense operator w/ second dimension = 1.
+TEST_F(Caffe2ImporterTest, BatchSparseToDense_lastdim1) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/batch_sparse_to_dense_last_dim_1.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Placeholder *outputPH;
+  PlaceholderBindings bindings;
+  // Create inputs.
+  constexpr dim_t numBatches = 100;
+  Tensor lengths(ElemKind::Int32ITy, {numBatches});
+  auto lengthsH = lengths.getHandle<int32_t>();
+  lengthsH.randomize(0, 1, mod.getPRNG());
+
+  // Calculate number of nonzero indices.
+  dim_t numIndices = 0;
+  for (size_t i = 0, n = lengthsH.actualSize(); i < n; i++) {
+    numIndices += lengthsH.at(i);
+  }
+  Tensor indices(ElemKind::Int64ITy, {numIndices});
+  Tensor values(ElemKind::FloatTy, {numIndices});
+  indices.zero();
+  values.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(
+        NetDescFilename, NetWeightFilename, {"lengths", "indices", "values"},
+        {&lengths.getType(), &indices.getType(), &values.getType()}, *F);
+    outputPH = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod,
+                                  {"lengths", "indices", "values"},
+                                  {&lengths, &indices, &values});
+  }
+
+  // Check that the shape of the output matches that of the expected output.
+  const std::vector<dim_t> expectedOutputShape{numBatches, 1};
+  EXPECT_EQ(expectedOutputShape, outputPH->dims().vec());
+  EXPECT_EQ(F->getNodes().size(), 8);
+
+  // Graph has three inputs and one output.
+  EXPECT_EQ(mod.getPlaceholders().size(), 4);
+
+  auto output = bindings.get(outputPH);
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto outputH = output->getHandle();
+
+  // Initialize with zeroes
+  std::vector<std::vector<float>> expected(numBatches, std::vector<float>(1));
+  for (dim_t d = 0, v = 0; d < numBatches; ++d) {
+    if (lengthsH.at(d) == 1) {
+      expected[d][0] = values.getHandle().at({v});
+      v++;
+    }
+  }
+
+  for (dim_t d = 0; d < numBatches; ++d) {
+    EXPECT_NEAR(expected[d][0], outputH.at({d, 0}), 1e-3);
+  }
+}
+
 /// Test loading NCHW2NHWC op.
 TEST_F(Caffe2ImporterTest, testNCHW2NHWC) {
   ExecutionEngine EE{};

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -938,6 +938,14 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .autoIRGen("Erf");
 
+  BB.newInstr("NonZero")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Cond", OperandKind::In)
+      .inplaceOperand({"Dest", "Cond"})
+      .dataParallel()
+      .autoVerify(VerifyKind::SameElementType, {"Cond", "ElemKind::BoolTy"})
+      .autoIRGen("NonZero");
+
   BB.newInstr("ElementSelect")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Cond", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -682,6 +682,12 @@ int main(int argc, char **argv) {
       .dataParallel()
       .setDocstring("Computes elementwise: result = log(input / (1 - input)).");
 
+  BB.newNode("NonZero")
+      .addInput("Cond")
+      .addResultFromCtorArg()
+      .dataParallel()
+      .setDocstring("Selects indices of the true elements in Cond");
+
   BB.newNode("Select")
       .addInput("Cond")
       .addInput("LHS")


### PR DESCRIPTION
Summary:
- Add NonZero operator to get true indices using NNPI select w/ lhs/rhs set to null
Nonzero operator in pytorch: https://pytorch.org/docs/stable/generated/torch.nonzero.html
Nonzero in NumPy: https://numpy.org/doc/stable/reference/generated/numpy.nonzero.html to the summary.
- Add BatchSparseToDense implementation for output's second dimension = 1

Reviewed By: khabinov

Differential Revision: D28001309

