### PR TITLE
Glow flag to convert SLS scale offset to fp32 precision

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -53,6 +53,9 @@ extern bool ForceSLSToFP16Accum;
 extern bool ClipZeroScaleFP16;
 extern bool ClipQuantRangeToFP16;
 
+// FP32 constants
+extern bool ConvertFusedScaleOffsetToFP32;
+
 // Debug Constants
 extern int32_t NumDebugTracesPerDump;
 extern bool DumpDebugTraces;
@@ -161,6 +164,7 @@ DECLARE_bool(glow_global_fp16);
 DECLARE_bool(glow_skip_bias_fp32tofp16_convert);
 DECLARE_bool(glow_clip_fp16);
 DECLARE_bool(glow_global_fused_scale_offset_fp16);
+DECLARE_bool(glow_global_fused_scale_offset_fp32);
 DECLARE_int32(glow_snn_partitioning_kbytes_per_card);
 DECLARE_int32(glow_snn_partitioning_num_cores_sls);
 DECLARE_int32(glow_snn_partitioning_num_cores_other);

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -64,6 +64,9 @@ bool ForceSLSToFP16Accum = true;
 bool ClipQuantRangeToFP16 = false;
 bool ClipZeroScaleFP16 = false;
 
+// Fp32 constants
+bool ConvertFusedScaleOffsetToFP32 = false;
+
 // Debug Constants
 int32_t NumDebugTracesPerDump = 100;
 bool DumpDebugTraces = false;
@@ -275,6 +278,15 @@ DEFINE_bool(glow_global_fused_scale_offset_fp16,
 DEFINE_validator(glow_global_fused_scale_offset_fp16,
                  [](const char *, bool val) {
                    glow::flags::ConvertFusedScaleOffsetToFP16 = val;
+                   return true;
+                 });
+DEFINE_bool(
+    glow_global_fused_scale_offset_fp32,
+    glow::flags::ConvertFusedScaleOffsetToFP32,
+    "Enable converting scale/offset in sls's input data from fp16 to fp32");
+DEFINE_validator(glow_global_fused_scale_offset_fp32,
+                 [](const char *, bool val) {
+                   glow::flags::ConvertFusedScaleOffsetToFP32 = val;
                    return true;
                  });
 DEFINE_bool(

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -200,6 +200,13 @@ onnxStatus HostManagerBackend::addNetwork(
     precConfig.convertFusedToFP16 = glow::flags::ConvertFusedScaleOffsetToFP16;
     LOG(INFO) << "Conversion of fused scales/offsets to fp16 enabled";
   }
+  if (glow::flags::ConvertFusedScaleOffsetToFP32) {
+    precConfig.convert4BitFusedToFP32 =
+        glow::flags::ConvertFusedScaleOffsetToFP32;
+    precConfig.convert8BitFusedToFP32 =
+        glow::flags::ConvertFusedScaleOffsetToFP32;
+    LOG(INFO) << "Conversion of fused scales/offsets to fp32 enabled";
+  }
   if (glow::flags::ClipToFP16) {
     precConfig.clipFP16 = glow::flags::ClipToFP16;
     LOG(INFO) << "Clipping to fp16 enabled";

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -109,12 +109,6 @@ llvm::cl::opt<bool> dumpOutputsOpt("dump_outputs",
                                    llvm::cl::Optional, llvm::cl::init(true),
                                    llvm::cl::cat(reproTestCat));
 
-llvm::cl::opt<bool> fuseScaleOffsetFp32Opt(
-    "glow_global_fused_scale_offset_fp32",
-    llvm::cl::desc(
-        "Enable converting scale/offset in sls's input data from fp16 to fp32"),
-    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(reproTestCat));
-
 llvm::cl::opt<bool> indicesInt64Opt(
     "glow_global_indices_fp64",
     llvm::cl::desc("Enable converting scale/offset in frwqslws's data from "
@@ -208,6 +202,7 @@ void parseCommandLine(int argc, char **argv) {
   FLAGS_glow_global_fp16 = true;
   FLAGS_glow_clip_fp16 = true;
   FLAGS_glow_global_fused_scale_offset_fp16 = true;
+  FLAGS_glow_global_fused_scale_offset_fp32 = false;
   FLAGS_glow_snn_partitioning_kbytes_per_card = 5000000;
   FLAGS_glow_snn_partitioning_num_cores_sls = 6;
   FLAGS_glow_snn_partitioning_num_cores_other = 6;
@@ -475,9 +470,9 @@ int run() {
     precConfig.convertFusedToFP16 = true;
     llvm::outs() << "Conversion of fused scales/offsets to fp16 enabled\n";
   }
-  if (fuseScaleOffsetFp32Opt) {
-    precConfig.convert4BitFusedToFP32 = fuseScaleOffsetFp32Opt;
-    precConfig.convert8BitFusedToFP32 = fuseScaleOffsetFp32Opt;
+  if (glow::flags::ConvertFusedScaleOffsetToFP32) {
+    precConfig.convert4BitFusedToFP32 = true;
+    precConfig.convert8BitFusedToFP32 = true;
     llvm::outs()
         << "Conversion of fused scales/offsets to fp32 in frwqslws enabled\n";
   }


### PR DESCRIPTION
Summary: Convert SLS scale & offset to fp32 precision

Differential Revision: D28015198

