### PR TITLE
Support loading to.prim_device

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -955,7 +955,7 @@ struct ToPrimOtherInputs {
   };
 };
 
-/// Indexes of aten::to.prim_other inputs.
+/// Indexes of aten::to.prim_dtype inputs.
 struct ToPrimDtypeInputs {
   enum {
     input = 0,
@@ -965,7 +965,7 @@ struct ToPrimDtypeInputs {
   };
 };
 
-/// Indexes of aten::to.prim_other inputs.
+/// Indexes of aten::to.prim_device inputs.
 struct ToPrimDeviceInputs {
   enum {
     input = 0,
@@ -6964,10 +6964,9 @@ Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
             return Error::success();
           }
         } else {
-          RETURN_ERR(glowVal.takeError());
+          RETURN_ERR(glowDtypeVal.takeError());
         }
         dtype_arg = ToPrimDeviceInputs::dtype;
-        return MAKE_ERR("aten::to.prim_device is not supported.");
       }
       // - to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False,
       //            bool copy=False, MemoryFormat? memory_format=None)

--- a/torch_glow/tests/nodes/to_test.py
+++ b/torch_glow/tests/nodes/to_test.py
@@ -78,11 +78,10 @@ class TestTo(utils.TorchGlowTestCase):
                 SimplePrimToModel(torch.float),
                 torch.randn(5, 6, 7),
             ),
-            # The following test is not yet supported:
-            # ("to_prim_device", SimplePrimToModel("cpu"), torch.randn(5, 6, 7)),
+            lambda: ("to_prim_device", SimplePrimToModel("cpu"), torch.randn(5, 6, 7)),
             lambda: (
                 "to_prim_device_with_dtype",
-                SimplePrimToModel(torch.float, "cpu"),
+                SimplePrimToModel(torch.float, "cuda"),
                 torch.randn(5, 6, 7),
             ),
         ]
@@ -91,7 +90,6 @@ class TestTo(utils.TorchGlowTestCase):
         utils.compare_tracing_methods(
             module,
             tensor,
-            fusible_ops={"prim::NumToTensor"},
+            fusible_ops={"prim::NumToTensor", "aten::to"},
             scripted=True,
-            skip_to_glow=True,
         )


### PR DESCRIPTION
Summary: Baisically just remove one line that returns an error. We are able to support `to.prim_device` because after ignoring `device` it's pretty much the same as `to.dtype`.

Differential Revision: D28453176

