### PR TITLE
Use better scale, offset and atol in quantized layernorm test

### DIFF
--- a/torch_glow/tests/nodes/quantized_layernorm_test.py
+++ b/torch_glow/tests/nodes/quantized_layernorm_test.py
@@ -34,23 +34,25 @@ class TestQuantizedLayerNorm(utils.TorchGlowTestCase):
     def test_layernorm_basic(self):
         """Basic test of the PyTorch quantized layernorm Node on Glow."""
 
-        inputs = torch.tensor([1.2, 0.6, 0.9]).reshape(1, 1, 3)
+        inputs = torch.tensor([0.3, 0.6, 0.3]).reshape(1, 1, 3)
         weight = torch.tensor([1.0, 1.1, 1.2])
         bias = torch.tensor([0.1, 0.1, 0.2])
 
         utils.compare_tracing_methods(
-            QuantizedLayerNormModule([3], 0.1, 0, weight, bias),
+            QuantizedLayerNormModule([3], 0.01, 66, weight, bias),
             inputs,
             fusible_ops={"quantized::layer_norm"},
+            atol=1e-02,
         )
 
     def test_layernorm_no_weight_bias(self):
         """Test of the PyTorch quantized::layer_norm without weights and bias."""
 
-        inputs = torch.tensor([1.2, 0.6, 0.9, 0.3]).reshape(1, 1, 2, 2)
+        inputs = torch.tensor([0.3, 0.6, 0.9, 0.3]).reshape(1, 1, 2, 2)
 
         utils.compare_tracing_methods(
-            QuantizedLayerNormModule([2, 2], 0.1, 0),
+            QuantizedLayerNormModule([2, 2], 0.01, 91),
             inputs,
             fusible_ops={"quantized::layer_norm"},
+            atol=1e-2,
         )

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -105,7 +105,7 @@ def assert_equivalent(
         matches = (
             torch.equal(result1, result2)
             if use_eq
-            else torch.allclose(result1, result2, atol, rtol)
+            else torch.allclose(result1, result2, rtol=rtol, atol=atol)
         )
         if matches:
             return True


### PR DESCRIPTION
Summary:
We lower Layernorm in Glow on Interpreter backend. If it's quantized layernorm, we dequantize the input first so that lowered ops are in float precision. The reason we were doing it is because we can't figure out proper scale and offset for those lowered ops if we lower it in int8. At the end, we quantize the float output of lowered ops to get int8 output.

```
// The graph of the test after lowering looks like this

fp input -> quantize -> dequantize -> lowered ops -> quantize -> reshape -> dequantize

// Adjacent quant/dequant will get removed and final graph looks like this

fp input -> lowered ops -> quantize -> reshape -> dequantize
```

D28390125 introduces an optimization pass that would optionally sink reshape op, which makes the above graph a bit different.

```
// After the diff, graph looks like this

fp input -> lowered ops -> reshape
```
This essentially makes the quantize layernorm on Interpreter backend fully runs on fp precision, which is good in terms of precision and performance. But for testing purpose we need to add some changes so that it would still pass because the reference result that is produced by torchscript model is still run on int8 precision.

Differential Revision: D28800427

