### PR TITLE
Add SparseNN partition scheme parameters in PyTorchLoaderSettings

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -219,6 +219,26 @@ void initializeCompilationContextFromSettings(
     LOG(INFO) << "Will skip provisioning (likely due to AOT opt).";
     cctx.skipProvisioning = true;
   }
+
+  if (settings.useSparseNNPartitioningScheme) {
+    cctx.optimizationOpts.useSparseNNPartitioningScheme = true;
+    cctx.optimizationOpts.sparseNNPartitioningAddSLSConcats =
+        settings.sparseNNPartitioningAddSLSConcats;
+    cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel =
+        settings.sparseNNPartitioningBalancePerfModel;
+    cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
+        settings.sparseNNPartitioningPairLNWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
+        settings.sparseNNPartitioningPairTileWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
+        settings.sparseNNPartitioningSchemeNumCards;
+    cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =
+        settings.sparseNNPartitioningSchemeSLSTableKBytesPerCard;
+    cctx.optimizationOpts.sparseNNPartitioningSchemeNumCoresSLS =
+        settings.SparseNNPartitioningSchemeNumCoresSLS;
+    cctx.optimizationOpts.sparseNNPartitioningSchemeNumCoresOther =
+        settings.SparseNNPartitioningSchemeNumCoresOther;
+  }
 }
 
 /// This function slice the input Tensor according to the expected shape in the

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -101,6 +101,24 @@ DEFINE_int32(debugLayers, 5, "See PyTorchLoaderSettings");
 DEFINE_bool(saveGlowIRIntoONNX, false, "See PyTorchLoaderSettings");
 DEFINE_bool(loadGlowIRFromONNX, false, "See PyTorchLoaderSettings");
 
+DEFINE_bool(useSparseNNPartitioningScheme, false, "See PyTorchLoaderSettings");
+DEFINE_bool(sparseNNPartitioningAddSLSConcats, false,
+            "See PyTorchLoaderSettings");
+DEFINE_bool(sparseNNPartitioningBalancePerfModel, false,
+            "See PyTorchLoaderSettings");
+DEFINE_bool(sparseNNPartitioningPairLNWithSLS, false,
+            "See PyTorchLoaderSettings");
+DEFINE_bool(sparseNNPartitioningPairTileWithSLS, false,
+            "See PyTorchLoaderSettings");
+DEFINE_int32(sparseNNPartitioningSchemeNumCards, 1,
+             "See PyTorchLoaderSettings");
+DEFINE_int64(sparseNNPartitioningSchemeSLSTableKBytesPerCard, 1,
+             "See PyTorchLoaderSettings");
+DEFINE_int32(SparseNNPartitioningSchemeNumCoresSLS, 1,
+             "See PyTorchLoaderSettings");
+DEFINE_int32(SparseNNPartitioningSchemeNumCoresOther, 1,
+             "See PyTorchLoaderSettings");
+
 namespace glow {
 namespace {
 
@@ -354,6 +372,20 @@ void PyTorchLoaderSettings::initSettings() {
   saveGlowIRIntoONNX = FLAGS_saveGlowIRIntoONNX;
   loadGlowIRFromONNX = FLAGS_loadGlowIRFromONNX;
   skipProvisioning = glow::flags::SkipProvisioning || saveGlowIRIntoONNX;
+  useSparseNNPartitioningScheme = FLAGS_useSparseNNPartitioningScheme;
+  sparseNNPartitioningAddSLSConcats = FLAGS_sparseNNPartitioningAddSLSConcats;
+  sparseNNPartitioningBalancePerfModel =
+      FLAGS_sparseNNPartitioningBalancePerfModel;
+  sparseNNPartitioningPairLNWithSLS = FLAGS_sparseNNPartitioningPairLNWithSLS;
+  sparseNNPartitioningPairTileWithSLS =
+      FLAGS_sparseNNPartitioningPairTileWithSLS;
+  sparseNNPartitioningSchemeNumCards = FLAGS_sparseNNPartitioningSchemeNumCards;
+  sparseNNPartitioningSchemeSLSTableKBytesPerCard =
+      FLAGS_sparseNNPartitioningSchemeSLSTableKBytesPerCard;
+  SparseNNPartitioningSchemeNumCoresSLS =
+      FLAGS_SparseNNPartitioningSchemeNumCoresSLS;
+  SparseNNPartitioningSchemeNumCoresOther =
+      FLAGS_SparseNNPartitioningSchemeNumCoresOther;
   debugLayers = FLAGS_debugLayers;
 
   if (!FLAGS_opBlacklist.empty()) {

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -239,6 +239,17 @@ public:
 
   /// Set the number of predecessor Nodes to be printed from an error node.
   int32_t debugLayers = 5;
+
+  // Sparse NN Partitioning Scheme Constants
+  bool useSparseNNPartitioningScheme = false;
+  bool sparseNNPartitioningAddSLSConcats = false;
+  bool sparseNNPartitioningBalancePerfModel = false;
+  bool sparseNNPartitioningPairLNWithSLS = false;
+  bool sparseNNPartitioningPairTileWithSLS = false;
+  int32_t sparseNNPartitioningSchemeNumCards = 1;
+  int64_t sparseNNPartitioningSchemeSLSTableKBytesPerCard = 1;
+  int32_t SparseNNPartitioningSchemeNumCoresSLS = 1;
+  int32_t SparseNNPartitioningSchemeNumCoresOther = 1;
 };
 
 /// Represents different possible output types from to_glow modules.


### PR DESCRIPTION
Summary: As titled, add SparseNN partition scheme parameters in PyTorchLoaderSettings for glow AOT serialization

Reviewed By: wfanzju

Differential Revision: D28721369

