### PR TITLE
Support serializing Glow DAG with constants after optimization and partitioning

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -133,6 +133,7 @@ extern std::string BackendName;
 extern bool SaveModel;
 extern bool SaveIO;
 extern bool SaveDAG;
+extern bool SaveDAGWithConstants;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -141,6 +141,7 @@ std::string BackendName = "";
 bool SaveModel = false;
 bool SaveIO = false;
 bool SaveDAG = false;
+bool SaveDAGWithConstants = false;
 } // namespace flags
 } // namespace onnxifi
 } // namespace glow
@@ -372,6 +373,15 @@ DEFINE_validator(glow_save_onnxifi_dag, [](const char *, bool val) {
   glow::onnxifi::flags::SaveDAG = val;
   return true;
 });
+DEFINE_bool(glow_save_onnxifi_dag_with_constants,
+            glow::onnxifi::flags::SaveDAGWithConstants,
+            "Whether to serialize constants in the DAG that has been optimized "
+            "and partitioned.");
+DEFINE_validator(glow_save_onnxifi_dag_with_constants,
+                 [](const char *, bool val) {
+                   glow::onnxifi::flags::SaveDAGWithConstants = val;
+                   return true;
+                 });
 DEFINE_bool(
     glow_delay_and_record_constant_modification,
     glow::flags::DelayAndRecordConstantModification,

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -559,6 +559,11 @@ int run() {
     LOG(INFO) << "Serializing DAG after optimization and partitioning.";
     cctx.serializeCompiledDAG = true;
   }
+  if (glow::onnxifi::flags::SaveDAGWithConstants) {
+    LOG(INFO) << "Serializing DAG with constants after optimization and "
+                 "partitioning.";
+    cctx.saveConstantInSerializeCompiledDAG = true;
+  }
 
   // Load deferred weights if applicable
   const auto &placeholderList = mod->getPlaceholders();


### PR DESCRIPTION
Summary:
Add flags to save DAGs with constants.

The name of the flag is `-glow_save_onnxifi_dag_with_constants`.

Reviewed By: jfix71

Differential Revision: D28370985

