### PR TITLE
Add more flags to support serialization of DAGs with weights after optimizations using Zip format

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -133,6 +133,7 @@ extern std::string BackendName;
 extern bool SaveModel;
 extern bool SaveIO;
 extern bool SaveDAG;
+extern bool SaveDAGWithConstants;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow

--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -134,6 +134,7 @@ extern bool SaveModel;
 extern bool SaveIO;
 extern bool SaveDAG;
 extern bool SaveDAGWithConstants;
+extern bool SaveDAGInZipMode;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -346,6 +346,10 @@ struct CompilationContext {
   /// Whether to serialize the DAG that has been optimized and partitioned.
   bool serializeCompiledDAG{false};
 
+  /// Whether to use Zip mode to serialize the DAG that has been optimized and
+  /// partitioned.
+  bool useZipModeForSerializeCompiledDAG{false};
+
   /// Whether to save constant data into the serialized DAG.
   bool saveConstantInSerializeCompiledDAG{false};
 

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -142,6 +142,7 @@ bool SaveModel = false;
 bool SaveIO = false;
 bool SaveDAG = false;
 bool SaveDAGWithConstants = false;
+bool SaveDAGInZipMode = false;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow
@@ -382,6 +383,14 @@ DEFINE_validator(glow_save_onnxifi_dag_with_constants,
                    glow::onnxifi::flags::SaveDAGWithConstants = val;
                    return true;
                  });
+DEFINE_bool(glow_save_onnxifi_dag_in_zip_mode,
+            glow::onnxifi::flags::SaveDAGWithConstants,
+            "Whether to serialize the DAG that has been optimized and "
+            "partitioned in ZIP mode.");
+DEFINE_validator(glow_save_onnxifi_dag_in_zip_mode, [](const char *, bool val) {
+  glow::onnxifi::flags::SaveDAGInZipMode = val;
+  return true;
+});
 DEFINE_bool(
     glow_delay_and_record_constant_modification,
     glow::flags::DelayAndRecordConstantModification,

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -141,6 +141,7 @@ std::string BackendName = "";
 bool SaveModel = false;
 bool SaveIO = false;
 bool SaveDAG = false;
+bool SaveDAGWithConstants = false;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow
@@ -372,6 +373,15 @@ DEFINE_validator(glow_save_onnxifi_dag, [](const char *, bool val) {
   glow::onnxifi::flags::SaveDAG = val;
   return true;
 });
+DEFINE_bool(glow_save_onnxifi_dag_with_constants,
+            glow::onnxifi::flags::SaveDAGWithConstants,
+            "Whether to serialize constants in the DAG that has been optimized "
+            "and partitioned.");
+DEFINE_validator(glow_save_onnxifi_dag_with_constants,
+                 [](const char *, bool val) {
+                   glow::onnxifi::flags::SaveDAGWithConstants = val;
+                   return true;
+                 });
 DEFINE_bool(
     glow_delay_and_record_constant_modification,
     glow::flags::DelayAndRecordConstantModification,

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -509,7 +509,8 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
       // meta info as the model does not need to be reloaded.
       ONNXModelWriter onnxWR(
           loc, nodeList, 7, 9, &writeErr,
-          /* textMode */ true, /* zipMode */ false,
+          /* textMode */ true,
+          /* zipMode */ cctx.useZipModeForSerializeCompiledDAG,
           /* includeConstantData */ cctx.saveConstantInSerializeCompiledDAG,
           extraMetadataProps, record, cctx.backendOpts.backendSpecificNodeInfo,
           cctx.skipProvisioning ? &cctx.loadedPHNames : nullptr,

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -564,6 +564,11 @@ int run() {
                  "partitioning.";
     cctx.saveConstantInSerializeCompiledDAG = true;
   }
+  if (glow::onnxifi::flags::SaveDAGInZipMode) {
+    LOG(INFO) << "Serializing DAG with constants after optimization and "
+                 "partitioning in Zip mode.";
+    cctx.useZipModeForSerializeCompiledDAG = true;
+  }
 
   // Load deferred weights if applicable
   const auto &placeholderList = mod->getPlaceholders();

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -559,6 +559,11 @@ int run() {
     LOG(INFO) << "Serializing DAG after optimization and partitioning.";
     cctx.serializeCompiledDAG = true;
   }
+  if (glow::onnxifi::flags::SaveDAGWithConstants) {
+    LOG(INFO) << "Serializing DAG with constants after optimization and "
+                 "partitioning.";
+    cctx.saveConstantInSerializeCompiledDAG = true;
+  }
 
   // Load deferred weights if applicable
   const auto &placeholderList = mod->getPlaceholders();


### PR DESCRIPTION
Summary:
Add flags to save DAGs into a zip file.

The name of the flag is `-glow_save_onnxifi_dag_in_zip_mode`.

Reviewed By: jfix71

Differential Revision: D28370984

