### PR TITLE
Debug Assist in AI compiler

### DIFF
--- a/torch_glow/src/GlowCompileSpec.h
+++ b/torch_glow/src/GlowCompileSpec.h
@@ -849,6 +849,7 @@ struct GlowPyTorchLoaderSettings : public JsonSerializableCustomClass {
     obj["saveGlowIRIntoONNX"] = settings_.saveGlowIRIntoONNX;
     obj["loadGlowIRFromONNX"] = settings_.loadGlowIRFromONNX;
     obj["skipProvisioning"] = settings_.skipProvisioning;
+    obj["debugLayers"] = settings_.debugLayers;
     return obj;
   }
 
@@ -1087,6 +1088,11 @@ struct GlowPyTorchLoaderSettings : public JsonSerializableCustomClass {
     if (dyn.count("skipProvisioning")) {
       ASSIGN_BOOL_FROM_DYN_FIELD_OR_RETURN_ERR(dyn, settings_.skipProvisioning,
                                                "skipProvisioning");
+    }
+
+    if (dyn.count("debugLayers")) {
+      ASSIGN_INT_FROM_DYN_FIELD_OR_RETURN_ERR(dyn, settings_.debugLayers,
+                                              "debugLayers");
     }
 
     return Error::success();

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -96,6 +96,7 @@ DEFINE_int32(nominalBatchIdx, -1, "See PyTorchLoaderSettings");
 DEFINE_bool(dumpFailedInputsToOnnxFiles, false, "See PyTorchLoaderSettings");
 DEFINE_bool(lazyCompile, false, "see PyTorchLoaderSettings");
 DEFINE_bool(enableDeviceTracing, false, "See PyTorchLoaderSettings");
+DEFINE_int32(debugLayers, 5, "See PyTorchLoaderSettings");
 
 DEFINE_bool(saveGlowIRIntoONNX, false, "See PyTorchLoaderSettings");
 DEFINE_bool(loadGlowIRFromONNX, false, "See PyTorchLoaderSettings");
@@ -353,6 +354,7 @@ void PyTorchLoaderSettings::initSettings() {
   saveGlowIRIntoONNX = FLAGS_saveGlowIRIntoONNX;
   loadGlowIRFromONNX = FLAGS_loadGlowIRFromONNX;
   skipProvisioning = glow::flags::SkipProvisioning || saveGlowIRIntoONNX;
+  debugLayers = FLAGS_debugLayers;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);
@@ -420,6 +422,7 @@ std::string PyTorchLoaderSettings::toString() const {
   INSERT_BOOL_TO_STREAM(dumpFailedInputsToOnnxFiles, s);
   INSERT_BOOL_TO_STREAM(lazyCompile, s);
   INSERT_BOOL_TO_STREAM(enableDeviceTracing, s);
+  INSERT_VALUE_TO_STREAM(debugLayers, s);
 
   if (opBlacklist.size() > 0) {
     s << "opBlacklist: [";

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -236,6 +236,9 @@ public:
   // and partitioned model into ONNX model file. During this process, we do not
   // need to do provisioning)
   bool skipProvisioning = false;
+
+  /// Set the number of predecessor Nodes to be printed from an error node.
+  int32_t debugLayers = 5;
 };
 
 /// Represents different possible output types from to_glow modules.

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -260,6 +260,11 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("enable_lazy_compile",
         []() { getGlobalPyTorchLoaderSettingsMutable().lazyCompile = true; });
 
+  /// Set the number of layers to print when dumpContextOnError is true.
+  m.def("set_debug_layers", [](size_t debugLayers) {
+    getGlobalPyTorchLoaderSettingsMutable().debugLayers = debugLayers;
+  });
+
   /// Set interpreter device memory (in KiB).
   m.def("set_interpreter_memory", [](const unsigned &memorySize) {
     glow::runtime::flags::InterpreterMemory = memorySize;


### PR DESCRIPTION
Summary: Add debugLayers flag as settings to print out nodes upto certain layer. This setting is user configurable. debugLayers=0 means no debug information related to nodes will be printed out.

Reviewed By: jackm321

Differential Revision: D28156940

