### PR TITLE
Glow serialization integration with predictor

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -1203,7 +1203,8 @@ Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
 Error CachingGraphRunner::warmCache(
     const std::vector<InputMetaStack> &metaStacks,
     const PyTorchLoaderSettings &settings,
-    runtime::DeferredWeightLoader *loader, bool useMaxSizeCompilation) {
+    runtime::DeferredWeightLoader *loader, bool useMaxSizeCompilation,
+    const std::string &serializationSpec, const std::string &onnxModelFile) {
   if (!hostManager_) {
     return MAKE_ERR("Host manager is null!");
   }

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -234,7 +234,9 @@ public:
   Error warmCache(const std::vector<InputMetaStack> &metaStacks,
                   const PyTorchLoaderSettings &settings,
                   runtime::DeferredWeightLoader *loader,
-                  bool useMaxSizeCompilation = true);
+                  bool useMaxSizeCompilation = true,
+                  const std::string &serializationSpec = "",
+                  const std::string &onnxModelFile = "");
 
   /// Warmup Graphoutput shape Map by getting output value shapes for each
   /// batch size.

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -309,12 +309,13 @@ at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMetaStr is the
 /// raw string containing the meta data of the glow fuser node input.
-void glowAOTFusion(
-    torch::jit::Module &module, const std::string &inputMetaStr,
-    runtime::DeferredWeightLoader *loader,
-    const PyTorchLoaderSettings &settings,
-    const std::string method_name = "forward",
-    const std::unordered_map<int, std::string> &batchShapes = {});
+void glowAOTFusion(torch::jit::Module &module, const std::string &inputMetaStr,
+                   runtime::DeferredWeightLoader *loader,
+                   const PyTorchLoaderSettings &settings,
+                   const std::string method_name = "forward",
+                   const std::unordered_map<int, std::string> &batchShapes = {},
+                   const std::string &serializationSpec = "",
+                   const std::string &onnxModelFile = "");
 
 /// Lower a pytorch \p module to glow before execution. \p inputMeta is a
 /// vector containing the meta data of the model inputs.
@@ -323,7 +324,9 @@ void glowAOTFusionWithShapeInference(
     runtime::DeferredWeightLoader *loader,
     const PyTorchLoaderSettings &settings,
     const std::string method_name = "forward",
-    const std::unordered_map<int, std::string> &batchShapes = {});
+    const std::unordered_map<int, std::string> &batchShapes = {},
+    const std::string &serializationSpec = "",
+    const std::string &onnxModelFile = "");
 
 /// Enable overriding signal handlers while exeucting torch_glow code. This
 /// should only be used in Python to enable easier debugging and not in


### PR DESCRIPTION
Summary:
Context
To enable AOT model compilation, predictor need to read the serialized onnx model file and the Glow serialization spec file, then pass the content into Glow for AOT compilation.
Change
This diff modifies predictor API to pass serialized onnx model and serialization spec (as strings) to Glow. The compilation in Glow using the files will be in the next diff.

Differential Revision: D28477458

