### PR TITLE
Fix NonZero Operator Interpreter test flakiness

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -3936,7 +3936,9 @@ void BoundInterpreterFunction::fwdElementExpInst(const ElementExpInst *I) {
 }
 
 void BoundInterpreterFunction::fwdNonZeroInst(const NonZeroInst *I) {
-  auto outW = getWeightHandle<int32_t>(I->getDest());
+  auto *T = getTensor(I->getDest());
+  T->zero();
+  auto outW = T->getHandle<int32_t>();
   auto condW = getWeightHandle<bool>(I->getCond());
   for (size_t condIdx = 0, outIdx = 0, n = condW.size(); condIdx < n;
        condIdx++) {

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -60,6 +60,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ResizeBilinear_Int16_outTy/0",
     "ResizeBilinear_Int32_outTy/0",
     "BoolReshape/0",
+    "NonZero/0",
     "replaceNaN_Float/0",
     "replaceNaN_Float16/0",
     "log/0",


### PR DESCRIPTION
Summary: The interpreter test was flaky since the teardown checked that the interpreter implementation always gives identical results, so zero out the tensor prior to setting values so that the same values are returned on multiple runs.

Reviewed By: khabinov

Differential Revision: D28122072

