### PR TITLE
Add the ability to define the base name of the file for a saved bundle

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -135,6 +135,8 @@ protected:
   std::string bundleName_;
   /// Name of the main entry.
   std::string mainEntryName_;
+  /// Base name of the saved bundle file, without extension.
+  std::string savedBundleName_;
   /// Instruction number for the module.
   std::unique_ptr<InstructionNumbering> instrNumbering_;
   /// Value holding the base address of the activations memory area.
@@ -398,6 +400,11 @@ public:
   llvm::StringRef getBundleName() const;
   /// Set the name of the bundle (name is automatically legalized).
   void setBundleName(const std::string &name);
+  /// \returns the base name of the saved bundle file to be used by a
+  /// BundleSaver.
+  llvm::StringRef getSavedBundleName() const;
+  /// Set the base name of the saved bundle file.
+  void setSavedBundleName(const std::string &name);
   /// \returns the name of the main entry point.
   /// When JITting, it will be "main". In case of bundling it will be the name
   /// of the bundle.

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -536,12 +536,17 @@ void BundleSaver::produceBundle() {
   auto &M = irgen_->getModule();
   auto outputDir = irgen_->getOutputDir();
   auto bundleName = irgen_->getBundleName();
+  auto savedBundleName = irgen_->getSavedBundleName().empty()
+                             ? bundleName
+                             : irgen_->getSavedBundleName();
   std::string extension = (llvmCompiler.empty()) ? ".o" : ".bc";
-  auto bundleCodeOutput = (outputDir + "/" + bundleName + extension).str();
+  std::string bundleCodeOutput;
+  bundleCodeOutput = (outputDir + "/" + savedBundleName + extension).str();
   auto bundleWeightsBinOut =
-      (outputDir + "/" + bundleName + ".weights.bin").str();
-  auto bundleHeaderOutput = (outputDir + "/" + bundleName + ".h").str();
+      (outputDir + "/" + savedBundleName + ".weights.bin").str();
+  auto bundleHeaderOutput = (outputDir + "/" + savedBundleName + ".h").str();
   DEBUG_GLOW(llvm::dbgs() << "Producing a bundle:\n"
+                          << "saved bundle name: " << savedBundleName << "\n"
                           << "bundle name: " << bundleName << "\n"
                           << "bundle code: " << bundleCodeOutput << "\n"
                           << "bundle weights:" << bundleWeightsBinOut << "\n"
@@ -568,10 +573,10 @@ void BundleSaver::produceBundle() {
       if (!llvmOpt.empty()) {
         bundleObjectCodeOutputOpt =
             " -emit-llvm -o " +
-            (outputDir + "/" + bundleName + ".beforeopt.bc").str();
+            (outputDir + "/" + savedBundleName + ".beforeopt.bc").str();
       } else {
         bundleObjectCodeOutputOpt =
-            " -o " + (outputDir + "/" + bundleName + ".o").str();
+            " -o " + (outputDir + "/" + savedBundleName + ".o").str();
       }
 
       cmd += bundleObjectCodeOutputOpt;
@@ -583,8 +588,10 @@ void BundleSaver::produceBundle() {
       if (!llvmOpt.empty()) {
         cmd.clear();
         cmd = llvmOpt;
-        cmd += " " + (outputDir + "/" + bundleName + ".beforeopt.bc").str();
-        cmd += " -O3 -o " + (outputDir + "/" + bundleName + ".opt.bc").str();
+        cmd +=
+            " " + (outputDir + "/" + savedBundleName + ".beforeopt.bc").str();
+        cmd +=
+            " -O3 -o " + (outputDir + "/" + savedBundleName + ".opt.bc").str();
         CHECK(!system(cmd.c_str()))
             << "Error running external opt compiler: " << cmd;
 
@@ -593,8 +600,8 @@ void BundleSaver::produceBundle() {
         for (auto option : llvmCompilerOptions) {
           cmd += " " + option + " ";
         }
-        cmd += " " + (outputDir + "/" + bundleName + ".opt.bc").str();
-        cmd += " -o " + (outputDir + "/" + bundleName + ".o").str();
+        cmd += " " + (outputDir + "/" + savedBundleName + ".opt.bc").str();
+        cmd += " -o " + (outputDir + "/" + savedBundleName + ".o").str();
         CHECK(!system(cmd.c_str()))
             << "Error running external LLVM compiler: " << cmd;
       }
@@ -628,7 +635,7 @@ void BundleSaver::produceBundle() {
   // Save weights also in text format for Static API.
   if (bundleAPI_ == BundleApiType::Static) {
     auto bundleWeightsTxtOut =
-        (outputDir + "/" + bundleName + ".weights.txt").str();
+        (outputDir + "/" + savedBundleName + ".weights.txt").str();
     serializeBinaryToText(bundleWeightsBinOut, bundleWeightsTxtOut);
   }
 }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -123,6 +123,15 @@ void LLVMIRGen::setBundleName(const std::string &name) {
   bundleName_ = name.empty() ? "bundle" : legalizeName(name);
 }
 
+llvm::StringRef LLVMIRGen::getSavedBundleName() const {
+  return savedBundleName_;
+}
+
+void LLVMIRGen::setSavedBundleName(const std::string &name) {
+  assert(!name.empty() && "Name cannot be empty");
+  savedBundleName_ = name;
+}
+
 std::string LLVMIRGen::getMainEntryName() const { return mainEntryName_; }
 
 void LLVMIRGen::setMainEntryName(std::string name) {


### PR DESCRIPTION
Summary:
It can be useful in some use-cases to explicitly set a base name for the output file where bundle is saved.

This PR is backwards compatible and should not break any existing code.

Reviewed By: chenccfb

Differential Revision: D28726956

