### PR TITLE
Fuse Clip into static placeholders

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -80,6 +80,8 @@ class Module final {
   PlaceholderList placeholders_;
   /// Deterministic PRNG used to initialize weights in this module.
   PseudoRNG PRNG_;
+  /// A list of clip node min/max args that are folded
+  std::map<llvm::StringRef, std::pair<float, float>> clipArgs_{};
 
   /// Module log context that stores all logs related to this module.
   LogContext moduleLogCtx_{nullptr};
@@ -184,6 +186,14 @@ public:
 
   /// \returns the list of types that the Module owns.
   const TypesList &getTypes() const { return types_; }
+
+  void registerClipArgs(llvm::StringRef name, float min, float max) {
+    clipArgs_.insert(std::make_pair(name, std::make_pair(min, max)));
+  }
+
+  std::map<llvm::StringRef, std::pair<float, float>> getClipArgs() {
+    return clipArgs_;
+  }
 
   /// Erase the constant \p N from the Module.
   void eraseConstant(Constant *N);

--- a/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
@@ -20,4 +20,5 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "staticPlaceholderInference/0",
     "FP16StaticPlaceholderInference/0",
+    "foldClipIntoStaticPlaceholders/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
@@ -17,4 +17,5 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "foldClipIntoStaticPlaceholders/0"};

--- a/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "FP16StaticPlaceholderInference/0",
+    "foldClipIntoStaticPlaceholders/0",
 };


### PR DESCRIPTION
Summary:
Fold clip ops directly following static placeholders by adding extending the `FoldElemKindConversionIntoInputs` function pass.

This updates the module with a map of clip min/max args for the folded clips so that in the Provisioner, it can check whether clips were folded after loading the deferred weights and clips the weights before transferring weights to devices.

Differential Revision: D28153329

