### PR TITLE
Add GlowJIT OrcV2 support

### DIFF
--- a/include/glow/LLVMIRCodeGen/GlowJIT.h
+++ b/include/glow/LLVMIRCodeGen/GlowJIT.h
@@ -37,6 +37,17 @@
 #include <string>
 #include <vector>
 
+#ifndef GLOW_JIT_ORC_VERSION
+#if LLVM_VERSION_MAJOR < 10
+#define GLOW_JIT_ORC_VERSION 1
+#else
+#define GLOW_JIT_ORC_VERSION 2
+#endif
+#endif
+
+//##############################################################################
+#if GLOW_JIT_ORC_VERSION == 1
+//##############################################################################
 namespace llvm {
 namespace orc {
 
@@ -44,8 +55,9 @@ namespace orc {
 // KaleidoscopeJIT example in the LLVM tree.
 class GlowJIT {
 private:
-  TargetMachine &TM_;
+  std::unique_ptr<llvm::TargetMachine> TM_;
   const DataLayout DL_;
+  std::unique_ptr<llvm::LLVMContext> ctx_;
 #if FACEBOOK_INTERNAL && LLVM_VERSION_MAJOR < 8
   SymbolStringPool SSP_;
   ExecutionSession ES_;
@@ -93,10 +105,10 @@ private:
   std::string mangle(const std::string &name);
 
 public:
-  GlowJIT(llvm::TargetMachine &TM);
+  GlowJIT(std::unique_ptr<llvm::TargetMachine> TM);
   ~GlowJIT();
 
-  TargetMachine &getTargetMachine() { return TM_; }
+  TargetMachine &getTargetMachine() { return *TM_; }
 
   JITSymbol findSymbol(const std::string &name);
 
@@ -105,9 +117,68 @@ public:
   ModuleHandle addModule(std::unique_ptr<Module> M);
 
   void removeModule(ModuleHandle H);
+
+  void setContext(std::unique_ptr<llvm::LLVMContext> ctx);
 };
 
 } // end namespace orc
 } // end namespace llvm
+
+namespace glow {
+using GlowJIT = llvm::orc::GlowJIT;
+}
+
+//##############################################################################
+#elif GLOW_JIT_ORC_VERSION == 2
+//##############################################################################
+
+namespace glow {
+
+class GlowJITOrcV2 {
+  friend class GlowJITDefGenerator;
+
+  std::unique_ptr<llvm::TargetMachine> tm_;
+  const llvm::DataLayout dl_;
+  std::shared_ptr<llvm::orc::SymbolStringPool> ssp_;
+  llvm::orc::ExecutionSession es_;
+  llvm::orc::JITDylib &jd_;
+
+  llvm::orc::RTDyldObjectLinkingLayer objectLayer_;
+  llvm::orc::IRCompileLayer compileLayer_;
+  llvm::orc::ThreadSafeContext ctx_;
+
+  llvm::orc::MangleAndInterner mangler_;
+
+  /// Handles symbols that are overridden by the JIT engine (needed to manage
+  /// C++ destructors for static objects).
+  llvm::orc::LocalCXXRuntimeOverrides cxxSymbolOverride_;
+
+  /// Object that records static C++ constructor/destructor names.
+  std::vector<llvm::orc::CtorDtorRunner> irStaticDestructorRunners_;
+
+  /// \returns the JITSymbol for the symbol named \p name. Differs from
+  /// findSymbol in that it handles resolving symbols outside of the
+  /// CompileLayer (e.g. in process symbols, overridden symbols).
+  /// Called indirectly by the ObjectLinkingLayer.
+  llvm::Error tryToGenerate(llvm::orc::LookupKind K, llvm::orc::JITDylib &JD,
+                            llvm::orc::JITDylibLookupFlags JDLookupFlags,
+                            const llvm::orc::SymbolLookupSet &LookupSet);
+
+public:
+  GlowJITOrcV2(std::unique_ptr<llvm::TargetMachine> tm);
+  virtual ~GlowJITOrcV2();
+
+  llvm::JITSymbol findSymbol(const std::string &name);
+
+  using ModuleHandle = llvm::orc::VModuleKey;
+  void setContext(std::unique_ptr<llvm::LLVMContext> ctx);
+  ModuleHandle addModule(std::unique_ptr<llvm::Module> M);
+};
+using GlowJIT = GlowJITOrcV2;
+
+} // namespace glow
+#else
+#error Unsupported GLOW_JIT_ORC_VERSION
+#endif
 
 #endif // GLOW_LLVMIRCODEGEN_GLOWJIT_H

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -198,7 +198,7 @@ protected:
   /// \param runtimeBundle bundle to be used for compiling the function.
   /// \returns created CompiledFunction.
   virtual std::unique_ptr<CompiledFunction>
-  createCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+  createCompiledFunction(std::unique_ptr<GlowJIT> JIT,
                          runtime::RuntimeBundle &&runtimeBundle) const = 0;
 
   /// \returns libjit bitcode for the current backend.

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -25,7 +25,7 @@ namespace glow {
 /// A Glow IR function compiled using LLVM.
 class LLVMCompiledFunction : public CompiledFunction {
 public:
-  LLVMCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+  LLVMCompiledFunction(std::unique_ptr<GlowJIT> JIT,
                        runtime::RuntimeBundle &&runtimeBundle);
 
   /// \name CompiledFunction interface
@@ -52,7 +52,7 @@ protected:
 
   /// The LLVM JIT engine. The jit must be initialized after the ctor
   /// initializes the LLVM backends.
-  std::unique_ptr<llvm::orc::GlowJIT> JIT_;
+  std::unique_ptr<GlowJIT> JIT_;
 
   /// The JIT can be accessed from multiple threads but is not thread safe,
   /// JITLock_ protects it.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -124,7 +124,7 @@ protected:
   /// Set of emitted LLVM functions for IR functions.
   llvm::SmallVector<llvm::Function *, 4> emittedLLVMFunctions_;
   /// The LLVM context.
-  llvm::LLVMContext ctx_;
+  std::unique_ptr<llvm::LLVMContext> ctx_;
   /// The LLVM IR module.
   std::unique_ptr<llvm::Module> llmodule_{nullptr};
   /// The target machine.
@@ -414,8 +414,18 @@ public:
   llvm::IRBuilder<> &getBuilder() { return *builder_; }
   /// \returns the target machine description.
   llvm::TargetMachine &getTargetMachine() { return *TM_; }
+  /// Takes the target machine for further processing, e.g. by a JIT.
+  /// The target machine cannot be used by the LLVMIRGen afterwards.
+  std::unique_ptr<llvm::TargetMachine> takeTargetMachine() {
+    return std::move(TM_);
+  }
   /// \returns the LLVMContext being used.
-  llvm::LLVMContext &getLLVMContext() { return ctx_; }
+  llvm::LLVMContext &getLLVMContext() { return *ctx_; }
+  /// Takes the LLVM Context for further processing, e.g. by a JIT.
+  /// The context cannot be used by the LLVMIRGen afterwards.
+  std::unique_ptr<llvm::LLVMContext> takeLLVMContext() {
+    return std::move(ctx_);
+  }
   /// Borrows the LLVM module for further processing, e.g. by a JIT.
   /// The module cannot be used by the LLVMIRGen afterwards.
   std::unique_ptr<llvm::Module> borrowModule() { return std::move(llmodule_); }

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -121,7 +121,7 @@ std::vector<unsigned> CPUBackend::scanDeviceIDs() {
 }
 
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(
-    std::unique_ptr<llvm::orc::GlowJIT> JIT,
+    std::unique_ptr<GlowJIT> JIT,
     runtime::RuntimeBundle &&runtimeBundle) const {
   return glow::make_unique<CPUFunction>(std::move(JIT),
                                         std::move(runtimeBundle));

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -84,7 +84,7 @@ public:
 
 protected:
   virtual std::unique_ptr<CompiledFunction>
-  createCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+  createCompiledFunction(std::unique_ptr<GlowJIT> JIT,
                          runtime::RuntimeBundle &&runtimeBundle) const override;
 
   virtual llvm::StringRef getLibjitBitcode() const override;

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -21,7 +21,7 @@
 
 using namespace glow;
 
-CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+CPUFunction::CPUFunction(std::unique_ptr<GlowJIT> JIT,
                          runtime::RuntimeBundle &&runtimeBundle)
     : LLVMCompiledFunction(std::move(JIT), std::move(runtimeBundle)) {}
 

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -27,7 +27,7 @@ namespace glow {
 /// A Glow IR function compiled for the CPU using LLVM.
 class CPUFunction final : public LLVMCompiledFunction {
 public:
-  CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+  CPUFunction(std::unique_ptr<GlowJIT> JIT,
               runtime::RuntimeBundle &&runtimeBundle);
 
   /// \name CompiledFunction interface

--- a/lib/LLVMIRCodeGen/GlowJIT.cpp
+++ b/lib/LLVMIRCodeGen/GlowJIT.cpp
@@ -24,8 +24,6 @@
 
 #define DEBUG_TYPE "jit-engine"
 
-using GlowJIT = llvm::orc::GlowJIT;
-
 namespace {
 /// An option to enabling the dump of the symbol information for the JITted
 /// functions. It dumps e.g. the names of the functions, their start addresses
@@ -73,7 +71,7 @@ class NotifyLoadedFunctor {
   }
 
 public:
-  NotifyLoadedFunctor(GlowJIT *jit)
+  NotifyLoadedFunctor()
       : dbgRegistrationListener_(
             llvm::JITEventListener::createGDBRegistrationListener()) {}
 
@@ -104,6 +102,11 @@ public:
 };
 
 } // namespace
+
+//##############################################################################
+#if GLOW_JIT_ORC_VERSION == 1
+//##############################################################################
+using GlowJIT = llvm::orc::GlowJIT;
 
 //==============================================================================
 #if LLVM_VERSION_MAJOR < 8 && FACEBOOK_INTERNAL
@@ -323,8 +326,8 @@ createLookupResolver(llvm::orc::ExecutionSession &ES,
 }
 #endif
 
-GlowJIT::GlowJIT(llvm::TargetMachine &TM)
-    : TM_(TM), DL_(TM_.createDataLayout()),
+GlowJIT::GlowJIT(std::unique_ptr<llvm::TargetMachine> TM)
+    : TM_(std::move(TM)), DL_(TM_->createDataLayout()),
 #if FACEBOOK_INTERNAL && LLVM_VERSION_MAJOR < 8
       ES_(SSP_),
       resolver_(createLookupResolver(
@@ -357,7 +360,7 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
             return RTDyldObjectLinkingLayer::Resources{
                 std::make_shared<SectionMemoryManager>(), resolver_};
           },
-          NotifyLoadedFunctor(this)),
+          NotifyLoadedFunctor()),
 #else
       objectLayer_(
           ES_,
@@ -365,10 +368,10 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
             return LegacyRTDyldObjectLinkingLayer::Resources{
                 std::make_shared<SectionMemoryManager>(), resolver_};
           },
-          NotifyLoadedFunctor(this)),
+          NotifyLoadedFunctor()),
 #endif
 #endif
-      compileLayer_(objectLayer_, SimpleCompiler(TM_)) {
+      compileLayer_(objectLayer_, SimpleCompiler(*TM_)) {
   //  When passing a null pointer to LoadLibraryPermanently, we request to
   //  'load' the host process itself, making its exported symbols available for
   //  execution.
@@ -437,3 +440,138 @@ std::string GlowJIT::mangle(const std::string &name) {
 llvm::JITSymbol GlowJIT::findSymbol(const std::string &name) {
   return compileLayer_.findSymbol(mangle(name), false);
 }
+
+void GlowJIT::setContext(std::unique_ptr<llvm::LLVMContext> ctx) {
+  ctx_ = std::move(ctx);
+}
+
+//##############################################################################
+#elif GLOW_JIT_ORC_VERSION == 2
+//##############################################################################
+
+namespace glow {
+
+class GlowJITDefGenerator : public llvm::orc::JITDylib::DefinitionGenerator {
+  GlowJIT *gj_;
+
+public:
+  GlowJITDefGenerator(GlowJIT *gj) : gj_(gj) {}
+  virtual ~GlowJITDefGenerator() {}
+
+  llvm::Error
+  tryToGenerate(llvm::orc::LookupKind k, llvm::orc::JITDylib &jd,
+                llvm::orc::JITDylibLookupFlags jdLookupFlags,
+                const llvm::orc::SymbolLookupSet &lookupSet) override {
+    return gj_->tryToGenerate(k, jd, jdLookupFlags, lookupSet);
+  }
+};
+
+GlowJITOrcV2::GlowJITOrcV2(std::unique_ptr<llvm::TargetMachine> tm)
+    : tm_(std::move(tm)), dl_(tm_->createDataLayout()),
+      ssp_(std::make_shared<llvm::orc::SymbolStringPool>()), es_(ssp_),
+      jd_(es_.createJITDylib("libGlowJIT.dylib")),
+      objectLayer_(
+          es_, []() { return std::make_unique<llvm::SectionMemoryManager>(); }),
+      compileLayer_(es_, objectLayer_,
+                    std::make_unique<llvm::orc::SimpleCompiler>(*tm_)),
+      mangler_(es_, dl_) {
+
+  cantFail(cxxSymbolOverride_.enable(jd_, mangler_));
+  objectLayer_.setNotifyLoaded(NotifyLoadedFunctor());
+  if (tm_->getTargetTriple().isOSBinFormatCOFF()) {
+    objectLayer_.setOverrideObjectFlagsWithResponsibilityFlags(true);
+    objectLayer_.setAutoClaimResponsibilityForObjectSymbols(true);
+  }
+  jd_.addGenerator(std::make_unique<GlowJITDefGenerator>(this));
+
+  //  When passing a null pointer to LoadLibraryPermanently, we request to
+  //  'load' the host process itself, making its exported symbols available for
+  //  execution.
+  llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+}
+
+GlowJITOrcV2::~GlowJITOrcV2() {
+  // Run any destructor discovered in the LLVM IR of the JIT modules.
+  for (auto i = irStaticDestructorRunners_.rbegin();
+       i != irStaticDestructorRunners_.rend(); ++i) {
+    cantFail(i->run());
+  }
+
+  // Run any destructor registered with __cxa_atexit.
+  cxxSymbolOverride_.runDestructors();
+}
+
+llvm::Error
+GlowJITOrcV2::tryToGenerate(llvm::orc::LookupKind K, llvm::orc::JITDylib &JD,
+                            llvm::orc::JITDylibLookupFlags JDLookupFlags,
+                            const llvm::orc::SymbolLookupSet &LookupSet) {
+  llvm::orc::SymbolMap newSymbols;
+
+  for (const auto &i : LookupSet) {
+    const llvm::orc::SymbolStringPtr &ssp = i.first;
+    llvm::StringRef name = *ssp;
+
+    // FIXME: looking for symbols external to libjit in the process is
+    // dangerous because it can be environment dependent. For example,
+    // we get cases where a symbol is found in the Linux environment,
+    // but not in the Windows environment.
+    if (auto processSymAddr =
+            llvm::RTDyldMemoryManager::getSymbolAddressInProcess(name)) {
+      newSymbols[ssp] = llvm::JITEvaluatedSymbol(
+          processSymAddr, llvm::JITSymbolFlags::Exported);
+      continue;
+    }
+
+    // The symbol was not resolved. This will make the retreival of
+    // 'main' function symbol fail later without much information about
+    // the source of the problem. Then, we dump an error message now to
+    // ease debugging.
+    DEBUG_GLOW(llvm::dbgs()
+               << "JIT: Error resolving symbol '" << name << "'\n");
+    // Return a 'symbol not found' JITSymbol object (nullptr).
+  }
+
+  if (newSymbols.empty())
+    return llvm::Error::success();
+
+  return JD.define(absoluteSymbols(std::move(newSymbols)));
+}
+
+llvm::JITSymbol GlowJITOrcV2::findSymbol(const std::string &name) {
+  auto s = es_.lookup({&jd_}, name);
+  return s ? llvm::JITSymbol(s.get()) : llvm::JITSymbol(s.takeError());
+}
+
+void GlowJITOrcV2::setContext(std::unique_ptr<llvm::LLVMContext> ctx) {
+  ctx_ = llvm::orc::ThreadSafeContext(std::move(ctx));
+}
+
+GlowJITOrcV2::ModuleHandle
+GlowJITOrcV2::addModule(std::unique_ptr<llvm::Module> m) {
+  std::string modName = m->getName();
+  auto k = es_.allocateVModule();
+
+  auto ctors = llvm::orc::getConstructors(*m.get());
+  llvm::orc::CtorDtorRunner ctorRunner(jd_);
+  ctorRunner.add(ctors);
+
+  auto dtors = llvm::orc::getDestructors(*m.get());
+  irStaticDestructorRunners_.emplace_back(jd_);
+  irStaticDestructorRunners_.back().add(dtors);
+
+  cantFail(compileLayer_.add(
+      jd_, llvm::orc::ThreadSafeModule(std::move(m), ctx_), k));
+
+  // Run the static constructors
+  if (auto err = ctorRunner.run()) {
+    LOG(WARNING) << "Error while running static constructors for " << modName
+                 << ": " << llvm::toString(std::move(err));
+  }
+
+  return k;
+}
+
+} // namespace glow
+#else
+#error Unsupported GLOW_JIT_ORC_VERSION
+#endif

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -678,7 +678,8 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   emitJitMain(*irgen);
   irgen->finishCodeGen();
   // Hand over the module to JIT for the machine code generation.
-  auto JIT = glow::make_unique<llvm::orc::GlowJIT>(irgen->getTargetMachine());
+  auto JIT = glow::make_unique<GlowJIT>(irgen->takeTargetMachine());
+  JIT->setContext(irgen->takeLLVMContext());
   JIT->addModule(irgen->borrowModule());
   // Build runtimeBundle object containing offsets and allocation sizes.
   MemoryAllocator constantAllocator("ConstantWeights", 0);

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -23,8 +23,7 @@
 using namespace glow;
 
 LLVMCompiledFunction::LLVMCompiledFunction(
-    std::unique_ptr<llvm::orc::GlowJIT> JIT,
-    runtime::RuntimeBundle &&runtimeBundle)
+    std::unique_ptr<GlowJIT> JIT, runtime::RuntimeBundle &&runtimeBundle)
     : CompiledFunction(std::move(runtimeBundle)), JIT_(std::move(JIT)) {}
 
 void LLVMCompiledFunction::collectConstants(const Module *module) {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -65,7 +65,8 @@ static unsigned getPointerNumBits(const llvm::TargetMachine &TM) {
 
 LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName, llvm::StringRef libjitBC)
-    : F_(F), allocationsInfo_(allocationsInfo), libjitBC_(libjitBC) {
+    : F_(F), ctx_(std::make_unique<llvm::LLVMContext>()),
+      allocationsInfo_(allocationsInfo), libjitBC_(libjitBC) {
   // Legalize main entry name.
   setMainEntryName(mainEntryName);
 }
@@ -73,7 +74,8 @@ LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
 LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName, llvm::StringRef libjitBC,
                      llvm::ArrayRef<llvm::MemoryBufferRef> objectRegistry)
-    : F_(F), allocationsInfo_(allocationsInfo), libjitBC_(libjitBC),
+    : F_(F), ctx_(std::make_unique<llvm::LLVMContext>()),
+      allocationsInfo_(allocationsInfo), libjitBC_(libjitBC),
       objectRegistry_(objectRegistry) {
   // Legalize main entry name.
   setMainEntryName(mainEntryName);
@@ -389,7 +391,7 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt32PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt8ITy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt8FusedQTy:
     T = llvm::Type::getInt8PtrTy(getLLVMContext());
@@ -498,10 +500,11 @@ llvm::Value *LLVMIRGen::emitConstFloatArray(llvm::IRBuilder<> &builder,
                                             llvm::ArrayRef<float> vals) {
   std::vector<llvm::Constant *> elems;
   for (auto I : vals) {
-    elems.push_back(
-        llvm::ConstantFP::get(llvm::Type::getFloatTy(ctx_), (float)I));
+    elems.push_back(llvm::ConstantFP::get(
+        llvm::Type::getFloatTy(getLLVMContext()), (float)I));
   }
-  return emitConstArray(builder, elems, llvm::Type::getFloatTy(ctx_));
+  return emitConstArray(builder, elems,
+                        llvm::Type::getFloatTy(getLLVMContext()));
 }
 
 llvm::Value *LLVMIRGen::emitConstArray(llvm::IRBuilder<> &builder,


### PR DESCRIPTION
Summary:

Update GlowJIT to support LLVM OrcV2 JIT compilation.

Documentation:

Fixes [#3551](https://github.com/pytorch/glow/issues/3551)

Test Plan:

