### PR TITLE
Move custom kernel injectors into NNPI importer

### DIFF
--- a/lib/Backends/NNPI/CustomKernels/CustomKernelInjector.h
+++ b/lib/Backends/NNPI/CustomKernels/CustomKernelInjector.h
@@ -9,13 +9,17 @@ namespace glow {
 /// Base class for callables that inject custom NNPI kernel nodes into a Glow
 /// Function.
 struct CustomKernelInjector {
-  /// Given a Glow Function \p F and a node in that graph \p node, replace the
-  /// node with a custom NNPI operator if possible. \returns whether or not a
-  /// replacement was made.
+  /// Given a Glow Function \p F and a node in that graph \p node, create a
+  /// replacement for the node with a custom NNPI operator if possible. \returns
+  /// the replacement node if one was created otherwise nullptr.
+  /// NOTE: Injectors should return a replacement node but should not actually
+  /// use the replacement node in the graph (for example by calling
+  /// replaceAllUsesOfWith), this is to avoid modifying the graph in a way that
+  /// will be visible to serialization.
   /// NOTE: for performance reasons implementations should return false quickly
   /// from tryInject if \p node is not relevent to the injector since all
   /// injectors are called on all nodes in every Function.
-  virtual bool tryInject(Function *F, Node *node) const = 0;
+  virtual Node *tryInject(Function *F, Node *node) const = 0;
   virtual ~CustomKernelInjector() = default;
 };
 } // namespace glow

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/CmpInt32Injector.cpp
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/CmpInt32Injector.cpp
@@ -53,53 +53,51 @@ NNPICustomDSPNode *createCustomCmp_int32(Function *F_, llvm::StringRef name,
 }
 
 template <class CmpOp, typename GlowNode>
-bool tryInject_Cmp_int32(Function *F, Node *node, std::string kernelName) {
+Node *tryInject_Cmp_int32(Function *F, Node *node, std::string kernelName) {
 
   auto *castedNode = llvm::dyn_cast<GlowNode>(node);
 
   if (!castedNode) {
-    return false;
+    return nullptr;
   }
 
   if (castedNode->getLHS().getElementType() != ElemKind::Int32ITy) {
-    return false;
+    return nullptr;
   }
 
   if (castedNode->getRHS().getElementType() != ElemKind::Int32ITy) {
-    return false;
+    return nullptr;
   }
 
   NNPICustomDSPNode *dspNode =
       createCustomCmp_int32<CmpOp>(F, "custom_cmpneq", castedNode->getLHS(),
                                    castedNode->getRHS(), kernelName);
 
-  castedNode->getResult().replaceAllUsesOfWith(dspNode);
-
-  return true;
+  return dspNode;
 }
 
 } // namespace
 
-bool CustomCmpNEQNodeDSPKernelInjector::tryInject(Function *F,
-                                                  Node *node) const {
+Node *CustomCmpNEQNodeDSPKernelInjector::tryInject(Function *F,
+                                                   Node *node) const {
   return tryInject_Cmp_int32<CmpNEQ_int32_func, CmpNEQNode>(F, node,
                                                             "CmpNEQ_int32");
 }
 
-bool CustomCmpEQNodeDSPKernelInjector::tryInject(Function *F,
-                                                 Node *node) const {
+Node *CustomCmpEQNodeDSPKernelInjector::tryInject(Function *F,
+                                                  Node *node) const {
   return tryInject_Cmp_int32<CmpEQ_int32_func, CmpEQNode>(F, node,
                                                           "CmpEQ_int32");
 }
 
-bool CustomCmpLTNodeDSPKernelInjector::tryInject(Function *F,
-                                                 Node *node) const {
+Node *CustomCmpLTNodeDSPKernelInjector::tryInject(Function *F,
+                                                  Node *node) const {
   return tryInject_Cmp_int32<CmpLT_int32_func, CmpLTNode>(F, node,
                                                           "CmpLT_int32");
 }
 
-bool CustomCmpLTENodeDSPKernelInjector::tryInject(Function *F,
-                                                  Node *node) const {
+Node *CustomCmpLTENodeDSPKernelInjector::tryInject(Function *F,
+                                                   Node *node) const {
   return tryInject_Cmp_int32<CmpLTE_int32_func, CmpLTENode>(F, node,
                                                             "CmpLTE_int32");
 }

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h
@@ -10,27 +10,27 @@ namespace glow {
 
 /// Injector for custom Relu node.
 struct CustomReluNodeDSPKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override;
+  Node *tryInject(Function *F, Node *node) const override;
 };
 
 /// Injector for custom CmpNEQ node.
 struct CustomCmpNEQNodeDSPKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override;
+  Node *tryInject(Function *F, Node *node) const override;
 };
 
 /// Injector for custom CmpEQ node.
 struct CustomCmpEQNodeDSPKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override;
+  Node *tryInject(Function *F, Node *node) const override;
 };
 
 /// Injector for custom CmpLT node.
 struct CustomCmpLTNodeDSPKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override;
+  Node *tryInject(Function *F, Node *node) const override;
 };
 
 /// Injector for custom CmpLTE node.
 struct CustomCmpLTENodeDSPKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override;
+  Node *tryInject(Function *F, Node *node) const override;
 };
 
 /// \returns the list of all CustomKernelInjectors for DSP nodes.

--- a/lib/Backends/NNPI/CustomKernels/DSPInjectors/ReluInjector.cpp
+++ b/lib/Backends/NNPI/CustomKernels/DSPInjectors/ReluInjector.cpp
@@ -31,21 +31,20 @@ NNPICustomDSPNode *createCustomReluFP16(Function *F_, llvm::StringRef name,
 }
 } // namespace
 
-bool CustomReluNodeDSPKernelInjector::tryInject(Function *F, Node *node) const {
+Node *CustomReluNodeDSPKernelInjector::tryInject(Function *F,
+                                                 Node *node) const {
   ReluNode *castedNode = llvm::dyn_cast<ReluNode>(node);
   if (!castedNode) {
-    return false;
+    return nullptr;
   }
 
   if (castedNode->getInput().getElementType() != ElemKind::Float16Ty) {
-    return false;
+    return nullptr;
   }
 
   NNPICustomDSPNode *dspNode =
       createCustomReluFP16(F, "custom_relu", castedNode->getInput());
 
-  castedNode->getResult().replaceAllUsesOfWith(dspNode);
-
-  return true;
+  return dspNode;
 }
 } // namespace glow

--- a/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.cpp
+++ b/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.cpp
@@ -9,14 +9,14 @@ namespace glow {
 namespace {
 template <typename GlowNode, ElemKind InputKind>
 struct UnaryNodeIAKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override {
+  Node *tryInject(Function *F, Node *node) const override {
     GlowNode *castedNode = llvm::dyn_cast<GlowNode>(node);
     if (!castedNode) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getInput().getElementType() != InputKind) {
-      return false;
+      return nullptr;
     }
 
     auto kernelName = strFormat("%s_%s_IAKernel", getNodeName<GlowNode>(),
@@ -27,26 +27,25 @@ struct UnaryNodeIAKernelInjector : public CustomKernelInjector {
                   kernelName.c_str()),
         castedNode->getResult().getType(), {castedNode->getInput()}, kernelName,
         GetNNPIKernels::getCompiledIAKernelsFilePath()));
-    castedNode->getResult().replaceAllUsesOfWith(iaNode);
 
-    return true;
+    return iaNode;
   }
 };
 
 template <typename GlowNode, ElemKind Input1Kind, ElemKind Input2Kind>
 struct BinaryNodeIAKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override {
+  Node *tryInject(Function *F, Node *node) const override {
     GlowNode *castedNode = llvm::dyn_cast<GlowNode>(node);
     if (!castedNode) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getNthInput(0).getElementType() != Input1Kind) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getNthInput(1).getElementType() != Input2Kind) {
-      return false;
+      return nullptr;
     }
 
     auto kernelName = strFormat("%s_%s_%s_IAKernel", getNodeName<GlowNode>(),
@@ -59,9 +58,8 @@ struct BinaryNodeIAKernelInjector : public CustomKernelInjector {
         castedNode->getResult().getType(),
         {castedNode->getNthInput(0), castedNode->getNthInput(1)}, kernelName,
         GetNNPIKernels::getCompiledIAKernelsFilePath()));
-    castedNode->getResult().replaceAllUsesOfWith(iaNode);
 
-    return true;
+    return iaNode;
   }
 };
 
@@ -69,14 +67,14 @@ struct BinaryNodeIAKernelInjector : public CustomKernelInjector {
 // tensor input.
 template <typename GlowNode, ElemKind Input1Kind>
 struct DimensionedIAKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override {
+  Node *tryInject(Function *F, Node *node) const override {
     GlowNode *castedNode = llvm::dyn_cast<GlowNode>(node);
     if (!castedNode) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getNthInput(0).getElementType() != Input1Kind) {
-      return false;
+      return nullptr;
     }
 
     auto kernelName = strFormat("%s_%s_Dim_IAKernel", getNodeName<GlowNode>(),
@@ -94,26 +92,24 @@ struct DimensionedIAKernelInjector : public CustomKernelInjector {
         castedNode->getResult().getType(),
         {castedNode->getNthInput(0), constNode}, kernelName,
         GetNNPIKernels::getCompiledIAKernelsFilePath()));
-    castedNode->getResult().replaceAllUsesOfWith(iaNode);
-
-    return true;
+    return iaNode;
   }
 };
 
 template <typename GlowNode, ElemKind ToKind, ElemKind FromKind>
 struct ConversionNodeIAKernelInjector : public CustomKernelInjector {
-  bool tryInject(Function *F, Node *node) const override {
+  Node *tryInject(Function *F, Node *node) const override {
     GlowNode *castedNode = llvm::dyn_cast<GlowNode>(node);
     if (!castedNode) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getResult().getElementType() != ToKind) {
-      return false;
+      return nullptr;
     }
 
     if (castedNode->getInput().getElementType() != FromKind) {
-      return false;
+      return nullptr;
     }
 
     auto kernelName = strFormat("%s_%s_%s_IAKernel", getNodeName<GlowNode>(),
@@ -125,9 +121,8 @@ struct ConversionNodeIAKernelInjector : public CustomKernelInjector {
                   kernelName.c_str()),
         castedNode->getResult().getType(), {castedNode->getInput()}, kernelName,
         GetNNPIKernels::getCompiledIAKernelsFilePath()));
-    castedNode->getResult().replaceAllUsesOfWith(iaNode);
 
-    return true;
+    return iaNode;
   }
 };
 } // namespace

--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -21,6 +21,9 @@
 #include "glow/IR/Instrs.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Quantization/Quantization.h"
+#include "glow/include/glow/Support/Error.h"
+#include "glow/lib/Backends/NNPI/CustomKernels/DSPInjectors/DSPInjectors.h"
+#include "glow/lib/Backends/NNPI/CustomKernels/IAInjectors/IAInjectors.h"
 #include "nnpi_transformer.h"
 #include <cmath>
 #include <cstdio>
@@ -455,8 +458,121 @@ glow::NNPIImporter::addIAExtentionPath(const std::string &extPath) {
   return NNPI_NO_ERROR;
 }
 
+/// Replaces any operators in the Function \p F with custom DSP NNPI kernel
+/// operators by calling each CustomKernelInjector on each node in sequence.
+/// \returns true iff any custom NNPI node was injected into the Function.
+static void getReplacementMapImpl(
+    Function *F, const std::string &replacementName,
+    const std::vector<std::unique_ptr<CustomKernelInjector>> &injectors,
+    std::unordered_map<Node *, Node *> &replacementMap) {
+  auto &nodes = F->getNodes();
+  for (auto &node : nodes) {
+    if (replacementMap.count(&node)) {
+      // Only one replacement per node
+      continue;
+    }
+    for (auto &injector : injectors) {
+      if (Node *newNode = injector->tryInject(F, &node)) {
+        LOG(INFO) << "Using a custom " << replacementName << " op for "
+                  << node.getKindName() << "node named "
+                  << node.getName().str();
+        replacementMap[&node] = newNode;
+        break;
+      }
+    }
+  }
+}
+
+static Error
+verifyReplacements(const std::unordered_map<Node *, Node *> &replacementMap) {
+
+  for (const auto &kv : replacementMap) {
+    Node *node = kv.first;
+    Node *replacementNode = kv.second;
+
+    // Make sure node has one output
+    RETURN_ERR_IF_NOT(
+        node->getNumResults() == 1,
+        strFormat(
+            "The node %s named %s which is being replaced by the node %s has "
+            "%d outputs but only 1 output is supported",
+            node->getKindName(), node->getName().data(),
+            replacementNode->getKindName(), int(node->getNumResults())));
+
+    // Make sure replacementNode has one output
+    RETURN_ERR_IF_NOT(
+        replacementNode->getNumResults() == 1,
+        strFormat(
+            "The node %s which is a replacement for the %s node named %s has "
+            "%d outputs but only 1 output is supported",
+            replacementNode->getKindName(), node->getKindName(),
+            node->getName().data(), int(replacementNode->getNumResults())));
+
+    // Make sure replacementNode has no users
+    RETURN_ERR_IF_NOT(
+        replacementNode->getNthResult(0).getNumUsers() == 0,
+        strFormat(
+            "The node %s which is a replacement for the %s node named %s has "
+            "actual users in the Graph it's in "
+            "but should only be used a temporary node with no users, make sure "
+            "you didn't call replaceAllUsesOfWith for this node",
+            replacementNode->getKindName(), node->getKindName(),
+            node->getName().data()));
+
+    const auto *nodeResType = node->getNthResult(0).getType();
+    const auto *replacementNodeResType =
+        replacementNode->getNthResult(0).getType();
+
+    // Make sure node and replacementNode have the same output type
+    RETURN_ERR_IF_NOT(
+        nodeResType->isEqual(replacementNodeResType),
+        strFormat(
+            "The node %s which is a replacement for the %s node named %s has "
+            "a different output type. Replacement node result type: %s vs "
+            "original node result type: %s",
+            replacementNode->getKindName(), node->getKindName(),
+            node->getName().data(), replacementNodeResType->toString().c_str(),
+            nodeResType->toString().c_str()));
+  }
+
+  return Error::success();
+}
+
+static Expected<std::unordered_map<Node *, Node *>>
+getReplacementMap(Function *F) {
+  std::unordered_map<Node *, Node *> replacementMap;
+
+  // NOTE: DSP kernels are generally faster and preferred relative to IA kernels
+  // so always call injectCustomDSPOps first to choose them over IA kernels
+  // where possible.
+  if (!glow::nnpi::flags::EnableCustomDSPKernels) {
+    LOG(INFO) << "Skipping custom DSP kernels because they are disabled";
+  } else {
+    LOG(INFO) << "Custom DSP ops enabled";
+    static const auto dspInjectors = buildDSPInjectors();
+    getReplacementMapImpl(F, "DSP", dspInjectors, replacementMap);
+  }
+
+  const char *useInfApi = std::getenv("USE_INF_API");
+  if (!glow::nnpi::flags::EnableCustomIAKernels) {
+    LOG(INFO) << "Skipping custom IA kernels because they are disabled";
+  } else if (!useInfApi || std::string(useInfApi) != "1") {
+    LOG(INFO) << "Skipping custom IA kernels because hardware inference isn't "
+                 "enabled";
+  } else {
+    LOG(INFO) << "Custom IA ops enabled";
+    static const auto iaInjectors = buildIAInjectors();
+    getReplacementMapImpl(F, "IA", iaInjectors, replacementMap);
+  }
+
+  RETURN_IF_ERR(verifyReplacements(replacementMap));
+
+  return replacementMap;
+}
+
 NNPINetwork glow::NNPIImporter::importFunction(Function *F,
-                                               const BackendOptions &opts) {
+                                               const BackendOptions &opts,
+                                               bool &requiresDSPKernels) {
   if (compileOptions_.normalizeLayerNames) {
     std::map<std::string, uint32_t> type2count;
     std::map<std::string, glow::Node *> nodes;
@@ -493,6 +609,21 @@ NNPINetwork glow::NNPIImporter::importFunction(Function *F,
   writeTensors_.clear();
   definedTensors_.clear();
   DBG_MEM_USAGE("ImportFunction <<");
+
+  // Build replacement map for replacing nodes with custom DSP and IA ops.
+  std::unordered_map<Node *, Node *> replacementMap;
+  std::unordered_set<Node *> replacementNodes;
+  if (auto replacementMapOrErr = getReplacementMap(F)) {
+    for (const auto &kv : *replacementMapOrErr) {
+      replacementNodes.insert(kv.second);
+    }
+    replacementMap = std::move(*replacementMapOrErr);
+  } else {
+    LOG(ERROR) << "Failure getting replacement map: "
+               << ERR_TO_STRING(replacementMapOrErr.takeError());
+    return NNPI_INVALID_NNPIHANDLE;
+  }
+
   // Add constants.
   for (const auto &c : F->getParent()->getConstants()) {
     DBG("Importing Constant: " << c->getName().str() << " ("
@@ -507,13 +638,9 @@ NNPINetwork glow::NNPIImporter::importFunction(Function *F,
 
   // Per node handling.
   for (auto &N : F->getNodes()) {
-    // Check this type is handled.
-    if (nodeImporters_.count(N.getKindName()) == 0) {
-      DBG("-------------------------------------------------");
-      DBG("Unhandled node type: " << N.getKindName());
-      N.dump();
-      DBG("-------------------------------------------------");
-      return NNPI_INVALID_NNPIHANDLE;
+    // Skip temporary replacement nodes.
+    if (replacementNodes.count(&N)) {
+      continue;
     }
 
     DBG("Importing Node: " << N.getName().str() << " (" << N.getKindName()
@@ -531,11 +658,61 @@ NNPINetwork glow::NNPIImporter::importFunction(Function *F,
       DBG("  Output: " << nodeValueName(resVal));
     }
     DBG_MEM_USAGE("ImportFunction import node: " << N.getKindName());
-    // Import node.
-    LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
-        nodeImporters_.at(N.getKindName())->importNode(&N, *this),
-        "Failed to import node");
+
+    if (replacementMap.count(&N)) {
+      Node *replacementNode = replacementMap.at(&N);
+      if (replacementNode->getKind() == Kinded::Kind::NNPICustomDSPNodeKind) {
+        requiresDSPKernels = true;
+        auto *glowDSPReplacementNode =
+            llvm::dyn_cast<NNPICustomDSPNode>(replacementNode);
+        LOG_AND_RETURN_IF_NOT(ERROR, glowDSPReplacementNode, "Bad node type",
+                              NNPI_INVALID_PARAM);
+
+        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
+            importNodeAsCustomDSPNode(&N, glowDSPReplacementNode),
+            "Failed to import node as DSP node replacement");
+      } else if (replacementNode->getKind() ==
+                 Kinded::Kind::NNPICustomIANodeKind) {
+        auto *glowIAReplacementNode =
+            llvm::dyn_cast<NNPICustomIANode>(replacementNode);
+        LOG_AND_RETURN_IF_NOT(ERROR, glowIAReplacementNode, "Bad node type",
+                              NNPI_INVALID_PARAM);
+
+        LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
+            importNodeAsCustomIANode(&N, glowIAReplacementNode),
+            "Failed to import node as IA node replacement");
+      } else {
+        LOG(ERROR) << "Invalid node kind for replacement, tried to replace a "
+                   << N.getKindName() << " with a "
+                   << replacementNode->getKindName();
+        N.dump();
+        return NNPI_INVALID_NNPIHANDLE;
+      }
+    } else {
+      // Check this type is handled.
+      if (nodeImporters_.count(N.getKindName()) == 0) {
+        LOG(ERROR) << "Unhandled node type: " << N.getKindName();
+        N.dump();
+        return NNPI_INVALID_NNPIHANDLE;
+      }
+
+      if (N.getKind() == Kinded::Kind::NNPICustomDSPNodeKind) {
+        requiresDSPKernels = true;
+      }
+
+      // Import node.
+      LOG_NNPI_IF_ERROR_RETURN_INVALID_HANDLE(
+          nodeImporters_.at(N.getKindName())->importNode(&N, *this),
+          "Failed to import node");
+    }
   }
+
+  // Delete temporary replacement nodes after they're used for loading.
+  for (auto &kv : replacementMap) {
+    F->eraseNode(kv.second);
+  }
+  replacementMap.clear();
+  replacementNodes.clear();
 
   // Handle placeholders (inputs/outputs).
   for (auto *v : F->getParent()->getPlaceholders()) {
@@ -2185,6 +2362,15 @@ public:
     auto *glowIA = llvm::dyn_cast<NNPICustomIANode>(n);
     LOG_AND_RETURN_IF_NOT(ERROR, glowIA, "Bad node type", NNPI_INVALID_PARAM);
 
+    return NNPICustomIANodeImporter::importNodeImpl(
+        glowIA, importer, glowIA->getName(), glowIA->getResult());
+  }
+
+  static NNPIErrorCode importNodeImpl(const NNPICustomIANode *glowIA,
+                                      NNPIImporter &importer,
+                                      llvm::StringRef nodeName,
+                                      const NodeValue &output) {
+
     auto numInputs = glowIA->getInputs().size();
     NNPIObjectName inputs[numInputs];
     LOG_AND_RETURN_IF_NOT(ERROR, inputs, "No inputs", NNPI_INVALID_PARAM);
@@ -2200,7 +2386,7 @@ public:
     NNPIObjectName outputs[numOutputs];
     LOG_AND_RETURN_IF_NOT(ERROR, outputs, "No outputs", NNPI_INVALID_PARAM);
     std::unordered_set<std::string> outputTensors;
-    auto nvName = nodeValueName(glowIA->getResult());
+    auto nvName = nodeValueName(output);
     strncpy(outputs[0], nvName.c_str(), sizeof(NNPIObjectName));
     outputTensors.insert(nvName);
 
@@ -2209,9 +2395,9 @@ public:
     LOG_AND_RETURN_IF_NOT(ERROR, error == NNPI_NO_ERROR,
                           "Failed to store IA extension", NNPI_INVALID_PARAM);
 
-    auto res = nnpiNetworkAddCustomIAOp(
-        importer.getNetwork(), glowIA->getName().begin(), numInputs, inputs,
-        numOutputs, outputs, glowIA->getKernelName().c_str());
+    auto res = nnpiNetworkAddCustomIAOp(importer.getNetwork(), nodeName.begin(),
+                                        numInputs, inputs, numOutputs, outputs,
+                                        glowIA->getKernelName().c_str());
     return res;
   }
 };
@@ -2221,6 +2407,14 @@ public:
     auto *glowDSP = llvm::dyn_cast<NNPICustomDSPNode>(n);
     LOG_AND_RETURN_IF_NOT(ERROR, glowDSP, "Bad node type", NNPI_INVALID_PARAM);
 
+    return NNPICustomDSPNodeImporter::importNodeImpl(
+        glowDSP, importer, glowDSP->getName(), glowDSP->getResult());
+  }
+
+  static NNPIErrorCode importNodeImpl(const NNPICustomDSPNode *glowDSP,
+                                      NNPIImporter &importer,
+                                      llvm::StringRef nodeName,
+                                      const NodeValue &output) {
     auto numInputs = glowDSP->getInputs().size();
     NNPIObjectName *inputs = new NNPIObjectName[numInputs];
     LOG_AND_RETURN_IF_NOT(ERROR, inputs, "No inputs", NNPI_INVALID_PARAM);
@@ -2236,7 +2430,7 @@ public:
     NNPIObjectName *outputs = new NNPIObjectName[numOutputs];
     LOG_AND_RETURN_IF_NOT(ERROR, outputs, "No outputs", NNPI_INVALID_PARAM);
     std::unordered_set<std::string> outputTensors;
-    auto nvName = nodeValueName(glowDSP->getResult());
+    auto nvName = nodeValueName(output);
     strncpy(outputs[0], nvName.c_str(), sizeof(NNPIObjectName));
     outputTensors.insert(nvName);
 
@@ -2257,9 +2451,8 @@ public:
     const Tensor *kpTensor = &kpConstant->getPayload();
     const Tensor *wcTensor = &wcConstant->getPayload();
     auto res = nnpiNetworkAddCustomDspOp(
-        importer.getNetwork(), glowDSP->getName().begin(), inputs, numInputs,
-        outputs, numOutputs, kpTensor->getUnsafePtr(),
-        kpTensor->getSizeInBytes(),
+        importer.getNetwork(), nodeName.begin(), inputs, numInputs, outputs,
+        numOutputs, kpTensor->getUnsafePtr(), kpTensor->getSizeInBytes(),
         reinterpret_cast<const NNPIWalkConfig *>(wcTensor->getUnsafePtr()),
         glowDSP->getPrivateAreaSize(), glowDSP->getKernelName().c_str(),
         reinterpret_cast<const NNPICustomDspIceRefCallback>(
@@ -2269,6 +2462,24 @@ public:
     return res;
   }
 };
+
+NNPIErrorCode glow::NNPIImporter::importNodeAsCustomDSPNode(
+    const Node *origNode, const NNPICustomDSPNode *glowDSPReplacementNode) {
+  LOG(INFO) << "Importing " << origNode->getKindName() << " as DSP node";
+
+  return NNPICustomDSPNodeImporter::importNodeImpl(glowDSPReplacementNode,
+                                                   *this, origNode->getName(),
+                                                   origNode->getNthResult(0));
+}
+
+NNPIErrorCode glow::NNPIImporter::importNodeAsCustomIANode(
+    const Node *origNode, const NNPICustomIANode *glowIAReplacementNode) {
+  LOG(INFO) << "Importing " << origNode->getKindName() << " as IA node";
+
+  return NNPICustomIANodeImporter::importNodeImpl(glowIAReplacementNode, *this,
+                                                  origNode->getName(),
+                                                  origNode->getNthResult(0));
+}
 
 class ClipNodeImporter : public INNPINodeImporter {
 public:

--- a/lib/Backends/NNPI/Importer.h
+++ b/lib/Backends/NNPI/Importer.h
@@ -50,7 +50,8 @@ public:
   /// The main entry point for the importer functionality
   /// Imports a Function \p F using options taken from \p opts
   /// \return true iff the import succeeded.
-  NNPINetwork importFunction(Function *F, const BackendOptions &opts);
+  NNPINetwork importFunction(Function *F, const BackendOptions &opts,
+                             bool &requiresDSPKernels);
 
   /// Get a new name for an internal object.
   std::string getInternalName() {
@@ -154,6 +155,20 @@ private:
 
   /// A list of IA extensions that need to be loaded by the device.
   std::vector<std::string> iaExtensionPaths_;
+
+  /// Instead of importing \p origNode directly, import a NNPICustomDSPNodeKind
+  /// \p glowDSPReplacementNode representation of it created by a custom
+  /// injector.
+  NNPIErrorCode
+  importNodeAsCustomDSPNode(const Node *origNode,
+                            const NNPICustomDSPNode *glowDSPReplacementNode);
+
+  /// Instead of importing \p origNode directly, import a NNPICustomIANodeKind
+  /// \p glowIAReplacementNode representation of it created by a custom
+  /// injector.
+  NNPIErrorCode
+  importNodeAsCustomIANode(const Node *origNode,
+                           const NNPICustomIANode *glowIAReplacementNode);
 };
 
 /// Interface class for all node specific importers.

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -155,7 +155,8 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
   case Kinded::Kind::ExpNodeKind:
   case Kinded::Kind::SoftPlusNodeKind:
     isNodePrecisionSupported = NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
+         ElemKind::Int32ITy});
     break;
   case Kinded::Kind::BatchedReduceMinNodeKind:
   case Kinded::Kind::BatchedReduceMaxNodeKind:
@@ -689,7 +690,8 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
   case Kinded::Kind::SparseToDenseNodeKind:
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind(
-            {ElemKind::FloatTy}, {SparseToDenseNode::IndicesIdx}) &&
+            {ElemKind::FloatTy, ElemKind::Float16Ty},
+            {SparseToDenseNode::IndicesIdx}) &&
         (NI.getInElemTy(SparseToDenseNode::IndicesIdx) == ElemKind::Int32ITy ||
          NI.getInElemTy(SparseToDenseNode::IndicesIdx) == ElemKind::Int64ITy);
     break;
@@ -752,6 +754,10 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
   case Kinded::Kind::LogitNodeKind:
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
+    break;
+  case Kinded::Kind::CumSumNodeKind:
+    isNodePrecisionSupported =
+        NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
     break;
   default:
     isNodeHasAnySupport = false;
@@ -1996,73 +2002,6 @@ NNPIBackend::transformPostOptPipeline(Function *F,
   return changed;
 }
 
-/// Replaces any operators in the Function \p F with custom DSP NNPI kernel
-/// operators by calling each CustomKernelInjector on each node in sequence.
-/// \returns true iff any custom NNPI node was injected into the Function.
-static bool injectCustomDSPOps(Function *F) {
-  if (!glow::nnpi::flags::EnableCustomDSPKernels) {
-    LOG(INFO) << "Skipping custom DSP kernels because they are disabled";
-    return false;
-  }
-
-  static const auto dspInjectors = buildDSPInjectors();
-
-  LOG(INFO) << "Custom DSP ops enabled";
-
-  bool modified = false;
-
-  auto &nodes = F->getNodes();
-  for (auto &node : nodes) {
-    for (auto &injector : dspInjectors) {
-      if (injector->tryInject(F, &node)) {
-        LOG(INFO) << "Using a custom DSP op for " << node.getName().str();
-        modified = true;
-        break;
-      }
-    }
-  }
-
-  return modified;
-}
-
-/// Replaces any operators in the Function \p F with custom IA NNPI kernel
-/// operators by calling each CustomKernelInjector on each node in sequence.
-/// \returns true iff any custom NNPI node was injected into the Function.
-static bool injectCustomIAOps(Function *F) {
-  if (!glow::nnpi::flags::EnableCustomIAKernels) {
-    LOG(INFO) << "Skipping custom IA kernels because they are disabled";
-    return false;
-  }
-
-  // For now only inject IA ops when running on device since custom IA
-  // kernels aren't currently supported by iceref.
-  const char *useInfApi = std::getenv("USE_INF_API");
-  if (!useInfApi || std::string(useInfApi) != "1") {
-    LOG(INFO) << "Skipping custom IA kernels because hardware inference isn't "
-                 "enabled";
-    return false;
-  }
-
-  static const auto iaInjectors = buildIAInjectors();
-
-  LOG(INFO) << "Custom IA ops enabled";
-
-  bool modified = false;
-
-  auto &nodes = F->getNodes();
-  for (auto &node : nodes) {
-    for (auto &injector : iaInjectors) {
-      if (injector->tryInject(F, &node)) {
-        LOG(INFO) << "Using a custom IA op for " << node.getName().str();
-        modified = true;
-        break;
-      }
-    }
-  }
-
-  return modified;
-}
-
 Expected<bool> NNPIBackend::transformPostLowering(
     Function *F, CompilationContext &cctx,
     const glow::runtime::DeviceInfo *devInfo) const {
@@ -2102,12 +2041,6 @@ Expected<bool> NNPIBackend::transformPostLowering(
     changed |= FPM.run(F, cctx);
   }
   changed |= lowerRequiredNodes(F, cctx);
-
-  // NOTE: DSP kernels are generally faster and preferred relative to IA kernels
-  // so always call injectCustomDSPOps first to choose them over IA kernels
-  // where possible.
-  changed |= injectCustomDSPOps(F);
-  changed |= injectCustomIAOps(F);
 
 #if FACEBOOK_INTERNAL
   if (!(glow::nnpi::flags::EnableCustomDSPKernels ||


### PR DESCRIPTION
Summary: Instead of actually injecting the custom kernel operators into the Glow graph, injectors just create the custom kernel nodes and the NNPI importer will treat them as if they had been injected but without actually injecting them. This ensures that the Glow graph remains unchanged after NNPI importing is complete.

Reviewed By: mjanderson09

Differential Revision: D28128323

