### PR TITLE
Add nnpi-sw 1.5 support for DQFC/DRQFC Importer

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -802,13 +802,14 @@ public:
                              nodeValueName(glowDQFC->getBias())},
                             {nodeValueName(glowDQFC->getResult())});
 
-    return nnpiNetworkAddFullyConnectedOp(
+    return nnpiNetworkAddDynamicQuantizedFullyConnectedOp(
         importer.getNetwork(), glowDQFC->getName().begin(),
         nodeValueName(glowDQFC->getInput()).c_str(),
         nodeValueName(glowDQFC->getResult()).c_str(),
         nodeValueName(glowDQFC->getWeights()).c_str(),
         glowDQFC->getBias() ? nodeValueName(glowDQFC->getBias()).c_str()
-                            : nullptr);
+                            : nullptr,
+        !glowDQFC->getIsSymmetric());
   }
 };
 
@@ -832,9 +833,6 @@ public:
         "supported.",
         NNPI_INVALID_PARAM);
 
-    // Create the weights with no offset tensor.
-    // Assert weights & biases have no offset or all zeroes.
-
     LOG_NNPI_IF_ERROR_RETURN_VALUE(
         importer.addTensor(nodeValueName(glowDRQFC->getWeights()),
                            /* alternativeLayout */ true,
@@ -842,19 +840,20 @@ public:
                            nodeValueName(glowDRQFC->getOffsets()),
                            /* forceSymlowp */ true),
         "Failed to add tensor to NNPI");
-    // Quantize bias if needed
+
     importer.setUsedTensors({nodeValueName(glowDRQFC->getInput()),
                              nodeValueName(glowDRQFC->getWeights()),
                              nodeValueName(glowDRQFC->getBias())},
                             {nodeValueName(glowDRQFC->getResult())});
 
-    return nnpiNetworkAddFullyConnectedOp(
+    return nnpiNetworkAddDynamicQuantizedFullyConnectedOp(
         importer.getNetwork(), glowDRQFC->getName().begin(),
         nodeValueName(glowDRQFC->getInput()).c_str(),
         nodeValueName(glowDRQFC->getResult()).c_str(),
         nodeValueName(glowDRQFC->getWeights()).c_str(),
         glowDRQFC->getBias() ? nodeValueName(glowDRQFC->getBias()).c_str()
-                             : nullptr);
+                             : nullptr,
+        !glowDRQFC->getIsSymmetric());
   }
 };
 

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -554,7 +554,7 @@ struct BlacklistInitializer {
       {"DynamicQuantizedFullyConnectedStrongWeights/0",
        TestBlacklist::AnyDeviceAnyEngine},
       {"DynamicRowwiseQuantizedFullyConnectedBasic/0",
-       TestBlacklist::AnyDeviceAnyEngine},
+       TestBlacklist::AnyDeviceHWEngine},
 #if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION == 0
       {"BBoxTransform_Rotated_Float16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"IntLookupTable/0", TestBlacklist::AnyDeviceAnyEngine},


### PR DESCRIPTION
Summary:
Change the DQFC Import to nnpi-sw 1.5 API
Currently DRQFC(rowwise) operator test runs fine, but DQFC tests are failing. Will bring this issue to Intel for analysis.

Reviewed By: jackm321

Differential Revision: D28087063

