### PR TITLE
Glow AOT serialization function

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -413,7 +413,8 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         return true;
 
       case ElemKind::UInt8FusedQTy:
-        return (kindTo == ElemKind::Float16Ty);
+        return (kindTo == ElemKind::Float16Ty ||
+                kindTo == ElemKind::UInt8FusedFP16QTy);
       case ElemKind::UInt8FusedFP16QTy:
         return (kindTo == ElemKind::Float16Ty);
       default:

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -301,9 +301,13 @@ Error setupGlowDeserializationSpecAndCctx(
               ? f->getParent()->uniqueType(elementType, newDims,
                                            type.getScale(), type.getOffset())
               : f->getParent()->uniqueType(elementType, newDims);
+      // Here staticPlaceholderTypes is used for serializing Glow IR in
+      // hostManager, which is post-precision conversion. staticPHTypes on the
+      // other hand is used in Glow deserialization, which requires the input
+      // tensor types (i.e., pre-precision conversion)
       staticPlaceholderTypes[std::string(ph->getName())] = *newType;
       staticPHNames.emplace_back(ph->getName().data());
-      staticPHTypes.emplace_back(newType->toString());
+      staticPHTypes.emplace_back(type.toString());
     }
   }
   size_t outputIdx = 0;

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -769,7 +769,9 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr,
 
   modelPreprocessing(model, method_name);
 
-  if (FLAGS_inferShapeForCompilation) {
+  // In Glow AOT serialization (i.e., settings.saveGlowIRIntoONNX = true), we
+  // always enable inferShapeForCompilation
+  if (FLAGS_inferShapeForCompilation || settings.saveGlowIRIntoONNX) {
     return glowAOTFusionWithShapeInference(model, metaStack, loader, settings,
                                            method_name, batchShapes);
   }


### PR DESCRIPTION
Summary:
Context
To enable ahead-of-time model compilation on A*, we need to run Glow serialization logic in model transformation service to (1) precompile the remote_other net; (2) Save the compiled & partitioned & optimized Glow IR as an ONNX model file and the compilation settings to the XL format model. In this diff, we implement the function to trigger Glow serialization.

Differential Revision: D28159708

