### PR TITLE
Add A* support for DEC 6X Model 269094314_26

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -287,6 +287,11 @@ public:
   bool hasGlowIValueForValue(const torch::jit::Value *value,
                              bool ignoreNones = false) const;
 
+  /// Extract the constant value from a node value.
+  template <typename T>
+  Error extractConstantFromNodeValue(const torch::jit::Value *value,
+                                     glow::ElemKind elemKind, T &output);
+
   /// If a NodeValue is mapped to \p value then return it, otherwise look for a
   /// float or integer IValue mapped to \p value, create a Glow Constant by
   /// splatting that value to a tensor of the requested dimensions and element

--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -184,6 +184,8 @@ ShapeInferenceEngine::buildShapeSymbolMapping() {
        ShapeInference(&glowUnpackedQuantizedLinear, &SI::addShapeDefault)},
       {"fb::quantized_linear_unpacked_weight",
        ShapeInference(&glowUnpackedQuantizedLinear, &SI::addShapeDefault)},
+      {"fb::quantized_linear_unpacked_weight_v2",
+       ShapeInference(&glowUnpackedQuantizedLinear, &SI::addShapeDefault)},
       {"fb::lengths_to_offsets",
        ShapeInference(&lengthsToOffsets, &SI::addShapeDefault)},
       {"fb::simple_embedding_bag_sum",
@@ -210,6 +212,8 @@ ShapeInferenceEngine::buildShapeSymbolMapping() {
       // Current shape inference function can handle both cases.
       {"fb::lengths_range_w_truncation_size",
        ShapeInference(&lengthsRange, &SI::addShapeDefault)},
+      {"fb::quantize_per_tensor",
+       ShapeInference(&quantizePerTensor, &SI::addShapeDefault)},
       {"aten::quantize_per_tensor",
        ShapeInference(&quantizePerTensor, &SI::addShapeDefault)},
       {"aten::dequantize", ShapeInference(&dequantize, &SI::addShapeDefault)},
@@ -1764,7 +1768,8 @@ ShapeInferenceEngine::chunk(const MetaStack &variableMetas) {
       "b, float r_scale, int r_zero_point) -> Tensor";
  * fb::quantized_linear_unpacked_weight(Tensor a_quant, Tensor w_quant, "
       "Tensor b, float r_scale, int r_zero_point) -> Tensor";
-
+ * fb::quantized_linear_unpacked_weight_v2(Tensor a_quant, Tensor w_quant, "
+      "Tensor b, Tensor r_scale, Tensor r_zero_point) -> Tensor";
 Input: (N, *, in_features) where * means any number of
 additional dimensions
 Weight: (out_features, in_features)
@@ -2004,8 +2009,9 @@ ShapeInferenceEngine::lengthsRange(const MetaStack &variableMetas) {
 }
 
 /*
- * quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType
- * dtype) -> Tensor
+ * aten::quantize_per_tensor(Tensor self, float scale, int zero_point,
+ * ScalarType dtype) -> Tensor fb::quantize_per_tensor(Tensor self, Tensor
+ * scale, Tensor zero_point, ScalarType dtype) -> Tensor
  */
 Expected<TensorOutput>
 ShapeInferenceEngine::quantizePerTensor(const MetaStack &variableMetas) {


### PR DESCRIPTION
Summary:
Context

DEC 6X model 269094314_26 has introduced two new operators
```
fb::quantize_per_tensor
fb::quantized_linear_unpacked_weight_v2

```
which is not yet supported in A*.

These two new operators have already some existing implementation in prod:
```
fb::quantize_per_tensor -> aten::quantize_per_tensor
fb::quantized_linear_unpacked_weight_v2 -> fb::quantized_linear_unpacked_weight
```
the major difference is that, the two new operators use `Tensor scale, Tensor zero_point` instead of `float / float scale, int zero_point,`. the shape inference is the same. and we majorly need to handle the lowering part.

## implementation
Extract the double / int from the tensor value. This logic is pretty similar. in this diff, we implement a template function for this purpose. the logic follows existing one: https://fburl.com/diffusion/igg571bi

Reviewed By: yinghai, qizzzh

Differential Revision: D28309288

