### PR TITLE
Fix GLOW NNPI OSS build by using loading headers from relative path

### DIFF
--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectorUtils.cpp
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectorUtils.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectorUtils.h"
+#include "DSPInjectorUtils.h"
 
 #include <glog/logging.h>
 

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.cpp
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h"
+#include "DSPInjectors.h"
 #include "glow/Graph/Graph.h"
 
 namespace glow {

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "glow/lib/Backends/NNPI/CustomKernels/CustomKernelInjector.h"
+#include "../CustomKernelInjector.h"
 
 namespace glow {
 

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/ReluInjector.cpp
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/ReluInjector.cpp
@@ -1,7 +1,7 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectorUtils.h"
-#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h"
+#include "DSPInjectorUtils.h"
+#include "DSPInjectors.h"
 
 namespace glow {
 namespace {

--- a/lib/Backends/NNPI/CustomKernels/GetNNPIKernels.cpp
+++ b/lib/Backends/NNPI/CustomKernels/GetNNPIKernels.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include "glow/lib/Backends/NNPI/CustomKernels/GetNNPIKernels.h"
+#include "GetNNPIKernels.h"
 #include "glow/Flags/Flags.h"
 
 namespace glow {

--- a/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.cpp
+++ b/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.cpp
@@ -1,8 +1,8 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include "glow/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.h"
+#include "IAInjectors.h"
+#include "../GetNNPIKernels.h"
 #include "glow/Graph/Graph.h"
-#include "glow/lib/Backends/NNPI/CustomKernels/GetNNPIKernels.h"
 
 namespace glow {
 

--- a/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.h
+++ b/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "glow/lib/Backends/NNPI/CustomKernels/CustomKernelInjector.h"
+#include "../CustomKernelInjector.h"
 
 namespace glow {
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -14,6 +14,8 @@
  */
 
 #include "NNPI.h"
+#include "CustomKernels/DSPInjectors/DSPInjectors.h"
+#include "CustomKernels/IAInjectors/IAInjectors.h"
 #include "DebugMacros.h"
 #include "Importer.h"
 #include "InferenceContext.h"
@@ -27,8 +29,6 @@
 #include "glow/Optimizer/GraphOptimizer/FunctionPassPipeline.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Optimizer/Lower/Lower.h"
-#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h"
-#include "glow/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.h"
 
 #include "llvm/Support/CommandLine.h"
 

--- a/lib/Backends/NNPI/NNPICompiledFunction.cpp
+++ b/lib/Backends/NNPI/NNPICompiledFunction.cpp
@@ -23,7 +23,7 @@
 #include "glow/Backend/BackendUtils.h"
 #include "glow/Flags/Flags.h"
 
-#include "glow/lib/Backends/NNPI/CustomKernels/GetNNPIKernels.h"
+#include "CustomKernels/GetNNPIKernels.h"
 
 #include <sstream>
 


### PR DESCRIPTION
Summary: The issues is raised from https://github.com/pytorch/glow/pull/5629/files#r627005160 . In this diff, I am changing it to make both OSS and Facebook internal work.

Differential Revision: D28291984

