### PR TITLE
dump output files in RecommendationSystemTest.cpp when -dump-model-inputs

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -420,6 +420,21 @@ protected:
     of << buffer;
   }
 
+  // dump outputs into onnx file which can run with repro binary.
+  void dumpOutputs() {
+    std::stringstream ss;
+    ss << "output_0.onnx";
+    std::ofstream of(ss.str(), std::ios::binary);
+    ONNX_NAMESPACE::GraphProto inputG;
+    auto *t = inputG.add_initializer();
+    ONNXModelWriter::writeTensor(*resultTensor, t,
+                                 /*useGlowCustomOps*/ true);
+    t->set_name("save");
+    std::string buffer;
+    inputG.SerializeToString(&buffer);
+    of << buffer;
+  }
+
   void TearDown() override {
     if (dumpBinaryResults) {
       ASSERT_TRUE(resultTensor) << "Could not dump result tensor, was nullptr";
@@ -1011,6 +1026,10 @@ protected:
       for (int i = 0, e = resultTensorH.size(); i < e; ++i) {
         EXPECT_GE(resultTensorH.raw(i), 0.0);
       }
+    }
+
+    if (dumpModelInputs) {
+      dumpOutputs();
     }
 
     // Compare against interpreter if we're not executing already on it.


### PR DESCRIPTION
Summary: In D28065106 (https://github.com/pytorch/glow/commit/8080880eb764a09c458eaebac987d377b3c2ff26), we only dumped out the model and input files (main.zip and input_0.onnx). It is actually better we dump out output files as well so we have everything ready for repro (in that sense, we don't need repro to dump out output_0.onnx)

Differential Revision: D28826299

