### PR TITLE
Add failed to load weight test to DeferredWeightLoader

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -306,8 +306,10 @@ public:
     MODEL_LOADER_INVALID_PROTOBUF,
     // Partitioner error.
     PARTITIONER_ERROR,
-    // Runtime error, out of device memory.
+    // Runtime error, general error.
     RUNTIME_ERROR,
+    // Runtime error, error while loading deferred weights.
+    RUNTIME_DEFERRED_WEIGHT_ERROR,
     // Runtime error, out of device memory.
     RUNTIME_OUT_OF_DEVICE_MEMORY,
     // Runtime error, could not find the specified model network.
@@ -379,6 +381,8 @@ public:
   bool isFatalError() const {
     return ec_ == ErrorCode::RUNTIME_DEVICE_NONRECOVERABLE;
   }
+
+  ErrorCode getErrorCode() const { return ec_; }
 
   GlowErrorValue(std::string message, ErrorCode ec)
       : message_(message), ec_(ec) {}

--- a/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
@@ -20,4 +20,5 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "staticPlaceholderInference/0",
     "FP16StaticPlaceholderInference/0",
+    "cleanupFailedDeferred/0",
 };

--- a/lib/Backends/Habana/tests/HabanaDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaDeferredWeightLoaderTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "staticPlaceholderInference/0",
+    "cleanupFailedDeferred/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "cleanupFailedDeferred/0",
+};

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -303,6 +303,12 @@ onnxStatus HostManagerBackend::addNetwork(
       throw std::invalid_argument(strFormat(
           "Error during AOT optimization (non-provisioned addNetwork):\n%s\n",
           errMsg.c_str()));
+    } else if (err.peekErrorValue()->getErrorCode() ==
+               ErrorValue::ErrorCode::RUNTIME_DEFERRED_WEIGHT_ERROR) {
+      // If a deferred weight error occurs, log the error but do not fatal so we
+      // can try again.
+      LOG(ERROR) << errMsg;
+      return ONNXIFI_STATUS_INTERNAL_ERROR;
     } else {
       LOG(FATAL) << errMsg;
     }

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -77,6 +77,8 @@ std::string GlowErrorValue::errorCodeToString(const ErrorCode &ec) {
     return "PARTITIONER_ERROR";
   case ErrorCode::RUNTIME_ERROR:
     return "RUNTIME_ERROR";
+  case ErrorCode::RUNTIME_DEFERRED_WEIGHT_ERROR:
+    return "RUNTIME_DEFERRED_WEIGHT_ERROR";
   case ErrorCode::RUNTIME_OUT_OF_DEVICE_MEMORY:
     return "RUNTIME_OUT_OF_DEVICE_MEMORY";
   case ErrorCode::RUNTIME_NET_NOT_FOUND:

--- a/tests/unittests/DeferredWeightLoaderTest.cpp
+++ b/tests/unittests/DeferredWeightLoaderTest.cpp
@@ -18,6 +18,7 @@
 #include "BackendTestUtils.h"
 #include "glow/ExecutionContext/ExecutionContext.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Runtime/Provisioner/Provisioner.h"
 
 #include "gtest/gtest.h"
 
@@ -28,6 +29,10 @@ class TestDeferredWeightLoader : public DeferredWeightLoader {
 public:
   Error loadNextWeight() override {
     position_++;
+    if (position_ < names_.size() && names_[position_] == "fail") {
+      return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_DEFERRED_WEIGHT_ERROR,
+                      "Fail to load weight.");
+    }
     return Error::success();
   }
   Error setSrc(void *loaderObject) override { return Error::success(); }
@@ -69,6 +74,82 @@ createHostManager(llvm::StringRef backendName,
   std::unique_ptr<HostManager> hostManager =
       glow::make_unique<HostManager>(std::move(configs), hostConfig);
   return hostManager;
+}
+
+TEST_P(DeferredWeightLoaderTest, cleanupFailedDeferred) {
+  // We want this provisioning to fail after loading a deferred weight, then
+  // verify that the network is cleaned up properly.
+  CHECK_IF_ENABLED();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
+  auto F = module->createFunction("main");
+  auto *X = module->createPlaceholder(ElemKind::FloatTy, {1}, "X", false);
+
+  auto *Y = module->createPlaceholder(ElemKind::FloatTy, {1}, "Y", false);
+  auto *Z = module->createPlaceholder(ElemKind::FloatTy, {1}, "Z", false);
+  auto *output =
+      module->createPlaceholder(ElemKind::FloatTy, {1}, "output", false);
+  // Set X and Y as static.
+  X->setStatic(true);
+  Y->setStatic(true);
+  auto pow1 = F->createPow("pow", X, Y);
+  auto pow2 = F->createPow("pow2", Z, pow1);
+  F->createSave("save", pow2, output);
+  std::vector<Tensor> staticInputs;
+  auto xTensor = Tensor(X->getType());
+  auto yTensor = Tensor(Y->getType());
+  auto zTensor = Tensor(Z->getType());
+  xTensor.getHandle().clear(2.0);
+  yTensor.getHandle().clear(3.0);
+  zTensor.getHandle().clear(2.0);
+
+  TestDeferredWeightLoader loader;
+  loader.addWeight(&xTensor);
+  loader.addWeight(&yTensor);
+  loader.addName("fail");
+  loader.addName("fail");
+  DeferredLoader()->registerLoader(&loader);
+
+  CompilationContext cctx;
+  cctx.deferredWeightLoader = &loader;
+  cctx.optimizationOpts.foldStaticPlaceholderConversions = true;
+
+  DeviceConfig config(GetParam());
+  std::unique_ptr<DeviceManager> device(
+      DeviceManager::createDeviceManager(config));
+  EXPECT_FALSE(ERR_TO_BOOL(device->init()));
+
+  DeviceManagerMapTy devices;
+  devices.emplace(0, std::move(device));
+
+  DAGListTy partitions;
+
+  DAGNodePtrVec nodes;
+  auto rootNode = glow::make_unique<DAGNode>();
+  auto firstNode = glow::make_unique<DAGNode>();
+  rootNode->name = "root";
+  rootNode->children.push_back(firstNode.get());
+  firstNode->name = "main";
+  firstNode->logicalDevices = {0};
+  firstNode->backendName = GetParam();
+  nodes.push_back(std::move(firstNode));
+  partitions.push_back({std::move(rootNode), std::move(nodes)});
+
+  Provisioner provisioner(devices);
+  auto err = provisioner.provision(partitions, *module.get(), cctx);
+  // Expect that there was an Error when provisioning
+  EXPECT_TRUE(ERR_TO_BOOL(std::move(err)));
+
+  // Setup a new loader with correct info.
+  TestDeferredWeightLoader loaderNew;
+  loaderNew.addWeight(&xTensor);
+  loaderNew.addWeight(&yTensor);
+  loaderNew.addName("X");
+  loaderNew.addName("Y");
+  DeferredLoader()->registerLoader(&loaderNew);
+  cctx.deferredWeightLoader = &loaderNew;
+  auto err2 = provisioner.provision(partitions, *module.get(), cctx);
+  // Verify provisioning completes correctly.
+  EXPECT_FALSE(ERR_TO_BOOL(std::move(err2)));
 }
 
 TEST_P(DeferredWeightLoaderTest, staticPlaceholderInference) {


### PR DESCRIPTION
Summary:
Adds a new test where the first time the loader fails to load the weight, the provisioner cleans up an we add again with a functional loader. This verifies that the Provisioner cleans up properly in the case of a failed weight loading.
Additionally this adds a new error code RUNTIME_DEFERRED_WEIGHT_ERROR and adds a check in HostmanagerOnnxifi to only log(ERROR) and not fatal for this class of errors.

Differential Revision: D28460005

