### PR TITLE
Avoid inserting clip after input if we have clipFP16SkipInputs to true

### DIFF
--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -231,9 +231,10 @@ void TypeAToTypeBFunctionConverter::convertAndClipStorage() {
       if (!isInput(PH, function_)) {
         continue;
       }
-      convertAndClipStorageHelper(*PH, function_, precConfig_.clipFP16,
-                                  precConfig_.float16Format, srcKind_,
-                                  dstKind_);
+      convertAndClipStorageHelper(
+          *PH, function_,
+          precConfig_.clipFP16 && !precConfig_.clipFP16SkipInputs,
+          precConfig_.float16Format, srcKind_, dstKind_);
     }
   }
   if (precConfig_.convertConstantsToFP16) {

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -1434,7 +1434,7 @@ checkConvertOnlyOutputs(PrecisionConfiguration::Float16Format float16Format) {
   ElemKind convertedElementType =
       PrecisionConfiguration::getElementType(float16Format);
 
-  // PH -> ConvertToFP16 -> Clip -> ConvertToFP32 -> ConvertToFP16 -> Relu ->
+  // PH -> ConvertToFP16 -> ConvertToFP32 -> ConvertToFP16 -> Relu ->
   // Clip -> ConvertToFP32 -> Save
 
   ConvertToNode *convertRN = llvm::dyn_cast<ConvertToNode>(SN->getInput());
@@ -1454,9 +1454,8 @@ checkConvertOnlyOutputs(PrecisionConfiguration::Float16Format float16Format) {
   ASSERT_TRUE(convert16To32);
   EXPECT_EQ(convert16To32->getResult().getType()->getElementType(),
             ElemKind::FloatTy);
-  ClipNode *clipPH = llvm::dyn_cast<ClipNode>(convert16To32->getInput());
-  ASSERT_TRUE(clipPH);
-  ConvertToNode *convertPH = llvm::dyn_cast<ConvertToNode>(clipPH->getInput());
+  ConvertToNode *convertPH =
+      llvm::dyn_cast<ConvertToNode>(convert16To32->getInput());
   ASSERT_TRUE(convertPH);
   EXPECT_EQ(convertPH->getResult().getType()->getElementType(),
             convertedElementType);
@@ -1495,10 +1494,8 @@ checkConvertClipStorage(PrecisionConfiguration::Float16Format float16Format) {
 
   ConvertToNode *convertFP32PH = llvm::dyn_cast<ConvertToNode>(SPH->getInput());
   ASSERT_TRUE(convertFP32PH);
-  ClipNode *clipPH = llvm::dyn_cast<ClipNode>(convertFP32PH->getInput());
-  ASSERT_TRUE(clipPH);
   ConvertToNode *convertFP16PH =
-      llvm::dyn_cast<ConvertToNode>(clipPH->getInput());
+      llvm::dyn_cast<ConvertToNode>(convertFP32PH->getInput());
   ASSERT_TRUE(convertFP16PH);
 
   ConvertToNode *convertFP32C = llvm::dyn_cast<ConvertToNode>(SC->getInput());


### PR DESCRIPTION
Summary: If we have `clipFP16SkipInputs`, we shouldn't insert Clip after input at the first place.

Differential Revision: D28126577

