### PR TITLE
Update Glow to build with LLVM 12

### DIFF
--- a/include/glow/LLVMIRCodeGen/GlowJIT.h
+++ b/include/glow/LLVMIRCodeGen/GlowJIT.h
@@ -22,7 +22,6 @@
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
-#include "llvm/ExecutionEngine/Orc/LambdaResolver.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
@@ -38,7 +37,7 @@
 #include <vector>
 
 #ifndef GLOW_JIT_ORC_VERSION
-#if LLVM_VERSION_MAJOR < 10
+#if LLVM_VERSION_MAJOR < 11
 #define GLOW_JIT_ORC_VERSION 1
 #else
 #define GLOW_JIT_ORC_VERSION 2
@@ -170,9 +169,8 @@ public:
 
   llvm::JITSymbol findSymbol(const std::string &name);
 
-  using ModuleHandle = llvm::orc::VModuleKey;
   void setContext(std::unique_ptr<llvm::LLVMContext> ctx);
-  ModuleHandle addModule(std::unique_ptr<llvm::Module> M);
+  void addModule(std::unique_ptr<llvm::Module> M);
 };
 using GlowJIT = GlowJITOrcV2;
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -435,7 +435,7 @@ Error Provisioner::provisionNetwork(std::unique_ptr<Network> network) {
 
         // Deserialize compiled function from cctx.nameToFunctions
         if (cctx.backendOpts.useDeserialize) {
-          std::string name = compiledFunction.first();
+          std::string name = compiledFunction.first().str();
           if (cctx.nameToFunctions.find(name) == cctx.nameToFunctions.end()) {
             return MAKE_ERR(
                 ErrorValue::ErrorCode::UNKNOWN,

--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 8 || argc == 9);
   size_t n = atoi(argv[1]);
   size_t numLayers = atoi(argv[2]);

--- a/tests/benchmark/BERTProxyLayerBench.cpp
+++ b/tests/benchmark/BERTProxyLayerBench.cpp
@@ -428,7 +428,7 @@ int main(int argc, char *argv[]) {
       "numReps numAsyncLaunches backendStr dtypeStr useInt8FCs\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 11);
   size_t maxSequenceLength = atoi(argv[1]);
   size_t batchSize = atoi(argv[2]);

--- a/tests/benchmark/BatchGemmBench.cpp
+++ b/tests/benchmark/BatchGemmBench.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
 
   assert(argc == 10 || argc == 11);
   size_t batchSize = atoi(argv[1]);

--- a/tests/benchmark/ConcatBench.cpp
+++ b/tests/benchmark/ConcatBench.cpp
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 9 || argc == 10);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
 
   std::vector<GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -156,7 +156,7 @@ public:
 };
 
 int main(int argc, char *argv[]) {
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 9);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/Int8AvgPool2dParallelBench.cpp
+++ b/tests/benchmark/Int8AvgPool2dParallelBench.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8Conv2dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv2dParallelBench.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8Conv3dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv3dParallelBench.cpp
@@ -269,7 +269,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8GemmBench.cpp
+++ b/tests/benchmark/Int8GemmBench.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[]) {
          "dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
 
   std::vector<Int8GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/Int8GemmParallelBench.cpp
+++ b/tests/benchmark/Int8GemmParallelBench.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 8 || argc == 9);
   if (argc > 8) {
     dev_id = argv[8];

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -519,7 +519,7 @@ int main(int argc, char *argv[]) {
   printf("\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
 
   std::vector<SLSParam> params;
   std::string runHeader;

--- a/tests/benchmark/TransposeBench.cpp
+++ b/tests/benchmark/TransposeBench.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
   assert(argc == 9 || argc == 10);
   size_t batchSize = atoi(argv[1]);
   size_t n = atoi(argv[2]);


### PR DESCRIPTION
Summary:
- Port GlowJIT to llvm 12
- Fix implicit StringRef -> std::string conversion 
- Replace use of llvm::DebugLoc::get 
- Replace ParseEnvironmentOptions with ParseCommandLineOptions 

Documentation:

Test Plan:
