### PR TITLE
Support ONNX serialization and deserialization of Glow tensor strides

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -150,6 +150,11 @@ public:
   TypeRef uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<dim_t> dims);
 
   /// The new type is identical to \p T, with a new shape \p dims and new \p
+  /// strides.
+  TypeRef uniqueTypeWithNewStrides(TypeRef T, llvm::ArrayRef<dim_t> dims,
+                                   llvm::ArrayRef<dim_t> strides);
+
+  /// The new type is identical to \p T, with a new shape \p dims and new \p
   /// alignments.
   TypeRef uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<dim_t> dims,
                                  llvm::ArrayRef<dim_t> alignments);

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -407,6 +407,7 @@ constexpr char trainableSignifier[] = "trainable";
 constexpr char elemKindSignifier[] = "elemKind";
 constexpr char loaderNameSignifier[] = "loaderName";
 constexpr char saveNameSignifier[] = "saveName";
+constexpr char stridesSignifier[] = "strides";
 constexpr char qScaleSignifier[] = "qScale";
 constexpr char qOffsetSignifier[] = "qOffset";
 constexpr char shapeSignifier[] = "shape";

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -158,6 +158,13 @@ void addTypeAttributes(ONNX_NAMESPACE::NodeProto *proto, TypeRef ty,
                     getTypeAttrID(ioNum, shapeSignifier, isInput, addPrefix),
                     ty->dims());
 
+  // Non-standard strides need to be serialized.
+  if (!ty->hasStandardStrides()) {
+    addValueAttribute(
+        proto, getTypeAttrID(ioNum, stridesSignifier, isInput, addPrefix),
+        ty->strides());
+  }
+
   // Write out scale/offset if quantized ElemKind.
   if (isQuantizedElemKind(ty->getElementType())) {
     addValueAttribute(proto,
@@ -1162,6 +1169,24 @@ static void addQuantParamsToDocString(T *out, const Type &type) {
   addAttrToDocString(out, qOffsetSignifier, std::to_string(type.getOffset()));
 }
 
+/// Add strides to the doc_string in \p out based on \p type.
+template <typename T>
+static void addStridesToDocString(T *out, const Type &type) {
+  // Non-standard strides need to be serialized.
+  if (type.hasStandardStrides()) {
+    return;
+  }
+  const auto &strides = type.strides();
+  std::string stridesStr;
+  std::string delim;
+  for (const auto &stride : strides) {
+    stridesStr.append(delim);
+    stridesStr.append(std::to_string(stride));
+    delim = ",";
+  }
+  addAttrToDocString(out, stridesSignifier, stridesStr);
+}
+
 void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out,
                                   bool useGlowCustomOps, bool includeData) {
   const auto &type = T.getType();
@@ -1177,6 +1202,7 @@ void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out,
 
   if (useGlowCustomOps) {
     addAttrToDocString(out, elemKindSignifier, type.getElementName());
+    addStridesToDocString(out, type);
   }
 
   if (type.isQuantizedType()) {
@@ -1208,6 +1234,7 @@ ONNXModelWriter::createProtoForIO(const Placeholder *PH, bool isInput) {
 
   if (useGlowCustomOps_) {
     // Write out any meta information we need to for the Placeholder.
+    addStridesToDocString(valueProto, *PH->getType());
     addAttrToDocString(valueProto, staticSignifier,
                        std::to_string(PH->isStatic()));
     addAttrToDocString(valueProto, trainableSignifier,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -560,6 +560,11 @@ TypeRef Module::uniqueTypeWithNewShape(TypeRef T, TypeRef shapeType) {
   return uniqueType(Type::newShape(*T, shapeType));
 }
 
+TypeRef Module::uniqueTypeWithNewStrides(TypeRef T, llvm::ArrayRef<dim_t> dims,
+                                         llvm::ArrayRef<dim_t> strides) {
+  return uniqueType(Type::newStrides(*T, strides));
+}
+
 TypeRef Module::uniqueTypeWithNewQuantParams(TypeRef T,
                                              TypeRef quantParamType) {
   return uniqueType(Type::newQuantparams(*T, quantParamType->getScale(),

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -225,6 +225,27 @@ getQuantParamsFromDocString(const std::string &docStr) {
   return std::make_pair(scale, offset);
 }
 
+ShapeVector getStridesFromDocString(const std::string &docStr) {
+  ShapeVector strides;
+  std::string stridesStr;
+  auto stridesOrError = getAttrFromDocString(stridesSignifier, docStr);
+  if (ERR_TO_BOOL(stridesOrError.takeError(), /* log */ false)) {
+    return strides;
+  }
+  stridesStr = std::move(stridesOrError.get());
+  if (stridesStr.empty()) {
+    return strides;
+  }
+  // Parse comma-delimited stride values.
+  llvm::SmallVector<llvm::StringRef, max_tensor_dimensions> stridesStrSplit;
+  llvm::StringRef stridesStrRef = llvm::StringRef(stridesStr);
+  stridesStrRef.split(stridesStrSplit, ',');
+  for (const auto &stride : stridesStrSplit) {
+    strides.emplace_back(std::stoi(stride.str()));
+  }
+  return strides;
+}
+
 /// Used for retrieving an attribute of type \p T from \p attr. Some
 /// specializations used \p loader if necessary.
 template <bool IsInteger, typename T> struct AttributeRetriever {
@@ -426,6 +447,25 @@ Expected<T> loadAttribute(const ONNX_NAMESPACE::AttributeProto *attr,
 using ArgumentDictionaryTy =
     std::unordered_map<std::string, const ONNX_NAMESPACE::AttributeProto *>;
 
+/// \returns a type based on \p ty, but using the provided \p strides.
+static Type getTypeWithCustomStrides(const Type &ty,
+                                     llvm::ArrayRef<dim_t> strides) {
+  if (strides.empty()) {
+    return ty;
+  }
+  return Type::newStrides(ty, strides);
+}
+
+/// \returns a type in module \p mod, based on \p ty, but using the provided \p
+/// strides.
+static TypeRef getTypeWithCustomStrides(glow::Module &mod, const TypeRef ty,
+                                        llvm::ArrayRef<dim_t> strides) {
+  if (strides.empty()) {
+    return ty;
+  }
+  return mod.uniqueTypeWithNewStrides(ty, ty->dims(), strides);
+}
+
 /// Given a docstring encoding \p str of a type and its dimension \p
 /// dims, parses the string and \returns a Glow Type from it or Error if
 /// parsing failed. Expected format of str is either elemKindSignifier or
@@ -436,6 +476,7 @@ Expected<Type> parseTypeFromDocString(const std::string &str,
   float scale = 1.0;
   int32_t offset = 0;
   ElemKind elemKind = ElemKind::FloatTy;
+  ShapeVector strides;
 
   if (useGlowCustomOps) {
     std::string elemKindStr;
@@ -449,6 +490,7 @@ Expected<Type> parseTypeFromDocString(const std::string &str,
                                  getQuantParamsFromDocString(str));
       std::tie(scale, offset) = scaleOffsetPair;
     }
+    strides = getStridesFromDocString(str);
   } else {
     size_t begin = 0;
 
@@ -488,11 +530,13 @@ Expected<Type> parseTypeFromDocString(const std::string &str,
     elemKind = Type::getElementKindFromName(elemKindStr);
   }
 
+  Type ty;
   if (isQuantizedElemKind(elemKind)) {
-    return Type(elemKind, dims, scale, offset);
+    ty = Type(elemKind, dims, scale, offset);
   } else {
-    return Type(elemKind, dims);
+    ty = Type(elemKind, dims);
   }
+  return getTypeWithCustomStrides(ty, strides);
 }
 
 /// Translates the protocol buffer node \p op into a random access map.
@@ -586,8 +630,14 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     dim.push_back(d);
   }
 
+  ShapeVector strides;
+  if (in.has_doc_string()) {
+    strides = getStridesFromDocString(in.doc_string());
+  }
+
   if (in.data_type() == ONNX_NAMESPACE::TensorProto::FLOAT) {
-    T->reset(ElemKind::FloatTy, dim);
+    Type ty(ElemKind::FloatTy, dim);
+    T->reset(getTypeWithCustomStrides(ty, strides));
 
     if (in.float_data_size() > 0) {
       auto TH = T->getHandle<>();
@@ -598,35 +648,38 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     } else if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(float));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(float));
     } else {
       return MAKE_ERR("Unsupported Tensor format for FLOAT, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::FLOAT16) {
-    T->reset(ElemKind::Float16Ty, dim);
+    Type ty(ElemKind::Float16Ty, dim);
+    T->reset(getTypeWithCustomStrides(ty, strides));
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * (sizeof(float) / 2));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * (sizeof(float) / 2));
     } else {
       return MAKE_ERR("Unsupported Tensor format for FLOAT16, name: " +
                           in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::BFLOAT16) {
-    T->reset(ElemKind::BFloat16Ty, dim);
+    Type ty(ElemKind::BFloat16Ty, dim);
+    T->reset(getTypeWithCustomStrides(ty, strides));
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * (sizeof(float) / 2));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * (sizeof(float) / 2));
     } else {
       return MAKE_ERR("Unsupported Tensor format for BFLOAT16, name: " +
                           in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT64) {
-    T->reset(ElemKind::Int64ITy, dim);
+    Type ty(ElemKind::Int64ITy, dim);
+    T->reset(getTypeWithCustomStrides(ty, strides));
 
     if (in.int64_data_size() > 0) {
       auto TH = T->getHandle<int64_t>();
@@ -637,7 +690,7 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     } else if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(int64_t));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(int64_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT64, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
@@ -654,12 +707,13 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
       // does not have data field for int8_t or uint8_t.
       // scale is set to 1 and offset is set to 0 since both scale and offset
       // themselves are operators inputs.
-      T->reset(ElemKind::Int8QTy, dim, 1 /* scale*/, 0 /* offset*/);
+      Type ty(ElemKind::Int8QTy, dim, 1 /* scale*/, 0 /* offset*/);
+      T->reset(getTypeWithCustomStrides(ty, strides));
     }
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(int8_t));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(int8_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT8, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
@@ -673,7 +727,7 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(int16_t));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(int16_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT16, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
@@ -687,7 +741,8 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     } else {
       // There are few cases when we will have int32 tensors. For example, the
       // second output of Concat from Caffe2 concat op is int32
-      T->reset(ElemKind::Int32ITy, dim);
+      Type ty(ElemKind::Int32ITy, dim);
+      T->reset(getTypeWithCustomStrides(ty, strides));
     }
 
     if (in.int32_data_size() > 0) {
@@ -699,7 +754,7 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     } else if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(int32_t));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(int32_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT32, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
@@ -716,23 +771,25 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
       // does not have data field for int8_t or uint8_t.
       // scale is set to 1 and offset is set to 0 since both scale and offset
       // themselves are operators inputs.
-      T->reset(ElemKind::UInt8QTy, dim, 1 /* scale*/, 0 /* offset*/);
+      Type ty(ElemKind::UInt8QTy, dim, 1 /* scale*/, 0 /* offset*/);
+      T->reset(getTypeWithCustomStrides(ty, strides));
     }
 
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(uint8_t));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(uint8_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for UINT8, name: " + in.name(),
                       ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::BOOL) {
-    T->reset(ElemKind::BoolTy, dim);
+    Type ty(ElemKind::BoolTy, dim);
+    T->reset(getTypeWithCustomStrides(ty, strides));
     if (in.has_raw_data() || !data.empty()) {
       std::istringstream inStream(data.empty() ? in.raw_data() : data,
                                   std::stringstream::binary);
-      inStream.read(T->getUnsafePtr(), T->size() * sizeof(bool));
+      inStream.read(T->getUnsafePtr(), T->actualSize() * sizeof(bool));
     } else if (in.int32_data_size() > 0) {
       // Some ONNX models use int32_data to initialize bool type (e.g., when
       // converted from Keras).
@@ -805,6 +862,7 @@ ONNXModelLoader::getTensorType(const ONNX_NAMESPACE::ValueInfoProto &in) {
   ElemKind kind = ElemKind::FloatTy;
   float scale = 1.0;
   int32_t offset = 0;
+  ShapeVector strides;
   if (useGlowCustomOps_) {
     std::string elemKindStr;
     ASSIGN_VALUE_OR_RETURN_ERR(
@@ -816,6 +874,7 @@ ONNXModelLoader::getTensorType(const ONNX_NAMESPACE::ValueInfoProto &in) {
                                  getQuantParamsFromDocString(in.doc_string()));
       std::tie(scale, offset) = scaleOffsetPair;
     }
+    strides = getStridesFromDocString(in.doc_string());
   } else {
     // Retrieve the ElemKind from the ONNX type, including considerations for
     // whether the datatype is quantized.
@@ -828,9 +887,9 @@ ONNXModelLoader::getTensorType(const ONNX_NAMESPACE::ValueInfoProto &in) {
   if (isQuantizedElemKind(kind)) {
     assert(useGlowCustomOps_ &&
            "Quantized loading not fully supported without custom Glow ops.");
-    return Type(kind, dim, scale, offset);
+    return getTypeWithCustomStrides(Type(kind, dim, scale, offset), strides);
   }
-  return Type(kind, dim);
+  return getTypeWithCustomStrides(Type(kind, dim), strides);
 }
 
 Error ONNXModelLoader::getInputsNamesAndTypes(
@@ -5133,9 +5192,19 @@ ONNXModelLoader::loadTypeFromAttributes(unsigned resNo,
       shape, getShape<dim_t>(dict[getTypeAttrID(resNo, shapeSignifier)],
                              /* allowEmptyShape */ true));
 
+  // Load strides. Note that we allow for empty strides here because 0
+  // dimensional shapes are allowed (representing scalars).
+  std::vector<dim_t> strides;
+  auto stridesKey = getTypeAttrID(resNo, stridesSignifier);
+  if (dict.count(stridesKey)) {
+    ASSIGN_VALUE_OR_RETURN_ERR(strides,
+                               getShape<dim_t>(dict[stridesKey],
+                                               /* allowEmptyShape */ true));
+  }
+
   // Create and return uniqued non-quantized Type.
   if (!isQuantizedElemKind(k)) {
-    return mod_.uniqueType(k, shape);
+    return getTypeWithCustomStrides(mod_, mod_.uniqueType(k, shape), strides);
   }
 
   // Must be quantized kind, so get scale/offset and create and return uniqued
@@ -5159,7 +5228,8 @@ ONNXModelLoader::loadTypeFromAttributes(unsigned resNo,
     offset = TQP.offset;
   }
 
-  return mod_.uniqueType(k, shape, scale, offset);
+  return getTypeWithCustomStrides(
+      mod_, mod_.uniqueType(k, shape, scale, offset), strides);
 }
 
 Expected<Node *>

--- a/tests/models/onnxModels/glow_custom_with_strides.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_with_strides.onnxtxt
@@ -1,0 +1,111 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "lhs"
+    input: "rhs"
+    output: "MM"
+    name: "MM"
+    op_type: "Glow_MatMul"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 3
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "o0_strides"
+      ints: 96
+      ints: 1
+      type: INTS
+    }
+  }
+  node {
+    input: "MM"
+    output: "save"
+    name: "save_save"
+    op_type: "Identity"
+  }
+  name: "glow"
+  input {
+    name: "lhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$strides:31,1$elemKind:float"
+  }
+  input {
+    name: "rhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  output {
+    name: "save"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float$saveName:save_save"
+  }
+}
+opset_import {
+  version: 9
+}


### PR DESCRIPTION
Summary:
Glow tensors have support for custom alignments, which affect the strides of those tensors. Since this feature is rarely used, it was never properly supported by the ONNX serialization and serialization machinery.

This diffs adds serialization/deserialization support for strides. To keep the change minimal and backwards compatible, strides are serialized optionally, only if they are non-standard, i.e. if they are used for custom tensor alignments.

Reviewed By: jfix71

Differential Revision: D28414262

