### PR TITLE
Build failure fix LLVM11

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -95,14 +95,14 @@ struct Vocabulary {
   std::unordered_map<std::string, int64_t> word2index_;
 
   void addWord(llvm::StringRef word) {
-    word2index_[word] = index2word_.size();
-    index2word_.push_back(word);
+    word2index_[word.str()] = index2word_.size();
+    index2word_.push_back(word.str());
   }
 
   Vocabulary() = default;
 
   void loadVocabularyFromFile(llvm::StringRef filename) {
-    std::ifstream file(filename);
+    std::ifstream file(filename.str());
     std::string word;
     while (getline(file, word))
       addWord(word);

--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -38,7 +38,7 @@ public:
   bool hasName() const { return !name_.empty(); }
 
   /// Set the name of the instruction to \p name.
-  void setName(llvm::StringRef name) { name_ = name; }
+  void setName(llvm::StringRef name) { name_ = name.str(); }
 
   /// Compares by names, \returns true if name_ < x.name_.
   bool compareByName(const Named &x) const {

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -931,7 +931,7 @@ protected:
     // argument name "axes". That's why the name is passed as a parameter.
     std::vector<unsigned_t> perm;
     if (dict.count(permArgName.str()))
-      ASSIGN_VALUE_OR_RETURN_ERR(perm, getShape<unsigned_t>(dict[permArgName]));
+      ASSIGN_VALUE_OR_RETURN_ERR(perm, getShape<unsigned_t>(dict[permArgName.str()]));
 
     if (perm.empty()) {
       // Empty permutation argument means reversing axes order.
@@ -1638,11 +1638,11 @@ protected:
       return true;
     }
     if (typeName == "Gather" || typeName == "BatchGather") {
-      RETURN_IF_ERR(loadGatherOps(typeName, op, dict));
+      RETURN_IF_ERR(loadGatherOps(typeName.str(), op, dict));
       return true;
     }
     if (typeName == "GatherND") {
-      RETURN_IF_ERR(loadGatherND(typeName, op, dict));
+      RETURN_IF_ERR(loadGatherND(typeName.str(), op, dict));
       return true;
     }
     if (typeName == "GatherRanges") {

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -59,21 +59,21 @@ class LLVMBackendOptions {
 public:
   LLVMBackendOptions();
   /// \returns target triple used by this backend.
-  llvm::StringRef getTarget() const { return target_; }
+  std::string getTarget() const { return target_; }
   /// Sets target triple used by this backend.
-  void setTarget(llvm::StringRef target) { target_ = target; }
+  void setTarget(llvm::StringRef target) { target_ = target.str(); }
   /// \returns arch used by this backend.
-  llvm::StringRef getArch() const { return arch_; }
+  std::string getArch() const { return arch_; }
   /// Sets arch used by this backend.
-  void setArch(llvm::StringRef arch) { arch_ = arch; }
+  void setArch(llvm::StringRef arch) { arch_ = arch.str(); }
   /// \returns cpu used by this backend.
-  llvm::StringRef getCPU() const { return cpu_; }
+  std::string getCPU() const { return cpu_; }
   /// Sets cpu used by this backend.
-  void setCPU(llvm::StringRef cpu) { cpu_ = cpu; }
+  void setCPU(llvm::StringRef cpu) { cpu_ = cpu.str(); }
   /// \returns ABI used by this backend.
-  llvm::StringRef getABIName() const { return abi_; }
+  std::string getABIName() const { return abi_; }
   /// Sets ABI used by this backend.
-  void setABIName(llvm::StringRef abi) { abi_ = abi; }
+  void setABIName(llvm::StringRef abi) { abi_ = abi.str(); }
   /// \returns Float ABI used by this backend.
   llvm::Optional<llvm::FloatABI::ABIType> getFloatABI() const {
     return floatABI_;

--- a/include/glow/Partitioner/PartitionerTypes.h
+++ b/include/glow/Partitioner/PartitionerTypes.h
@@ -171,7 +171,7 @@ public:
   /// Create a new partition \p F, and map it with \p backendName.
   void createPartition(Function *F, llvm::StringRef backendName) {
     functions_.emplace_back(F);
-    functionToBackendName_[F] = backendName;
+    functionToBackendName_[F] = backendName.str();
   }
 
   std::string getPartitionBackendName(Function *F) const {

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -70,7 +70,8 @@ Stream &operator<<(Stream &os, const llvm::ArrayRef<E> list) {
 /// After the last block no delimiter is added.
 std::string separateString(const std::string &str, size_t length,
                            const std::string &delimiter = "\n");
-
+  std::string separateString(llvm::StringRef str, size_t length,
+			     const std::string &delimiter = "\n");
 /// \returns the escaped content of string \p str.
 /// The char '\n' becomes '\'+'n' and quotes are handled correctly.
 std::string escapeDottyString(const std::string &str);

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -187,7 +187,7 @@ void TraceContext::logCompleteTraceEvent(
 
 void TraceContext::setThreadName(int tid, llvm::StringRef name) {
   std::lock_guard<std::mutex> l(lock_);
-  threadNames_[tid] = name;
+  threadNames_[tid] = name.str();
 }
 
 void TraceContext::setThreadName(llvm::StringRef name) {
@@ -239,7 +239,7 @@ ScopedTraceBlock::~ScopedTraceBlock() { end(); }
 
 ScopedTraceBlock &ScopedTraceBlock::addArg(llvm::StringRef key,
                                            llvm::StringRef value) {
-  args_[key] = value;
+  args_[key.str()] = value.str();
   return *this;
 }
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -41,7 +41,7 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend,
   clear();
   module_.reset(new Module);
   rawModule_ = module_.get();
-  backendName_ = backend;
+  backendName_ = backend.str();
 
   if (hostManager_) {
     EXIT_ON_ERR(hostManager_->clearHost());
@@ -299,7 +299,7 @@ void ExecutionEngine::compile(CompilationContext &cctx) {
       skipAdding = std::find(pFuns.begin(), pFuns.end(), F) != pFuns.end();
     }
     if (!skipAdding) {
-      compiledFunctions_.insert(F->getName());
+      compiledFunctions_.insert(F->getName().str());
     }
   }
 

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -267,7 +267,7 @@ void findOutputNames(const Node *node, ONNX_TRAITS::GraphProto &graph,
   // output to save output
   for (const auto &p : saveOutputs) {
     if (resultUsers[p.second] == 1) {
-      callback(p.first->getPlaceholder()->getName());
+      callback(p.first->getPlaceholder()->getName().str());
       saveResNo.insert(p.second);
     } else {
       auto *proto = graph.add_node();
@@ -277,7 +277,7 @@ void findOutputNames(const Node *node, ONNX_TRAITS::GraphProto &graph,
       proto->add_input(p.second == 0 ? node->getName().str()
                                      : (node->getName().str() + "_out_" +
                                         std::to_string(p.second)));
-      proto->add_output(p.first->getPlaceholder()->getName());
+      proto->add_output(p.first->getPlaceholder()->getName().str());
     }
   }
 
@@ -287,7 +287,7 @@ void findOutputNames(const Node *node, ONNX_TRAITS::GraphProto &graph,
       continue;
     }
     if (b == 0) {
-      callback(node->getName());
+      callback(node->getName().str());
     } else {
       callback(node->getName().str() + "_out_" + std::to_string(b));
     }
@@ -306,9 +306,9 @@ void inputsToProto(const Node *node, ONNX_NAMESPACE::NodeProto *proto) {
   for (unsigned b = 0, e = node->getNumInputs(); b < e; ++b) {
     const auto NV = node->getNthInput(b);
     auto resNo = NV.getResNo();
-    auto name = NV.getNode()->getName();
+    auto name = NV.getNode()->getName().str();
     if (resNo) {
-      proto->add_input(name.str() + "_out_" + std::to_string(b));
+      proto->add_input(name + "_out_" + std::to_string(b));
     } else {
       proto->add_input(name);
     }
@@ -325,7 +325,7 @@ bool outputKindToProto(Kinded::Kind kind, const Node *node,
     if (user->getKind() == Kinded::Kind::SaveNodeKind) {
       found = true;
       const SaveNode *SN = llvm::cast<SaveNode>(user);
-      proto->add_output(SN->getPlaceholder()->getName());
+      proto->add_output(SN->getPlaceholder()->getName().str());
       break;
     } else if (user->getKind() == kind) {
       found = true;
@@ -343,13 +343,13 @@ template <typename T>
 Error writeMatMulKind(const T *node, ONNX_TRAITS::GraphProto &graph,
                       const std::string &nodeKind) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type(nodeKind);
 
   Node *LHS = node->getLHS().getNode();
-  proto->add_input(LHS->getName());
+  proto->add_input(LHS->getName().str());
   Node *RHS = node->getRHS().getNode();
-  proto->add_input(RHS->getName());
+  proto->add_input(RHS->getName().str());
 
   outputsToProto(node, graph, proto);
   return Error::success();
@@ -370,7 +370,7 @@ void writeTransposeResult(const T *node, ONNX_NAMESPACE::NodeProto *&proto,
   proto->set_op_type("Transpose");
   proto->add_input(newName);
 
-  proto->add_output(node->getName());
+  proto->add_output(node->getName().str());
 
   // T node proto.
   proto = graph.add_node();
@@ -393,7 +393,7 @@ void writeTransposeInput(const Node *node, const Node *input,
   std::vector<unsigned_t> shuffle(NHWC2NCHW);
   llvm::ArrayRef<unsigned_t> container(shuffle);
   addValueAttribute(transformProto, "perm", container);
-  transformProto->add_input(input->getName());
+  transformProto->add_input(input->getName().str());
   transformProto->add_output(newName);
   proto->add_input(newName);
 }
@@ -409,7 +409,7 @@ Error writeArithmetic(const std::string &opName, const T *node,
                       ONNX_TRAITS::GraphProto &graph, ReportedNodes &reporter,
                       bool hasMultidirectionalBroadcast) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type(opName);
   outputsToProto(node, graph, proto);
 
@@ -427,8 +427,8 @@ Error writeArithmetic(const std::string &opName, const T *node,
     axis = BN->getAxis();
   }
 
-  proto->add_input(LHS.getNode()->getName());
-  proto->add_input(RHS.getNode()->getName());
+  proto->add_input(LHS.getNode()->getName().str());
+  proto->add_input(RHS.getNode()->getName().str());
 
   // Check if the shapes of LHS and RHS are different and broadcast attribute is
   // required.
@@ -896,7 +896,7 @@ Error ONNXModelWriter::finalizeAndWriteProto(llvm::StringRef name) {
         outputStringPtr_ == nullptr,
         "OnnxModelWriter write to string for zip mode not supported");
     const bool compressed = false;
-    ZipWriter zip(&ff_, name);
+    ZipWriter zip(&ff_, name.str());
     std::stringstream ss;
     ss << initializers_.size() << "\n";
     zip.writeRecord("weights", ss.str().c_str(), ss.str().size(), compressed);
@@ -958,7 +958,7 @@ ONNXModelWriter::ONNXModelWriter(
   auto setup = [&]() -> Error {
     setupNewProto();
     for (auto &prop : extraMetadataProps_) {
-      addMetadataProp(prop.getKey(), prop.second);
+      addMetadataProp(prop.getKey().str(), prop.second);
     }
 
     RETURN_IF_ERR(writeFunction());
@@ -1087,7 +1087,7 @@ ONNXModelWriter::ONNXModelWriter(
   auto setup = [&]() -> Error {
     setupNewProto();
     for (auto &prop : extraMetadataProps_) {
-      addMetadataProp(prop.getKey(), prop.second);
+      addMetadataProp(prop.getKey().str(), prop.second);
     }
 
     RETURN_ERR_IF_NOT(dagList.size() == 1, "Expect only one DAG.");
@@ -1230,7 +1230,7 @@ ONNXModelWriter::createProtoForIO(const Placeholder *PH, bool isInput) {
     valueProto = isInput ? &inputValueInfos_[PH] : &outputValueInfos_[PH];
   }
 
-  tensorShapeFromInput(PH->getName(), PH->getType(), valueProto);
+  tensorShapeFromInput(PH->getName().str(), PH->getType(), valueProto);
 
   if (useGlowCustomOps_) {
     // Write out any meta information we need to for the Placeholder.
@@ -1293,7 +1293,7 @@ ONNXModelWriter::createProtoForIO(const Placeholder *PH, bool isInput) {
 Error ONNXModelWriter::writeAllWithNode(const std::string &opName,
                                         const Node *node, GraphType &graph,
                                         NodeType *proto) {
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type(opName);
   inputsToProto(node, proto);
   outputsToProto(node, graph, proto);
@@ -1334,7 +1334,7 @@ Error ONNXModelWriter::writePad(const PadNode *node, GraphType &graph) {
     }
     return writeAllWithNode("Pad", node, graph, proto);
   } else {
-    proto->set_name(node->getName());
+    proto->set_name(node->getName().str());
     proto->set_op_type("Pad");
     // Input for data.
     inputsToProto(node, proto);
@@ -1496,10 +1496,10 @@ Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
 
   const Node *input = node->getInput().getNode();
   if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {
-    proto->add_input(TN->getInput().getNode()->getName());
+    proto->add_input(TN->getInput().getNode()->getName().str());
     reportedNodes_.insert(TN);
   } else if (const ReshapeNode *RSN = llvm::dyn_cast<ReshapeNode>(input)) {
-    proto->add_input(RSN->getInput().getNode()->getName());
+    proto->add_input(RSN->getInput().getNode()->getName().str());
     reportedNodes_.insert(RSN);
   } else {
     writeTransposeInput(node, input, proto, graph);
@@ -1507,18 +1507,18 @@ Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
 
   const Node *filter = node->getFilter().getNode();
   if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(filter)) {
-    proto->add_input(TN->getInput().getNode()->getName());
+    proto->add_input(TN->getInput().getNode()->getName().str());
     reportedNodes_.insert(TN);
   } else if (const ReshapeNode *RSN = llvm::dyn_cast<ReshapeNode>(filter)) {
-    proto->add_input(RSN->getInput().getNode()->getName());
+    proto->add_input(RSN->getInput().getNode()->getName().str());
     reportedNodes_.insert(RSN);
   } else {
     writeTransposeInput(node, filter, proto, graph);
   }
 
-  proto->add_input(node->getBias().getNode()->getName());
+  proto->add_input(node->getBias().getNode()->getName().str());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("Conv");
 
   return Error::success();
@@ -1572,7 +1572,7 @@ Error ONNXModelWriter::writeBatchedReduceMean(const BatchedReduceMeanNode *node,
   // Add dictionary entries.
   addValueAttribute(proto, "axes", node->getAxes());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("ReduceMean");
   inputsToProto(node, proto);
 
@@ -1590,7 +1590,7 @@ Error ONNXModelWriter::writeBatchedReduceAdd(const BatchedReduceAddNode *node,
   llvm::ArrayRef<unsigned_t> axes(axis);
   addValueAttribute(proto, "axes", axes);
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("ReduceSum");
   inputsToProto(node, proto);
 
@@ -1608,7 +1608,7 @@ Error ONNXModelWriter::writeBatchedReduceSumSquare(
   llvm::ArrayRef<unsigned_t> axes(axis);
   addValueAttribute(proto, "axes", axes);
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("ReduceSum");
   inputsToProto(node, proto);
 
@@ -1644,7 +1644,7 @@ Error ONNXModelWriter::writeBatchedReduceProd(const BatchedReduceProdNode *node,
   llvm::ArrayRef<unsigned_t> axes(axis);
   addValueAttribute(proto, "axes", axes);
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("ReduceProd");
   inputsToProto(node, proto);
 
@@ -1661,14 +1661,14 @@ Error ONNXModelWriter::writeBatchNormalization(
   addValueAttribute(proto, "epsilon", node->getEpsilon());
   addValueAttribute(proto, "momentum", node->getMomentum());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("BatchNormalization");
 
-  proto->add_input(node->getInput().getNode()->getName());
-  proto->add_input(node->getScale().getNode()->getName());
-  proto->add_input(node->getBias().getNode()->getName());
-  proto->add_input(node->getMean().getNode()->getName());
-  proto->add_input(node->getVar().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
+  proto->add_input(node->getScale().getNode()->getName().str());
+  proto->add_input(node->getBias().getNode()->getName().str());
+  proto->add_input(node->getMean().getNode()->getName().str());
+  proto->add_input(node->getVar().getNode()->getName().str());
 
   outputsToProto(node, graph, proto);
   return Error::success();
@@ -1680,12 +1680,12 @@ Error ONNXModelWriter::writeLayerNormalization(
   // Add dictionary entries.
   addValueAttribute(proto, "epsilon", node->getEpsilon());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("LayerNormalization");
 
-  proto->add_input(node->getInput().getNode()->getName());
-  proto->add_input(node->getScale().getNode()->getName());
-  proto->add_input(node->getBias().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
+  proto->add_input(node->getScale().getNode()->getName().str());
+  proto->add_input(node->getBias().getNode()->getName().str());
 
   outputsToProto(node, graph, proto);
   return Error::success();
@@ -1698,7 +1698,7 @@ Error ONNXModelWriter::writeMeanVarNormalization(
   addValueAttribute(proto, "channel", node->getChannelIdx());
   addValueAttribute(proto, "momentum", node->getMomentum());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("MeanVarianceNormalization");
 
   inputsToProto(node, proto);
@@ -1754,8 +1754,8 @@ Error ONNXModelWriter::writeSlice(const SliceNode *node, GraphType &graph) {
 
 Error ONNXModelWriter::writePow(const PowNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
-  proto->add_input(node->getLHS().getNode()->getName());
+  proto->set_name(node->getName().str());
+  proto->add_input(node->getLHS().getNode()->getName().str());
   outputsToProto(node, graph, proto);
 
   // Find exponent from splat node
@@ -1776,7 +1776,7 @@ Error ONNXModelWriter::writePow(const PowNode *node, GraphType &graph) {
     break;
   }
   default:
-    proto->add_input(RHSN->getName());
+    proto->add_input(RHSN->getName().str());
     break;
   }
 
@@ -1847,21 +1847,21 @@ Error ONNXModelWriter::writeArgMin(const ArgMinNode *node, GraphType &graph) {
 
 Error ONNXModelWriter::writePRelu(const PReluNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("PRelu");
-  proto->add_input(node->getInput().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
 
   const auto *slope = node->getSlope().getNode();
   if (const auto *BN = llvm::dyn_cast<BroadcastNode>(slope)) {
-    proto->add_input(BN->getInput().getNode()->getName());
+    proto->add_input(BN->getInput().getNode()->getName().str());
     reportedNodes_.insert(BN);
   } else if (const SplatNode *SN = llvm::dyn_cast<SplatNode>(slope)) {
     // Conversion a scalar to a tensor is required.
     Tensor scalar = {SN->getValue()};
     auto *tensorProto = addInitializer(graph);
-    tensorProto->set_name(SN->getName());
+    tensorProto->set_name(SN->getName().str());
     writeTensor(scalar, tensorProto, useGlowCustomOps_);
-    proto->add_input(SN->getName());
+    proto->add_input(SN->getName().str());
     reportedNodes_.insert(SN);
   } else {
     return MAKE_ERR("Can't find Splat/Broadcast Node as part of PRelu Node.");
@@ -1994,11 +1994,11 @@ Error ONNXModelWriter::writeResizeBilinear(const ResizeBilinearNode *node,
 
 Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("Softmax");
   outputsToProto(node, graph, proto);
   // Find input from Reshape node
-  proto->add_input(node->getInput().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
 
   // Mark selected input as visited.
   reportedNodes_.insert(node->getSelected().getNode());
@@ -2008,11 +2008,11 @@ Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node, GraphType &graph) {
 Error ONNXModelWriter::writeLogSoftMax(const LogSoftMaxNode *node,
                                        GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("LogSoftmax");
   outputsToProto(node, graph, proto);
   // Find input from Reshape node
-  proto->add_input(node->getInput().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
 
   // Mark selected input as visited.
   reportedNodes_.insert(node->getSelected().getNode());
@@ -2064,7 +2064,7 @@ Error ONNXModelWriter::writeAdaptiveAvgPool(const AdaptiveAvgPoolNode *node,
 Error ONNXModelWriter::writeLocalResponseNormalization(
     const LocalResponseNormalizationNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("LRN");
   outputsToProto(node, graph, proto);
   // Find input from Transpose node
@@ -2073,7 +2073,7 @@ Error ONNXModelWriter::writeLocalResponseNormalization(
   RETURN_ERR_IF_NOT(
       TN,
       "Can't find Transpose Node as part of LocalResponseNormalization Node.");
-  proto->add_input(TN->getInput().getNode()->getName());
+  proto->add_input(TN->getInput().getNode()->getName().str());
   reportedNodes_.insert(TN);
   // Add dictionary entries.
   addValueAttribute(proto, "size", 2 * node->getHalfWindowSize());
@@ -2131,10 +2131,10 @@ void writeTensorwiseQuantizedPool(const T *node, const std::string &op,
                       MPN->getType(MaxPoolNode::ResultIdx)->getOffset());
   }
 
-  proto->add_input(node->getInput().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
   outputsToProto(node, graph, proto);
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type(op);
 }
 
@@ -2179,16 +2179,16 @@ void writePool(const T *node, const std::string &op,
 
   const Node *input = node->getInput().getNode();
   if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {
-    proto->add_input(TN->getInput().getNode()->getName());
+    proto->add_input(TN->getInput().getNode()->getName().str());
     reporter.insert(TN);
   } else if (const ReshapeNode *RSN = llvm::dyn_cast<ReshapeNode>(input)) {
-    proto->add_input(RSN->getInput().getNode()->getName());
+    proto->add_input(RSN->getInput().getNode()->getName().str());
     reporter.insert(RSN);
   } else {
     writeTransposeInput(node, input, proto, graph);
   }
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type(op);
 }
 } // namespace
@@ -2224,10 +2224,10 @@ Error ONNXModelWriter::writeSpaceToDepth(const SpaceToDepthNode *node,
       llvm::dyn_cast<TransposeNode>(node->getInput().getNode());
   RETURN_ERR_IF_NOT(TN,
                     "Can't find Transpose Node as part of SpaceToDepth Node.");
-  proto->add_input(TN->getInput().getNode()->getName());
+  proto->add_input(TN->getInput().getNode()->getName().str());
   reportedNodes_.insert(TN);
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("SpaceToDepth");
   // Add dictionary entries.
   addValueAttribute(proto, "blocksize", node->getBlockSize());
@@ -2506,13 +2506,13 @@ Error ONNXModelWriter::writeRescaleQuantized(const RescaleQuantizedNode *node,
 
 Error ONNXModelWriter::writeGemm(const GemmNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("Gemm");
 
-  proto->add_input(node->getA().getNode()->getName());
-  proto->add_input(node->getB().getNode()->getName());
+  proto->add_input(node->getA().getNode()->getName().str());
+  proto->add_input(node->getB().getNode()->getName().str());
   if (node->getC().getNode()) {
-    proto->add_input(node->getC().getNode()->getName());
+    proto->add_input(node->getC().getNode()->getName().str());
   }
 
   addValueAttribute(proto, "alpha", node->getAlpha());
@@ -2527,15 +2527,15 @@ Error ONNXModelWriter::writeGemm(const GemmNode *node, GraphType &graph) {
 Error ONNXModelWriter::writeFullyConnected(const FullyConnectedNode *node,
                                            GraphType &graph) {
   auto *proto = graph.add_node();
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("FullyConnected");
 
   if (node->getInput().dims().size() != 2) {
     return MAKE_ERR("Don't support input dim other than 2");
   }
-  proto->add_input(node->getInput().getNode()->getName());
-  proto->add_input(node->getWeights().getNode()->getName());
-  proto->add_input(node->getBias().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
+  proto->add_input(node->getWeights().getNode()->getName().str());
+  proto->add_input(node->getBias().getNode()->getName().str());
   outputsToProto(node, graph, proto);
   return Error::success();
 }
@@ -2547,7 +2547,7 @@ Error ONNXModelWriter::writeVectorNorm(const VectorNormNode *node,
   // Add dictionary entries.
   addValueAttribute(proto, "axis", node->getAxis());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("VectorNorm");
   inputsToProto(node, proto);
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5527,8 +5527,8 @@ ExternalFunctionCallNode *Function::createExternalFunctionCall(
     llvm::StringRef name, TypeRef outTy, llvm::ArrayRef<glow::NodeValue> inputs,
     llvm::StringRef funcName, llvm::StringRef funcImpl,
     llvm::StringRef funcKind) {
-  return addNode(new ExternalFunctionCallNode(name, outTy, inputs, funcName,
-                                              funcImpl, funcKind));
+  return addNode(new ExternalFunctionCallNode(name.str(), outTy, inputs, funcName.str(),
+                                              funcImpl.str(), funcKind.str()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -195,8 +195,7 @@ TensorLayoutDescription::TensorLayoutDescription(
   }
 }
 
-const llvm::StringRef
-TensorLayoutDescription::getNthDimDescription(size_t n) const {
+const llvm::StringRef TensorLayoutDescription::getNthDimDescription(size_t n) const {
   assert(n < numDims_ && "Wrong dimension number");
   return dims_[n];
 }
@@ -261,8 +260,8 @@ llvm::StringRef TensorLayoutDescription::setAttribute(size_t n,
   removeAttribute(name.str(), dimStr);
   // Add new name information to dim:
   dimStr.append("[");
-  dimStr.append(name);
-  dimStr.append(value);
+  dimStr.append(name.str());
+  dimStr.append(value.str());
   dimStr.append("]");
   reconstructSerialized();
   return dimStr;
@@ -271,7 +270,7 @@ llvm::StringRef TensorLayoutDescription::setAttribute(size_t n,
 std::string TensorLayoutDescription::getAttribute(size_t n,
                                                   llvm::StringRef name) const {
   assert(n < numDims_ && "Wrong dimension number");
-  size_t pos = dims_[n].find(name);
+  size_t pos = dims_[n].find(name.str());
   if (pos == std::string::npos) {
     return "";
   }
@@ -567,7 +566,7 @@ std::string TensorLayoutCommon::getNthResultLayoutRequirements(const Node *node,
         input.dims().size());
     auto shuffle = TN->getShuffle();
     for (unsigned idx = 0, e = inputLayoutHelper.getNumDims(); idx < e; ++idx) {
-      dims[shuffle[idx]] = inputLayoutHelper.getNthDimDescription(idx);
+      dims[shuffle[idx]] = inputLayoutHelper.getNthDimDescription(idx).str();
     }
     TensorLayoutDescription tld(dims);
     return tld.getSerializedLayout();

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -6102,7 +6102,7 @@ Error ONNXModelLoader::setupPartitions(ONNX_NAMESPACE::ModelProto &modelDef,
                                        PrePartitionedConfig &PPC,
                                        llvm::StringRef rootName,
                                        int numPartitions) {
-  PPC.funcName = rootName;
+  PPC.funcName = rootName.str();
   PPC.resizeAndReserve(numPartitions);
 
   for (int i = 0; i < numPartitions; i++) {
@@ -6259,7 +6259,7 @@ Error ONNXModelLoader::setupUpdatedTQPMap(
                                 "of updatedTQPs_ %lu",
                                 idx, updatedTQPs_.size()));
 
-    auto it = originNameToTQPMap.find(nameOffsetPair.first);
+    auto it = originNameToTQPMap.find(nameOffsetPair.first.str());
     RETURN_ERR_IF_NOT(it != originNameToTQPMap.end(),
                       strFormat("Did not find matching TQP for %s",
                                 nameOffsetPair.first.str().data()));

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -206,7 +206,7 @@ void ProtobufLoader::deleteUnusedConstants() {
     auto *node = kv.second.getNode();
     if (auto *c = llvm::dyn_cast<Constant>(node)) {
       if (!c->hasUsers()) {
-        nodeValuesToRemove.push_back(kv.getKey());
+        nodeValuesToRemove.push_back(kv.getKey().str());
         constantToRemove.insert(c);
       }
     }

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -175,7 +175,7 @@ BundleSaver::BundleSaver(const LLVMBackend &llvmBackend,
       bundleAPI_(llvmBackend.getOptions().getBundleAPI()) {
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
-  irgen_->setBundleName(bundleName);
+  irgen_->setBundleName(bundleName.str());
   irgen_->setOutputDir(outputDir);
   irgen_->setObjectRegistry(llvmBackend.getObjectRegistry());
   // Use the bundle code model as a code model for the TargetMachine.
@@ -189,7 +189,7 @@ void BundleSaver::setIRFunction(llvm::StringRef mainEntryName,
                                 const IRFunction *F) {
   irgen_->setIRFunction(F);
   if (F) {
-    savedIRFunctions_.push_back(SavedIRFunction{mainEntryName, F});
+    savedIRFunctions_.push_back(SavedIRFunction{mainEntryName.str(), F});
   }
 }
 
@@ -739,7 +739,7 @@ void BundleSaver::performBundleMemoryAllocation() {
 
 void BundleSaver::save(llvm::StringRef mainEntryName, const IRFunction *F) {
   // Object files generation works properly only in small mode.
-  irgen_->setMainEntryName(mainEntryName);
+  irgen_->setMainEntryName(mainEntryName.str());
   // Set current IRFunction using the legalized name.
   setIRFunction(irgen_->getMainEntryName(), F);
   // irgen_->initCodeGen();

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -25,7 +25,7 @@
 #include "glow/IR/Instrs.h"
 #include "glow/Optimizer/IROptimizer/IROptimizer.h"
 #include "glow/Support/Debug.h"
-
+#include "llvm/Support/Host.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/IRBuilder.h"
@@ -598,7 +598,7 @@ llvm::SmallVector<std::string, 0> LLVMBackend::getHostFeatures() {
         if (fn.startswith("avx512")) {
           continue;
         }
-        result.push_back(fn);
+        result.push_back(fn.str());
       }
     }
   }

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -39,7 +39,7 @@ void LLVMCompiledFunction::loadPlaceholders(
   // Copy Placeholders into allocated memory.
   auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto &PH : bindings->pairs()) {
-    auto it = symbolTable.find(PH.first->getName());
+    auto it = symbolTable.find(PH.first->getName().str());
     if (it == symbolTable.end()) {
       continue;
     }
@@ -58,7 +58,7 @@ void LLVMCompiledFunction::updatePlaceholders(
   // Copy placeholders from device back into bindings.
   auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto &PH : bindings->pairs()) {
-    auto it = symbolTable.find(PH.first->getName());
+    auto it = symbolTable.find(PH.first->getName().str());
     if (it == symbolTable.end()) {
       continue;
     }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -680,9 +680,10 @@ llvm::Value *LLVMIRGen::emitStringConst(llvm::IRBuilder<> &builder,
   llvm::GlobalVariable *gvarStr = new llvm::GlobalVariable(
       *llmodule_, constStrArray->getType(), true,
       llvm::GlobalValue::PrivateLinkage, constStrArray, ".str");
-  gvarStr->setAlignment(1);
+  gvarStr->setAlignment(llvm::MaybeAlign(1));
   // Add unnamed_addr attribute to enable constmerge pass.
   gvarStr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+
   return builder.CreateBitCast(gvarStr, builder.getInt8PtrTy());
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -447,7 +447,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
                   << " partial size=" << inputTensor.getUnpaddedSizeInBytes()
                   << " resized size=" << resized.getType().toString();
         }
-        t->set_name(p.first->getName());
+        t->set_name(p.first->getName().str());
       }
       std::string buffer;
       inputG.SerializeToString(&buffer);
@@ -543,7 +543,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
         auto *t = inputG.add_initializer();
         ONNXModelWriter::writeTensor(outputTensor, t,
                                      glow::flags::UseCustomOpsForExport);
-        t->set_name(outPhPtr->getName());
+        t->set_name(outPhPtr->getName().str());
       }
       std::string buffer;
       inputG.SerializeToString(&buffer);

--- a/lib/Onnxifi/GlowOnnxifiManager.cpp
+++ b/lib/Onnxifi/GlowOnnxifiManager.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<runtime::HostManager>
 GlowOnnxifiManager::getOrCreateHostManager(llvm::StringRef backendName) {
   std::shared_ptr<runtime::HostManager> hostManager;
 
-  auto it = hostManagers_.find(backendName);
+  auto it = hostManagers_.find(backendName.str());
 
   if (it != hostManagers_.end()) {
     hostManager = it->second.lock();
@@ -92,7 +92,7 @@ GlowOnnxifiManager::getOrCreateHostManager(llvm::StringRef backendName) {
   if (!hostManager) {
     hostManager = onnxifi::HostManagerBackend::createHostManager(backendName);
     assert(hostManager);
-    hostManagers_[backendName] = hostManager;
+    hostManagers_[backendName.str()] = hostManager;
   }
 
   return hostManager;

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -431,18 +431,18 @@ Expected<DAGListTy> Partitioner::createDAGWithoutPartition(
   const DeviceIDTy logDevice = 0;
   for (auto F : module_->getFunctions()) {
     if (!optimized_) {
-      auto backend = backendMap[backendName].backend;
+      auto backend = backendMap[backendName.str()].backend;
       RETURN_IF_ERR(::glow::optimizeFunction(
           F, *backend, cctx, &getDeviceInfoForBackend(backendName)));
     }
     std::unique_ptr<DAGNode> DAG0 = glow::make_unique<DAGNode>();
     DAG0->logicalDevices = {logDevice};
-    DAG0->name = F->getName();
+    DAG0->name = F->getName().str();
     DAG0->module = module_;
     std::unique_ptr<DAGNode> DAG1 = glow::make_unique<DAGNode>();
     DAG1->logicalDevices = {logDevice};
-    DAG1->name = F->getName();
-    DAG1->backendName = backendName;
+    DAG1->name = F->getName().str();
+    DAG1->backendName = backendName.str();
     DAG1->parents.push_back(DAG0.get());
     DAG0->children.push_back(DAG1.get());
     DAG1->replicationCount = cctx.replicationCount;
@@ -1034,7 +1034,7 @@ Partitioner::setupPrepartitionedModule(CompilationContext &cctx) {
   if (cctx.saturateHost) {
     // Use the config's logical IDs to determine how many cards it's using.
     llvm::SmallSet<DeviceIDTy, 6> allLogicalIDs;
-    for (const auto IDs : config.logicalIDs) {
+    for (const auto &IDs : config.logicalIDs) {
       for (const auto &id : IDs) {
         allLogicalIDs.insert(id);
       }

--- a/lib/Partitioner/PartitionerBase.cpp
+++ b/lib/Partitioner/PartitionerBase.cpp
@@ -27,7 +27,7 @@ using llvm::isa;
 static std::unique_ptr<DAGNode>
 createDAGNodeFromFun(Function *F, NodeToFunctionMap &mapping) {
   std::unique_ptr<DAGNode> DN = glow::make_unique<DAGNode>();
-  DN->name = F->getName();
+  DN->name = F->getName().str();
   DN->logicalDevices = mapping.getLogicalDeviceIDList(F);
   DN->backendName = mapping.getPartitionBackendName(F);
   DN->size = mapping.getGraphMemInfo(F).getTotalMemSize();
@@ -47,7 +47,7 @@ DAGListTy PartitionerBase::doPartitioning(
   DAGNodePtr DAGRoot = glow::make_unique<DAGNode>();
   DAGNodePtrVec nodes;
   DAGRoot->logicalDevices = {0};
-  DAGRoot->name = funcName;
+  DAGRoot->name = funcName.str();
   DAGRoot->module = module;
   DAGNode *root = DAGRoot.get();
 
@@ -196,7 +196,7 @@ void PartitionerBase::dumpDAG(llvm::StringRef dotFilename,
   LOG(INFO) << "Writing dotty graph for DAG after graph partitioning: "
             << dotFilename.str();
   std::ofstream myfile;
-  myfile.open(dotFilename);
+  myfile.open(dotFilename.str());
   myfile << "digraph DAG {\n\trankdir=TB;\n";
   // Dump DAGNodes
   std::vector<DAGNode *> nodes;

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -956,7 +956,7 @@ findAndInsertLoweredInfos(llvm::StringRef currName,
   // also lowered from a previous node.
   for (auto i = currSet.begin(), e = currSet.end(); i != e; ++i) {
     llvm::StringRef currOrigName = i->getName();
-    profilingInfos.emplace_back(currOrigName, TPP);
+    profilingInfos.emplace_back(currOrigName.str(), TPP);
     findAndInsertLoweredInfos(currOrigName, loweredMap, profilingInfos, TPP);
   }
 }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -325,10 +325,9 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     for (auto &device : availableDevices_) {
       DeviceInfo info = devices_[device]->getDeviceInfo();
       info.availableMemory = devices_[device]->getAvailableMemory();
-      info.backendName = devices_[device]->getBackendName();
-      info.nonSupportedNodes =
-          devices_[device]->getParamByName("nonSupportedNodes");
-      info.supportedNodes = devices_[device]->getParamByName("supportedNodes");
+      info.backendName = devices_[device]->getBackendName().str();
+      info.nonSupportedNodes =devices_[device]->getParamByName("nonSupportedNodes").str();
+      info.supportedNodes = devices_[device]->getParamByName("supportedNodes").str();
       // If p2p is enabled update the inputCount limit.
       if (cctx.enableP2P) {
         info.inputCountMax = P2PInputLimit;
@@ -1002,7 +1001,7 @@ HostManager::runNetwork(llvm::StringRef networkName,
     }
     reportCurrentQueueSize(queueSize);
     // Setup the request
-    InferRequest queuedRequest(networkName, std::move(context), callback,
+    InferRequest queuedRequest(networkName.str(), std::move(context), callback,
                                priority, currentRun, requestReceived);
     {
       std::unique_lock<std::shared_timed_mutex> lock(inferQueueLock_);

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -98,7 +98,13 @@ std::string separateString(const std::string &str, size_t length,
   assert(sepStr.size() == outSize && "Inconsistent string separation!");
   return sepStr;
 }
-
+  std::string separateString(llvm::StringRef str, size_t length,
+			     const std::string &delimiter)
+  {
+    std::string str1=str.str();
+    return separateString(str1,length,delimiter);
+    
+  }
 std::string escapeDottyString(const std::string &str) {
   std::string out;
   out.reserve(str.capacity());

--- a/tests/Testing/StrCheck.cpp
+++ b/tests/Testing/StrCheck.cpp
@@ -20,26 +20,26 @@
 using glow::StrCheck;
 
 StrCheck &StrCheck::check(llvm::StringRef needle) {
-  size_t found = input_.find(needle, pos_);
+  size_t found = input_.find(needle.str(), pos_);
   return found != std::string::npos ? match(found, needle.size())
                                     : fail("not found: check", needle);
 }
 
 StrCheck &StrCheck::sameln(llvm::StringRef needle) {
-  size_t found = input_.find(needle, pos_);
+  size_t found = input_.find(needle.str(), pos_);
   return found < findEol() ? match(found, needle.size())
                            : fail("not found: sameln", needle);
 }
 
 StrCheck &StrCheck::nextln(llvm::StringRef needle) {
   size_t eol = findEol();
-  size_t found = input_.find(needle, eol);
+  size_t found = input_.find(needle.str(), eol);
   return found < findEol(eol) ? match(found, needle.size())
                               : fail("not found: nextln", needle);
 }
 
 StrCheck &StrCheck::no(llvm::StringRef needle) {
-  nos_.push_back(needle);
+  nos_.push_back(needle.str());
   return *this;
 }
 

--- a/tests/benchmark/ResNetBench.cpp
+++ b/tests/benchmark/ResNetBench.cpp
@@ -405,7 +405,7 @@ private:
           false);
       Placeholder *output = builder.build(input, F);
       FunctionBundle bundle;
-      bundle.name = F->getName();
+      bundle.name = F->getName().str();
       bundle.input = input;
       bundle.output = output;
       res.push_back(std::move(bundle));

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -465,9 +465,9 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
   auto table = dag->nodes[0]->runtimeBundle->getSymbolTable();
 
   // Check that placeholders and constants are correctly labelled.
-  EXPECT_EQ(table.find(S->getPlaceholder()->getName())->second.symbolCategory,
+  EXPECT_EQ(table.find(S->getPlaceholder()->getName().str())->second.symbolCategory,
             glow::runtime::SymbolCategory::Placeholder);
-  EXPECT_EQ(table.find(ex->getName())->second.symbolCategory,
+  EXPECT_EQ(table.find(ex->getName().str())->second.symbolCategory,
             glow::runtime::SymbolCategory::Constant);
   // Check that activations are labelled correctly.
   EXPECT_EQ(table.find("FC_res")->second.symbolCategory,
@@ -478,15 +478,15 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
             glow::runtime::SymbolCategory::PlaceholderTensorView);
 
   // Check that placeholders and constants input/output flags are correctly set.
-  EXPECT_EQ(table.find(S->getPlaceholder()->getName())->second.input, false);
-  EXPECT_EQ(table.find(S->getPlaceholder()->getName())->second.output, true);
-  EXPECT_EQ(table.find(ex->getName())->second.input, false);
-  EXPECT_EQ(table.find(ex->getName())->second.output, false);
-  EXPECT_EQ(table.find(input->getName())->second.input, true);
-  EXPECT_EQ(table.find(input->getName())->second.output, false);
-  EXPECT_EQ(table.find(qp->getHistogramPlaceholder()->getName())->second.input,
+  EXPECT_EQ(table.find(S->getPlaceholder()->getName().str())->second.input, false);
+  EXPECT_EQ(table.find(S->getPlaceholder()->getName().str())->second.output, true);
+  EXPECT_EQ(table.find(ex->getName().str())->second.input, false);
+  EXPECT_EQ(table.find(ex->getName().str())->second.output, false);
+  EXPECT_EQ(table.find(input->getName().str())->second.input, true);
+  EXPECT_EQ(table.find(input->getName().str())->second.output, false);
+  EXPECT_EQ(table.find(qp->getHistogramPlaceholder()->getName().str())->second.input,
             true);
-  EXPECT_EQ(table.find(qp->getHistogramPlaceholder()->getName())->second.output,
+  EXPECT_EQ(table.find(qp->getHistogramPlaceholder()->getName().str())->second.output,
             true);
   // Check that activations are labelled correctly.
   EXPECT_EQ(table.find("FC_res")->second.input, false);
@@ -1009,8 +1009,8 @@ TEST_P(BackendExecTest, BundleSharedConstant) {
   auto table1 = function->getRuntimeBundle().getSymbolTable();
   auto table2 = function2->getRuntimeBundle().getSymbolTable();
   /// Make sure X is in both tables.
-  auto it = table1.find(X->getName());
-  auto it2 = table2.find(X->getName());
+  auto it = table1.find(X->getName().str());
+  auto it2 = table2.find(X->getName().str());
   EXPECT_TRUE(it != table1.end());
   EXPECT_TRUE(it2 != table2.end());
 }

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -685,7 +685,7 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   for (auto *EE : engines) {
     auto &mod = EE->getModule();
     Function *F = mod.createFunction("main");
-    fName = F->getName();
+    fName = F->getName().str();
     var1 = createPlaceholder(mod, bindings, inputs, "var1");
     var2 = createPlaceholder(mod, bindings, selected, "var2");
     auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
@@ -740,7 +740,7 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   for (auto *EE : engines) {
     auto &mod = EE->getModule();
     Function *F = mod.createFunction("main");
-    fName = F->getName();
+    fName = F->getName().str();
     var1 = createPlaceholder(mod, bindings, inputs, "var1");
     var2 = createPlaceholder(mod, bindings, selected, "var2");
     auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
@@ -1359,7 +1359,7 @@ void inferMaxSplat(Tensor *input, Tensor *out, llvm::StringRef kind) {
 void insertCompiledFunction(llvm::StringRef name, CompiledFunction *func,
                             runtime::DeviceManager *device, Module *mod) {
   runtime::FunctionMapTy functionMap;
-  functionMap[name] = func;
+  functionMap[name.str()] = func;
 
   std::promise<void> addPromise;
   auto fut = addPromise.get_future();
@@ -1380,7 +1380,7 @@ void runOnDevice(ExecutionContext &context, llvm::StringRef name,
   auto fut = runPromise.get_future();
   Error runErr = Error::empty();
   device->runFunction(
-      name, std::move(contextPtr),
+		      name.str(), std::move(contextPtr),
       [&runPromise, &runErr](runtime::RunIdentifierTy, Error err,
                              std::unique_ptr<ExecutionContext> contextPtr) {
         // Don't delete context.

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1034,7 +1034,7 @@ TEST_F(Caffe2ImporterTest, batchMatMulManyDims) {
       {{2, 4, 5}, {3, 2, 5, 6}, {3, 2, 4, 6}},
   };
 
-  for (const auto shapes : shape_cases) {
+  for (const auto &shapes : shape_cases) {
     ExecutionEngine EE{};
     auto &mod = EE.getModule();
     Function *F = mod.createFunction("main");
@@ -2683,7 +2683,7 @@ TEST_F(Caffe2ImporterTest, HalfToFloat) {
     // Loaded protos must have at least one external output, so load an unused
     // output and type to satisfy it. It is named unused_output in
     // empty_predict_net.pbtxt.
-    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X"},
+    Caffe2ModelLoader caffe2LD(NetDescFilename.str(), NetWeightFilename, {"X"},
                                {&input.getType()}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
@@ -2721,7 +2721,7 @@ TEST_F(Caffe2ImporterTest, Alias) {
     // Loaded protos must have at least one external output, so load an unused
     // output and type to satisfy it. It is named unused_output in
     // empty_predict_net.pbtxt.
-    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X"},
+    Caffe2ModelLoader caffe2LD(NetDescFilename.str(), NetWeightFilename, {"X"},
                                {&input.getType()}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
@@ -4857,7 +4857,7 @@ TEST_F(Caffe2ImporterTest, reduceBackSum) {
         {64, 64, 11},
         {2, 3, 4, 5},
     };
-    for (const auto inputShape : inputShapes) {
+    for (const auto &inputShape : inputShapes) {
       ExecutionEngine EE{};
       auto &mod = EE.getModule();
       Function *F = mod.createFunction("main");

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -937,7 +937,7 @@ TEST(Graph, moduleCloneTest) {
     C->getPayloadMutable().getHandle().clear(1.0f);
     auto *SM = F->createAdd("add", concat, C);
     auto *SN = F->createSave("Save", SM);
-    resultName = SN->getPlaceholder()->getName();
+    resultName = SN->getPlaceholder()->getName().str();
 
     // Clone the original module into the cloned module.
     originalM.clone(&clonedM);

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<HostManager>
 createHostManager(llvm::StringRef backendName,
                   HostConfig hostConfig = HostConfig()) {
   std::vector<std::unique_ptr<DeviceConfig>> configs =
-      generateConfigs(backendName, 1);
+    generateConfigs(std::string(backendName), 1);
   std::unique_ptr<HostManager> hostManager =
       glow::make_unique<HostManager>(std::move(configs), hostConfig);
   return hostManager;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1163,7 +1163,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
     auto *FCL = F->createFullyConnected(inferBindings, "fc", TANH, 2);
     auto *SM = F->createSoftMax("sm", FCL, ex);
     F->createSave("ret", SM);
-    fName = F->getName();
+    fName = F->getName().str();
   }
 
   auto *mod = &EET_.getModule();
@@ -1300,7 +1300,7 @@ TEST_P(MLTest, testFindPixelRegression) {
     auto *FC1 = F->createFullyConnected(inferBindings, "fc1", RL0, 2);
     auto *R = F->createRegression("regression", FC1, ex);
     F->createSave("ret", R);
-    fName = F->getName();
+    fName = F->getName().str();
   }
 
   auto *mod = &EET_.getModule();

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -184,8 +184,8 @@ static Placeholder *createPlaceholderConditionallyQuantized(
     Module &mod, ElemKind T, llvm::ArrayRef<dim_t> dims, llvm::StringRef name,
     bool isTrainable, llvm::StringRef layout = ANY_LAYOUT) {
   return isQuantizedElemKind(T)
-             ? mod.createPlaceholder(T, dims, 1.0, 0, name, isTrainable, layout)
-             : mod.createPlaceholder(T, dims, name, isTrainable, layout);
+    ? mod.createPlaceholder(T, dims, 1.0, 0, name.str(), isTrainable, layout.str())
+    : mod.createPlaceholder(T, dims, name.str(), isTrainable, layout.str());
 }
 
 /// Helper to get a unique Type; if \p T is quantized, then it will include a

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -44,7 +44,7 @@ static void executeDAG(DAGNode *G, Module &mod, PlaceholderBindings &bindings,
   std::unordered_map<std::string, Function *> name2func;
 
   for (auto *F : mod.getFunctions()) {
-    name2func[F->getName()] = F;
+    name2func[F->getName().str()] = F;
   }
 
   std::vector<DAGNode *> exeList;
@@ -591,7 +591,7 @@ TEST_F(PartitionerTest, Basic1Roofline) {
                                        *backend, cctx));
   std::unordered_map<Node *, std::string> nodeNamesMap;
   for (auto &node : EEP.getModule().getFunction("main")->getNodes()) {
-    nodeNamesMap[&node] = node.getName();
+    nodeNamesMap[&node] = node.getName().str();
   }
 
   // check compute costs

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -413,7 +413,7 @@ protected:
       const auto &resultTensor = pair.second;
       ONNXModelWriter::writeTensor(resultTensor, t,
                                    /*useGlowCustomOps*/ true);
-      t->set_name(PH->getName());
+      t->set_name(PH->getName().str());
     }
     std::string buffer;
     inputG.SerializeToString(&buffer);

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -696,7 +696,7 @@ int run() {
     std::copy_if(placeholderList.begin(), placeholderList.end(),
                  std::back_inserter(inputPlaceholderList),
                  [&](const glow::Placeholder *p) {
-                   return inputTensorNames.find(p->getName()) !=
+                   return inputTensorNames.find(p->getName().str()) !=
                           inputTensorNames.end();
                  });
 

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -37,15 +37,15 @@ public:
   }
 
   void addTimeSeriesValue(llvm::StringRef key, double value) override {
-    timeSeries[key].push_back(value);
+    timeSeries[key.str()].push_back(value);
   }
 
   void incrementCounter(llvm::StringRef key, int64_t value) override {
-    counters[key] += value;
+    counters[key.str()] += value;
   }
 
   void setCounter(llvm::StringRef key, int64_t value) override {
-    counters[key] = value;
+    counters[key.str()] = value;
   }
 
   void clear() {

--- a/tests/unittests/TFLiteImporterTest.cpp
+++ b/tests/unittests/TFLiteImporterTest.cpp
@@ -92,7 +92,7 @@ static void loadAndRunModel(std::string modelName, float maxError = 1e-6) {
 
   // Load data into the input placeholders.
   size_t dotPos = llvm::StringRef(modelPath).find_first_of('.');
-  std::string dataBasename = llvm::StringRef(modelPath).substr(0, dotPos);
+  std::string dataBasename = std::string(modelPath).substr(0, dotPos);
   size_t inpIdx = 0;
   for (const auto &inpPH : inputPH) {
     std::string inpFilename = dataBasename + ".inp" + std::to_string(inpIdx++);

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -1649,10 +1649,10 @@ static void tensorInputWriterLoader(ImageLayout outImageLayout,
   if (tempFileRes.value() != 0) {
     FAIL() << "Failed to create temp file to write into.";
   }
-  dumpInputTensorToFileWithType({path.str()}, tensorRef, outImageLayout);
+  dumpInputTensorToFileWithType({std::string(path)}, tensorRef, outImageLayout);
   //
   Tensor tensorTest;
-  loadInputImageFromFileWithType({path.str()}, &tensorTest, inImageLayout);
+  loadInputImageFromFileWithType({std::string(path)}, &tensorTest, inImageLayout);
 
   if (outImageLayout == ImageLayout::NHWC) {
     Tensor transposed;

--- a/tests/unittests/ThreadPoolExecutorTest.cpp
+++ b/tests/unittests/ThreadPoolExecutorTest.cpp
@@ -351,7 +351,7 @@ public:
     // later.
     if (!parents.empty()) {
       for (const auto &parent : parents) {
-        auto it = nodes_.find(parent);
+        auto it = nodes_.find(parent.str());
         if (it == nodes_.end()) {
           assert(!"Parent specified for node not found!");
         }

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -425,7 +425,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
   cctx.backendOpts.collectConstants = true;
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
 
-  std::string name = F->getName();
+  std::string name = F->getName().str();
   auto config =
       glow::make_unique<runtime::DeviceConfig>(backend->getBackendName());
   std::unique_ptr<runtime::DeviceManager> device(

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -217,12 +217,12 @@ public:
 
   /// Automatically generates verification of type \p verif
   InstrBuilder &autoVerify(VerifyKind verif,
-                           llvm::ArrayRef<llvm::StringRef> operands = {""}) {
+                           llvm::ArrayRef<std::string> operands = {""}) {
     if (verif != VerifyKind::NoVerify) {
       assert(operands.size() > 1 && "Must list 2 or more operands.");
     }
     auto newPair = std::make_pair(verif, std::vector<std::string>());
-    newPair.second.insert(newPair.second.begin(), operands.begin(),
+    newPair.second.insert(newPair.second.begin(),operands.begin(),
                           operands.end());
     autoVerificationPairs_.push_back(newPair);
     return *this;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -356,7 +356,7 @@ static void getModelInputs(std::vector<std::string> &inputNames,
                                 std::string(name).c_str());
       }
     }
-    inputNames.push_back(name);
+    inputNames.push_back(name.str());
 
     if (!inputTypes) {
       continue;
@@ -464,7 +464,7 @@ void Loader::loadModel(PlaceholderBindings *bindings,
     // explicitly (mandatory).
     std::unique_ptr<ProtobufLoader> protoLoader;
     protoLoader.reset(new Caffe2ModelLoader(
-        getCaffe2NetDescFilename(), getCaffe2NetWeightFilename(), inputNameRefs,
+					    getCaffe2NetDescFilename().str(), getCaffe2NetWeightFilename().str(), inputNameRefs,
         inputTypeRefs, *getFunction()));
     // Load the maps between original model names and the placeholders.
     inputPlaceholderByName_ = protoLoader->getInputVarsMapping();
@@ -476,8 +476,7 @@ void Loader::loadModel(PlaceholderBindings *bindings,
   } else if (!getTFLiteModelFilename().empty()) {
     // For TensorFlowLite format the input placeholder names/types are not
     // provided since are used directly from the model.
-    auto tfliteLoader = glow::make_unique<TFLiteModelLoader>(
-        getTFLiteModelFilename(), getFunction());
+    auto tfliteLoader = glow::make_unique<TFLiteModelLoader>(getTFLiteModelFilename().str(), getFunction());
     // Load the maps between original model names and the placeholders.
     inputPlaceholderByName_ = tfliteLoader->getInputPlaceholderMap();
     outputPlaceholderByName_ = tfliteLoader->getOutputPlaceholderMap();
@@ -508,7 +507,7 @@ void Loader::loadModel(PlaceholderBindings *bindings,
     // the input placeholder types in order to override the placeholder sizes
     // (one such example is the batch size).
     std::unique_ptr<ProtobufLoader> protoLoader;
-    protoLoader.reset(new ONNXModelLoader(getOnnxModelFilename(), inputNameRefs,
+    protoLoader.reset(new ONNXModelLoader(getOnnxModelFilename().str(), inputNameRefs,
                                           inputTypeRefs, *getFunction()));
     // Load the maps between original model names and the placeholders.
     inputPlaceholderByName_ = protoLoader->getInputVarsMapping();
@@ -546,7 +545,7 @@ static bool commandLineIsInvalid() {
         for (auto it = llvm::sys::path::rbegin(modelPathOpt[0]),
                   end = llvm::sys::path::rend(modelPathOpt[0]);
              it != end; ++it) {
-          networkName = *it;
+          networkName = std::string(*it);
           // Strip extension (if any).
           size_t lastDotPos = networkName.find_last_of(".");
           if (lastDotPos != std::string::npos) {

--- a/tools/loader/LoaderUtils.cpp
+++ b/tools/loader/LoaderUtils.cpp
@@ -39,7 +39,7 @@ glow::readUnlabeledDataSetFromFile(llvm::StringRef dataSetFile,
             strFormat("The dataset path '%s' is not a directory!",
                       dataSetDirPath.data()));
   // Parse the dataset file.
-  std::ifstream inpFile(dataSetFile);
+  std::ifstream inpFile(dataSetFile.str());
   checkCond(inpFile.is_open(), strFormat("Cannot open the dataset file '%s'!",
                                          dataSetFile.data()));
   std::string line;
@@ -100,7 +100,7 @@ LabeledDataSet glow::readLabeledDataSet(llvm::StringRef dataSetFile,
             strFormat("The dataset path '%s' is not a directory!",
                       dataSetDirPath.data()));
   // Parse the dataset file.
-  std::ifstream inpFile(dataSetFile);
+  std::ifstream inpFile(dataSetFile.str());
   checkCond(inpFile.is_open(), strFormat("Cannot open the dataset file '%s'!",
                                          dataSetFile.data()));
   std::string line;

--- a/tools/loader/ModelProfiler.cpp
+++ b/tools/loader/ModelProfiler.cpp
@@ -117,21 +117,21 @@ getInputDatasets(std::vector<std::string> &inputNames,
     auto strPair = llvm::StringRef(str).split(',');
     llvm::StringRef name = strPair.first;
     checkCond(name.size(), "Model input name for dataset is empty!");
-    inputNames.push_back(name);
+    inputNames.push_back(name.str());
     // Parse format.
     strPair = strPair.second.split(',');
     llvm::StringRef format = strPair.first;
     checkCond(format.size(),
               strFormat("Model input dataset format is empty for '%s'!",
                         name.data()));
-    inputFormats.push_back(format);
+    inputFormats.push_back(format.str());
     // Parse source.
     strPair = strPair.second.split(',');
     llvm::StringRef source = strPair.first;
     checkCond(source.size(),
               strFormat("Model input dataset source is empty for '%s'!",
                         name.data()));
-    inputSources.push_back(source);
+    inputSources.push_back(source.str());
     // Parse options (optional).
     std::vector<std::string> options;
     while (strPair.second.size() != 0) {
@@ -140,7 +140,7 @@ getInputDatasets(std::vector<std::string> &inputNames,
       checkCond(opt.size(),
                 strFormat("Model input dataset options is empty for '%s'!",
                           name.data()));
-      options.push_back(opt);
+      options.push_back(opt.str());
     }
     inputOptions.push_back(options);
   }

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -36,11 +36,11 @@ int main(int argc, char **argv) {
   // Create the model based on the input net, and get SaveNode for the output.
   std::unique_ptr<ProtobufLoader> LD;
   if (!loader.getCaffe2NetDescFilename().empty()) {
-    LD.reset(new Caffe2ModelLoader(loader.getCaffe2NetDescFilename(),
-                                   loader.getCaffe2NetWeightFilename(), {}, {},
+    LD.reset(new Caffe2ModelLoader(loader.getCaffe2NetDescFilename().str(),
+                                   loader.getCaffe2NetWeightFilename().str(), {}, {},
                                    *loader.getFunction()));
   } else {
-    LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
+    LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename().str(), {}, {},
                                  *loader.getFunction()));
   }
   Placeholder *output = EXIT_ON_ERR(LD->getSingleOutput());

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -100,7 +100,7 @@ public:
     DCHECK(spaceIdx != llvm::StringRef::npos)
         << "Unexpected format for dict file.";
 
-    auto word = line.take_front(spaceIdx);
+    auto word = std::string(line.take_front(spaceIdx));
     DCHECK_GT(word.size(), 0) << "Did not find word correctly.";
 
     word2index_[word] = index2word_.size();
@@ -112,7 +112,7 @@ public:
   /// Load a dictionary from text file \p filename, adding each word from each
   /// line of the file.
   void loadDictionaryFromFile(llvm::StringRef filename) {
-    std::ifstream file(filename);
+    std::ifstream file(filename.str());
     std::string word;
     while (getline(file, word)) {
       addWord(word);
@@ -121,7 +121,7 @@ public:
 
   /// Get the index for the input \p word from the dictionary.
   size_t getIdxFromWord(llvm::StringRef word) {
-    auto iter = word2index_.find(word);
+    auto iter = word2index_.find(word.str());
     // If unknown word, return the index for unknown.
     if (iter == word2index_.end()) {
       return unkIdx;
@@ -158,7 +158,7 @@ static void encodeString(const llvm::StringRef sentence,
   encodedWords.reserve(maxInputLenOpt);
 
   // Get each word from the sentence and encode it.
-  std::istringstream iss(sentence);
+  std::istringstream iss(sentence.str());
   std::string word;
   while (iss >> word) {
     auto idx = srcVocab.getIdxFromWord(word);
@@ -368,8 +368,8 @@ int main(int argc, char **argv) {
       &encoderInputs.getType(), &attnWeights.getType(),
       &prevHyposIndices.getType(), &prevScores.getType(), &prevToken.getType()};
 
-  Caffe2ModelLoader LD(loader.getCaffe2NetDescFilename(),
-                       loader.getCaffe2NetWeightFilename(), inputNames,
+  Caffe2ModelLoader LD(loader.getCaffe2NetDescFilename().str(),
+                       loader.getCaffe2NetWeightFilename().str(), inputNames,
                        inputTensors, *loader.getFunction());
 
   // Allocate tensors to back all inputs and outputs.

--- a/tools/loader/XModelBuilder.cpp
+++ b/tools/loader/XModelBuilder.cpp
@@ -103,10 +103,11 @@ createProtobufLoader(Loader &loader, const TypeRef inputType) {
 
   if (caffe2Model) {
     ptbLoader.reset(new Caffe2ModelLoader(
-        loader.getCaffe2NetDescFilename(), loader.getCaffe2NetWeightFilename(),
+					  loader.getCaffe2NetDescFilename().str(),
+					  loader.getCaffe2NetWeightFilename().str(),
         {modelInputName.c_str()}, {inputType}, *loader.getFunction()));
   } else {
-    ptbLoader.reset(new ONNXModelLoader(loader.getOnnxModelFilename(),
+    ptbLoader.reset(new ONNXModelLoader(loader.getOnnxModelFilename().str(),
                                         {modelInputName.c_str()}, {inputType},
                                         *loader.getFunction()));
   }


### PR DESCRIPTION
Summary: LLVM>=11 no longer supports implicit conversion from  llvm::StringRef-> std::string . Because of this glow contains lot of broken places and does not compile anymore. Made a fix on such places by explicitly converting llvm::StringRef->std::string.

