### PR TITLE
dump final graph and print operator stats via to_glow API

### DIFF
--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Runtime/Provisioner/Provisioner.h"
+#include "folly/String.h"
 #include "glow/Backend/BackendUtils.h"
 #include "glow/Backend/CompiledFunction.h"
 #include "glow/Flags/Flags.h"
@@ -420,6 +421,18 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
             deviceBackendName.c_str(), function->getName().str().c_str());
         LOG(INFO) << "Dumping final graph to " << fname;
         function->dumpDAG(fname);
+        // print stats of node
+        std::map<std::string, int> opCounter;
+        for (const auto &node : function->getNodes()) {
+          opCounter[node.getKindName()]++;
+        }
+        std::ostringstream ss;
+        ss << "Dump of Node stats for Function:\n";
+        ss << folly::stringPrintf("%30s %13s \n", "NodeKind", "Count");
+        for (const auto &p : opCounter) {
+          ss << folly::stringPrintf("%30s %13d \n", p.first.c_str(), p.second);
+        }
+        LOG(INFO) << ss.str();
       }
 
       if (glow::flags::DumpCompilationLog) {

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <string>
 
+#include "ATen/core/interned_strings.h"
 #include "PyTorchCommon.h"
 
 #include "FuseKnownPatterns.h"
@@ -116,6 +117,20 @@ PyTorchLoaderSettings &getPyTorchLoaderSettingsInternalOnly() {
 }
 
 } // namespace
+
+void dumpOperatorStats(const torch::jit::Graph &graph) {
+  std::map<torch::jit::NodeKind, int> opCounter;
+  for (const auto *node : graph.nodes()) {
+    opCounter[node->kind()]++;
+  }
+  std::ostringstream ss;
+  ss << "Dump of operator/node stats for graph:\n";
+  ss << folly::stringPrintf("%30s %13s \n", "Node Kind", "Count");
+  for (const auto &[kind, count] : opCounter) {
+    ss << folly::stringPrintf("%30s %13d \n", kind.toQualString(), count);
+  }
+  LOG(INFO) << ss.str();
+}
 
 std::shared_ptr<runtime::HostManager>
 getHostManager(const PyTorchLoaderSettings &settings) {

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -35,6 +35,8 @@ struct InputMetaStack;
 using BatchShapesMapType = std::unordered_map<
     int, std::unordered_map<const torch::jit::Value *, VariableMeta>>;
 
+void dumpOperatorStats(const torch::jit::Graph &graph);
+
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -8832,6 +8832,7 @@ PyTorchModelLoader::PyTorchModelLoader(
       out.open(fname);
       graph.print(out);
       out.close();
+      glow::dumpOperatorStats(graph);
     }
 
     RETURN_ERR_IF_NOT(


### PR DESCRIPTION
Summary:
- dump final graph in glow
- print operator stats via to_glow API
   - 1) node stats for final glow graph
   - 2) operator stats in TorchGlowBackend for torch::jit::graph to lower

Reviewed By: khabinov

Differential Revision: D28444501

