### PR TITLE
option for not writing out weights to binary file

### DIFF
--- a/include/glow/LLVMIRCodeGen/BundleSaver.h
+++ b/include/glow/LLVMIRCodeGen/BundleSaver.h
@@ -58,6 +58,23 @@ public:
   /// Produce a bundle.
   virtual void produceBundle();
 
+  /// Set flag for saving weights.
+  /// \p val set the flag to this value.
+  void setSaveWeights(bool val) { saveWeights_ = val; }
+  /// Set flag for saving header.
+  /// \p val set the flag to this value.
+  void setSaveHeader(bool val) { saveHeader_ = val; }
+  /// Set flag for saving weights as text.
+  /// \p val set the flag to this value.
+  void setSaveWeightsAsText(bool val) { saveWeightsAsText_ = val; }
+
+  /// Get flag for saving weights.
+  bool getSaveWeights() const { return saveWeights_; }
+  /// Get flag for saving header.
+  bool getSaveHeader() const { return saveHeader_; }
+  /// Get flag for saving weights as text.
+  bool getSaveWeightsAsText() const { return saveWeightsAsText_; }
+
 protected:
   /// Perform memory allocation for a bundle.
   virtual void performBundleMemoryAllocation();
@@ -104,6 +121,12 @@ protected:
   BundleApiType bundleAPI_;
   /// Indicates if this bundle was saved already.
   bool isSaved_{false};
+  /// Flag for saving weights (to binary file).
+  bool saveWeights_{true};
+  /// Flag for saving header.
+  bool saveHeader_{true};
+  /// Flag for saving weights as text.
+  bool saveWeightsAsText_{true};
 };
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -629,14 +629,20 @@ void BundleSaver::produceBundle() {
   createBundleArchive(fileName, irgen_->getObjectRegistry(),
                       irgen_->getBundleObjects());
   // Output weights.
-  saveWeights(bundleWeightsBinOut);
+  if (saveWeights_) {
+    saveWeights(bundleWeightsBinOut);
+  }
   // Header file.
-  saveHeader(bundleHeaderOutput);
+  if (saveHeader_) {
+    saveHeader(bundleHeaderOutput);
+  }
   // Save weights also in text format for Static API.
-  if (bundleAPI_ == BundleApiType::Static) {
-    auto bundleWeightsTxtOut =
-        (outputDir + "/" + savedBundleName + ".weights.txt").str();
-    serializeBinaryToText(bundleWeightsBinOut, bundleWeightsTxtOut);
+  if (saveWeightsAsText_) {
+    if (bundleAPI_ == BundleApiType::Static) {
+      auto bundleWeightsTxtOut =
+          (outputDir + "/" + savedBundleName + ".weights.txt").str();
+      serializeBinaryToText(bundleWeightsBinOut, bundleWeightsTxtOut);
+    }
   }
 }
 


### PR DESCRIPTION
Summary: Add option for writing out weights in BundleSaver::produceBundle, so backend can control it to avoid writing out unnecessary weights file. The default is true for keeping same behavior as before.

Reviewed By: opti-mix

Differential Revision: D28917726

