### PR TITLE
[Backend] [NNPI] NNPI v1.7.0.1 changes

### DIFF
--- a/lib/Backends/NNPI/ClassGen/NNPISpecificNodes.h
+++ b/lib/Backends/NNPI/ClassGen/NNPISpecificNodes.h
@@ -29,9 +29,12 @@ BB.newNode("NNPICustomDSP")
 
 BB.newNode("NNPICustomIA")
     .addMember(MemberType::VectorNodeValue, "Inputs")
-    .addResultFromCtorArg() // for now use single output
+    .addResultFromCtorArg()   // for now use single output
+    .addInput("KernelParams") // paramsblob
     .addMember(MemberType::String, "KernelName")
     .addMember(MemberType::String, "IAPath")
+    .addMember(MemberType::Int64,
+               "ICERefCallback") // NNPICustomIAIceRefCallback*
     .setDocstring("This is an experimental NNPI-specific node representing a "
                   "custom IA op");
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -192,7 +192,8 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind(
             {ElemKind::Float16Ty}, {ROIAlignNode::BatchIndicesIdx}) &&
-        (NI.getInElemTy(ROIAlignNode::BatchIndicesIdx) == ElemKind::Int32ITy);
+        (NI.getInElemTy(ROIAlignNode::BatchIndicesIdx) == ElemKind::Int32ITy ||
+         NI.getInElemTy(ROIAlignNode::BatchIndicesIdx) == ElemKind::Int64ITy);
     break;
   case Kinded::Kind::LSTMUnitNodeKind:
     isNodePrecisionSupported =
@@ -279,10 +280,15 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         {ElemKind::Int8QTy, ElemKind::Float16Ty});
     break;
   case Kinded::Kind::FmodNodeKind:
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+    isNodePrecisionSupported =
+        NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
+#else
     // Supporting these two for now because for fp inputs NNPI returns result
     // with the same sign as the divisor instead of the dividend.
     isNodePrecisionSupported = NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::Int64ITy, ElemKind::Int32ITy});
+#endif // NNPI >= 1.7
     break;
   // Data transfer fp32/fp16/i8/i32/i64/bool.
   case Kinded::Kind::SaveNodeKind:
@@ -345,7 +351,11 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         case ElemKind::BoolTy:
           return true;
         case ElemKind::Int32ITy:
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+          return true;
+#else
           return glow::nnpi::flags::EnableCustomIAKernels;
+#endif // NNPI >= 1.7
         default:
           return false;
         }
@@ -388,6 +398,7 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
 
       case ElemKind::Int32ITy:
         switch (kindTo) {
+        case ElemKind::Int64ITy:
         case ElemKind::Float16Ty:
         case ElemKind::FloatTy:
         case ElemKind::Int8QTy:
@@ -791,8 +802,13 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
     break;
   case Kinded::Kind::CumSumNodeKind:
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+    isNodePrecisionSupported = NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::Int32ITy, ElemKind::Int8QTy, ElemKind::UInt8QTy});
+#else
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
+#endif // NNPI >= 1.7
     break;
   default:
     isNodeHasAnySupport = false;
@@ -2184,12 +2200,12 @@ Error NNPIBackend::bindContexts(
 
 /// Partial update of the NNPITensorDesc. Some members are ignored as they're
 /// not used for estimation.
-static bool updateDescForEstimate(NNPITensorDesc &desc,
-                                  const glow::TypeRef ty) {
+static bool updateDescForEstimate(NNPITensorDesc &desc, const glow::TypeRef ty,
+                                  bool alternativeLayout) {
   LOG_AND_RETURN_IF(ERROR, ty == nullptr, "Invalid type", false);
 
   // Update dims and layout.
-  NNPIImporter::updateDescDimsFromGlow(ty->dims(), desc);
+  NNPIImporter::updateDescDimsFromGlow(ty->dims(), desc, alternativeLayout);
 
   // Update Quantization.
   switch (ty->getElementType()) {
@@ -2256,14 +2272,16 @@ static bool updateDescForEstimate(NNPITensorDesc &desc,
 
 /// Prepare the list of NNPITensorDesc for the estimate call.
 static bool updateDescListForEstimate(std::vector<NNPITensorDesc> &descs,
-                                      const std::vector<glow::TypeRef> types) {
+                                      const std::vector<glow::TypeRef> types,
+                                      bool alternativeLayout = false) {
   if (descs.size() != types.size()) {
     return false;
   }
   bool retVal = true;
   for (size_t i = 0; i < descs.size(); i++) {
     if (types.at(i) != nullptr) {
-      retVal &= updateDescForEstimate(descs.at(i), types.at(i));
+      retVal &=
+          updateDescForEstimate(descs.at(i), types.at(i), alternativeLayout);
     }
   }
   return retVal;
@@ -2438,6 +2456,57 @@ double NNPIBackend::estimateEmbeddingNode(const glow::NodeInfo &NI,
   return estimate;
 }
 
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+static bool isBatchNormUsingAlternativeLayout(const size_t channelIdx,
+                                              const size_t numDims) {
+  // Handle NNPI_LAYOUT_NDHWC and NNPI_LAYOUT_NHWC layout.
+  if ((numDims == 4 || numDims == 5) && (channelIdx == numDims - 1)) {
+    return true;
+  }
+
+  // Handle NNPI_LAYOUT_CN layout.
+  if (numDims == 2 && channelIdx == 0) {
+    return true;
+  }
+
+  return false;
+}
+
+double NNPIBackend::estimateBatchNormalizationNode(
+    const BatchNormalizationNode *BN) const {
+
+  NodeInfo NI(*BN);
+  if (!isOpSupported(NI)) {
+    return -1.0;
+  }
+
+  auto inputDims = BN->getInput().getType()->dims().size();
+  auto alternativeLayout =
+      isBatchNormUsingAlternativeLayout(BN->getChannelIdx(), inputDims);
+
+  std::vector<NNPITensorDesc> descs(1); // only input for this node type
+
+  LOG_AND_RETURN_IF(ERROR,
+                    !updateDescListForEstimate(
+                        descs, {NI.getInTy(BatchNormalizationNode::InputIdx)},
+                        alternativeLayout),
+                    "Failed to update NNPITensorDesc", -1.0);
+
+  double estimate = -1.0;
+  const NNPITensorDesc *td = &(descs.at(0));
+
+  LOG_NNPI_IF_ERROR(
+      nnpiEstimateOp(
+          (BN->getName().str()).c_str(),
+          NNPI_COST_MODEL_OP_TYPE::NNPI_COST_MODEL_BATCH_NORMALIZATION,
+          0, /* subType is don't care for this node */
+          &td, 1, &estimate),
+      "Failed to estimate BatchNormalization op.");
+
+  return estimate;
+}
+#endif // NNPI >= 1.7
+
 Expected<double> NNPIBackend::estimateNodeCost(const glow::Node *node) const {
   double returnCost = -1.0;
   switch (node->getKind()) {
@@ -2494,6 +2563,13 @@ Expected<double> NNPIBackend::estimateNodeCost(const glow::Node *node) const {
                               EBBRO->getLengthsMode(), EBBRO->getAvgLength());
     break;
   }
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+  case Kinded::Kind::BatchNormalizationNodeKind: {
+    const BatchNormalizationNode *BN = llvm::cast<BatchNormalizationNode>(node);
+    returnCost = estimateBatchNormalizationNode(BN);
+    break;
+  }
+#endif // NNPI >= 1.7
   default:
     break;
   }
@@ -2501,19 +2577,4 @@ Expected<double> NNPIBackend::estimateNodeCost(const glow::Node *node) const {
                     strFormat("Estimate not supported for Node kind %s",
                               Kinded::getKindName(node->getKind())));
   return returnCost;
-}
-
-Expected<llvm::StringMap<std::unique_ptr<CompiledFunction>>>
-NNPIBackend::compileFunctions(std::vector<Function *> &functions,
-                              llvm::StringMap<BackendOptions> &optsMap) const {
-  if (functions.size() > 1) {
-    // This is experimental, so it is disabled by default.
-    // Use NNPI_WEIGHTS_OFF_MEM_POOL=1 to override this.
-    std::pair<std::string, std::string> wtsPoolOption(
-        "NNPI_disableWeightsInPool", "0");
-    for (auto it = functions.begin(), end = functions.end(); it != end; ++it) {
-      optsMap[(*it)->getName()].backendSpecificOpts.insert(wtsPoolOption);
-    }
-  }
-  return (Backend::compileFunctions(functions, optsMap));
 }

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -43,9 +43,6 @@ public:
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;
 
-  Expected<llvm::StringMap<std::unique_ptr<CompiledFunction>>>
-  compileFunctions(std::vector<Function *> &functions,
-                   llvm::StringMap<BackendOptions> &optsMap) const override;
 #if FACEBOOK_INTERNAL
   Expected<std::unique_ptr<CompiledFunction>>
   compileFX(const folly::dynamic &FXIR, const std::string &submod,
@@ -110,6 +107,13 @@ public:
   estimateEmbeddingNode(const glow::NodeInfo &NI, bool fp32Accumulation = false,
                         glow::LengthsMode lengthsMode = LengthsMode::Variable,
                         float averageLength = NAN) const;
+
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+  /// Estimate performance cost for a given BatchNorm Node \p BN.
+  /// \returns a unitless value to be used when comparing to other estimates.
+  /// or -1 if no estimate could be generated.
+  double estimateBatchNormalizationNode(const BatchNormalizationNode *BN) const;
+#endif // NNPI >= 1.7
 
   /// \returns a unitless value to be used when comparing Nodes or
   /// error if no estimate can be generated.

--- a/lib/Backends/NNPI/NNPIOptions.cpp
+++ b/lib/Backends/NNPI/NNPIOptions.cpp
@@ -81,6 +81,13 @@ template <> unsigned NNPIOptions::getStringAsType<unsigned>(std::string sVal) {
   return 0;
 }
 
+template <> uint64_t NNPIOptions::getStringAsType<uint64_t>(std::string sVal) {
+  if (isUInt(sVal)) {
+    return (uint64_t)std::strtoull(sVal.c_str(), NULL, 0);
+  }
+  return 0;
+}
+
 template <> float NNPIOptions::getStringAsType<float>(std::string sVal) {
   return std::strtof(sVal.c_str(), nullptr);
 }

--- a/lib/Backends/NNPI/NNPIOptions.h
+++ b/lib/Backends/NNPI/NNPIOptions.h
@@ -103,6 +103,8 @@ template <> int NNPIOptions::getStringAsType<int>(std::string sVal);
 template <> unsigned NNPIOptions::getStringAsType<unsigned>(std::string sVal);
 /// Explicit forward declaration of template type.
 template <> float NNPIOptions::getStringAsType<float>(std::string sVal);
+/// Explicit forward declaration of template type for uint64_t.
+template <> uint64_t NNPIOptions::getStringAsType<uint64_t>(std::string sVal);
 
 #define DECLARE_NNPI_OPTION(VAR_NAME, VAR_TYPE, OPT_NAME, OPT_DESC, OPT_ENV,   \
                             OPT_DEFAULT)                                       \
@@ -346,6 +348,13 @@ public:
                       "enableConvSpatialSplitter",
                       "Enable splits along X-Y Dims of Convolution Nodes.",
                       "NNPI_ENABLE_CONV_SPATIAL_SPLITTER", "0");
+
+  /// Enable Batch splitter for Convolution Nodes
+  /// This needs the 'Generic Node splitter' to be enabled.
+  DECLARE_NNPI_OPTION(enableConvBatchSplitter, bool, "enableConvBatchSplitter",
+                      "Enable splits on Batch Dim of Convolution Nodes.",
+                      "NNPI_ENABLE_CONV_BATCH_SPLITTER", "0");
+
   /// Approximation used in dequantization
   DECLARE_NNPI_OPTION(enableFCDynamicQuantizationAllSA, bool,
                       "enableFCDynamicQuantizationAllSA",
@@ -353,12 +362,37 @@ public:
                       "NNPI_ENABLE_FC_DQ_ALL_SA", "1");
 #endif
 
+  /// Pointer to custom DSP kernels library.
+  /// This is only valid if CustomDSPLib is not provided.
+  DECLARE_NNPI_OPTION(customDspKernelsLibPtr, uint64_t, "CustomDSPLibPtr",
+                      "Pointer to custom DSP kernels lib.",
+                      "NNPI_CUSTOM_DSP_LIB_PTR", "0");
+  /// Size of custom DSP kernels library.
+  DECLARE_NNPI_OPTION(customDspKernelsSize, uint64_t, "CustomDSPLibSize",
+                      "Size of custom DSP kernels lib.",
+                      "NNPI_CUSTOM_DSP_LIB_SIZE", "0");
+
   /// Disable weigths from memory pool.
   /// When this flag is true, weights will not be part of memory pool.
   /// This helps runtime to reuse weights based on SHA.
   DECLARE_NNPI_OPTION(disableWeightsInPool, bool, "disableWeightsInPool",
                       "Don't include weights in memory pool.",
                       "NNPI_WEIGHTS_OFF_MEM_POOL", "0");
+
+  /// Dump intermediate buffers.
+  DECLARE_NNPI_OPTION(dumpIntermediate, bool, "dumpIntermediate",
+                      "Dump Intermediate buffers.", "NNPI_DUMP_INTER", "0");
+
+  /// Number of Parallel Decider Compilations. 0 means all decider in parallel.
+  DECLARE_NNPI_OPTION(numDeciderCompilation, uint32_t, "numDeciderCompilation",
+                      "Number of Parallel Decider OMP Compilations.",
+                      "NNPI_NUM_PARALLEL_COMPILE", "2");
+
+  /// Weights threshold to be in pool, valid if disable weights pool is enabled.
+  DECLARE_NNPI_OPTION(thresholdDisableWeightsPool, uint32_t,
+                      "thresholdDisableWeightsPool",
+                      "Below this threshold, weights to be part of pool.",
+                      "NNPI_THRESHOLD_WEIGHTS_OFF_MEM_POOL", "0");
 
   NNPICompilationOptions(const BackendSpecificOptions &parameters) {
     INIT_NNPI_OPTIONS(useIceT, parameters);
@@ -396,8 +430,20 @@ public:
     INIT_NNPI_OPTIONS(enableESUnifyAdditionalPass, parameters);
     INIT_NNPI_OPTIONS(enableLayerSplitter, parameters);
     INIT_NNPI_OPTIONS(enableConvSpatialSplitter, parameters);
+    INIT_NNPI_OPTIONS(enableConvBatchSplitter, parameters);
 #endif
+    INIT_NNPI_OPTIONS(customDspKernelsLibPtr, parameters);
+    INIT_NNPI_OPTIONS(customDspKernelsSize, parameters);
     INIT_NNPI_OPTIONS(disableWeightsInPool, parameters);
+
+    INIT_NNPI_OPTIONS(dumpIntermediate, parameters);
+    if (inferOnDevice) {
+      // dumpIntermediate is not supported for device, works only with ice-ref.
+      dumpIntermediate.setVal(false);
+    }
+
+    INIT_NNPI_OPTIONS(numDeciderCompilation, parameters);
+    INIT_NNPI_OPTIONS(thresholdDisableWeightsPool, parameters);
   }
 
   virtual llvm::StringRef getOptionsName() const override {

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -84,7 +84,9 @@ struct BlacklistInitializer {
       {"IntGemm/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum_Float/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum_Float16/0", TestBlacklist::AnyDeviceAnyEngine},
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION < 7
       {"CumSum_Int32/0", TestBlacklist::AnyDeviceSWEngine},
+#endif // NNPI < 1.7
       {"CumSum_Int64/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum_Exclusive/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum_Reverse/0", TestBlacklist::AnyDeviceAnyEngine},
@@ -125,11 +127,13 @@ struct BlacklistInitializer {
       {"CumSum3D_bfloat16_t_Dim0/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_bfloat16_t_Dim1/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_bfloat16_t_Dim2/0", TestBlacklist::AnyDeviceAnyEngine},
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION < 7
       {"CumSum2D_int32_t_Dim0/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum2D_int32_t_Dim1/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_int32_t_Dim0/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_int32_t_Dim1/0", TestBlacklist::AnyDeviceAnyEngine},
       {"CumSum3D_int32_t_Dim2/0", TestBlacklist::AnyDeviceAnyEngine},
+#endif // NNPI < 1.7
       {"LayerNorm_Int8_With_Float_Scale_Bias/0",
        TestBlacklist::AnyDeviceAnyEngine},
       {"LayerNorm_BFloat16/0", TestBlacklist::AnyDeviceAnyEngine},
@@ -245,7 +249,12 @@ struct BlacklistInitializer {
       {"FloorDiv_Trunc_Int32ITy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"FloorDiv_Trunc_Int8QTy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ArithFmod_float/0", TestBlacklist::AnyDeviceAnyEngine},
+#if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 7
+      {"ArithFmod_int32_t/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"ArithFmod_int64_t/0", TestBlacklist::AnyDeviceAnyEngine},
+#else
       {"ArithFmod_float16_t/0", TestBlacklist::AnyDeviceAnyEngine},
+#endif // NNPI >= 1.7
       {"ArithFmod_bfloat16_t/0", TestBlacklist::AnyDeviceAnyEngine},
       {"BasicFmodNetFloatVsFloat16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"BasicFmodNetFloatVsBFloat16/0", TestBlacklist::AnyDeviceAnyEngine},


### PR DESCRIPTION
Summary:

    1. Support for ICE-REF callbacks for custom IA nodes.
    2. Support for passing custom DSP lib instead of file.
    3. Support for CumSum/Fmod operators.
    4. CostModel for BatchNorm node.
    5. Knob to dump intermediate in ice-ref flow (NNPI_DUMP_INTER).
    6. Knob for threshold for weights to be not part of pool for sharing (NNPI_THRESHOLD_WEIGHTS_OFF_MEM_POOL).
