### PR TITLE
[GraphOptimizer] Reshape sinking pass

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -21,6 +21,7 @@
 FUN_PASS(DCE)
 FUN_PASS(SinkCode)
 FUN_PASS(SinkConversions)
+FUN_PASS(SinkReshapes)
 FUN_PASS(HoistCode)
 FUN_PASS(MergeMatMul)
 FUN_PASS(MergePadIntoConvolution)

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1067,24 +1067,6 @@ bool SinkCode::run(Function *F, const CompilationContext &cctx) {
         continue;
       }
     }
-
-    // Sink Clip below Reshape nodes.
-    if (auto *RN = dyn_cast<ReshapeNode>(node)) {
-      auto *CN = dyn_cast<ClipNode>(RN->getInput());
-      if (!CN) {
-        continue;
-      }
-
-      ReshapeNode *newRN = F->createReshape(RN->getName(), CN->getInput(),
-                                            RN->getDims(), RN->getLayout());
-      ClipNode *newCN = F->createClip(CN->getName(), newRN->getResult(),
-                                      CN->getMin(), CN->getMax());
-      RN->getResult().replaceAllUsesOfWith(newCN->getResult());
-      newRN->setPredicate(RN->getPredicate());
-      newCN->setPredicate(CN->getPredicate());
-      changed = true;
-      continue;
-    }
   } // For all nodes in the graph.
 
   // Transformations to sink nodes below Slice. Outlined into a separate loop to

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -202,6 +202,14 @@ createDefaultGraphOptimizationPassPipeline() {
       // Run code hoisting pass to undo such unsuccessful sinking.
       {FunctionPassID::HoistCode, ConvergenceMode::UntilFixedPoint},
 
+      // Try to eliminate Reshape nodes by sinking them through the graph.
+      // Such sinking can create new optimization opportunities as well as
+      // prevent some optimizations from happening, so do it at the very end of
+      // the pipeline to keep the current iteration unaffected and bear all
+      // benefits/consequences on the next pipeline iteration.
+      {FunctionPassID::SinkReshapes, ConvergenceMode::UntilFixedPoint},
+      {FunctionPassID::OptimizeReshape},
+
       // Perform a round of Dead Code Elimination to cleanup the final pass.
       getDCEPassConfig(),
   };


### PR DESCRIPTION
Summary:

Add Reshape sinking pass in GraphOptimizer. Currently supports only sinking below unary eltwise operators.
The sinking logic is implemented using generic node interfaces and properties (DataParallel), as opposed to having dedicated node-specific code for each operator. The benefits of this approach are:
1) Every unary elementwise operator is covered by the pass. If we ever add a new unary eltwise operator it's going to participate in Reshape sinking transformations automatically.
2) Backend-specific nodes (if they are unary and marked as DataParallel in node description) will benefit from this transformation as well, i.e. no need for backend to implement it.

Also, remove Clip sinking below Reshape, as Clip is handled by Reshape sinking pass now.

Documentation:
N/A

Fixes #5247 (partially)

Test Plan:
Added a GraphOptz unit test.
