### PR TITLE
Add glow trace activity profiler instrumentation to C2/onnx

### DIFF
--- a/include/glow/Runtime/TraceExporter.h
+++ b/include/glow/Runtime/TraceExporter.h
@@ -18,6 +18,7 @@
 
 #include "glow/ExecutionContext/TraceEvents.h"
 
+#include <mutex>
 #include <vector>
 
 namespace glow {
@@ -66,6 +67,7 @@ public:
 private:
   /// Registered TraceExporters.
   std::vector<TraceExporter *> exporters_;
+  std::mutex mutex_;
 };
 
 } // namespace glow

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <fstream>
+#include <glog/logging.h>
 
 namespace glow {
 
@@ -38,8 +39,8 @@ void TraceEvent::dumpTraceEvents(
     std::list<TraceEvent> &events, llvm::StringRef filename,
     const std::string &processName,
     const std::map<int, std::string> &threadNames) {
-  llvm::errs() << "dumping " << events.size() << " trace events to "
-               << filename.str() << ".\n";
+  LOG(INFO) << "dumping " << events.size() << " trace events to "
+            << filename.str();
 
   auto process = processName.empty() ? "glow" : processName;
   std::error_code EC;
@@ -47,7 +48,7 @@ void TraceEvent::dumpTraceEvents(
 
   // Print an error message if the output stream can't be created.
   if (EC) {
-    llvm::errs() << "Unable to open file " << filename << "\n";
+    LOG(ERROR) << "Unable to open file " << filename.str();
     return;
   }
 


### PR DESCRIPTION
Summary:
# Summary
Adds support to start glow traces / export glow traces to Glow activity profiler. This profiler will be integrated with lib Kineto and thus
we can on-demand trace the glow runtime :)

## Flags
The glow activity profiler gets integrated via linking (FB only). I added two command line flags for testing,
``--dump_glow_activity_trace`` and the trace dump filename. When enabled all inference requests get traced and a glow trace file is dumped out.

## Diff Details
instrumentation/Glow
1. Adding trace exporter hooks to glow/glow/lib/Onnxifi/Base.cpp, this is on similar lines to D27785196 that does the same for pytorch.
2. Added trace exporter hooks to repro unittest.
3. Add some thread safety to TraceExporter class.

Glow activity profiler
1. **Moved it from fb/torch_glow to fb/**, and better naming of the target
2. Added the static flags and init section.
3. Fixed link whole = True, otherwise static init does not take place and profiler does not get registered into the trace exporter.

Reviewed By: gcatron

Differential Revision: D28261951

