### PR TITLE
[OnnxModelLoader] Fix Resize scale error message

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2596,10 +2596,9 @@ Error ONNXModelLoader::loadResize(const ONNX_NAMESPACE::NodeProto &op,
         (scales.size() >= 3 && scales.size() <= 6 && modeStr == "nearest") ||
             scales.size() == 4,
         opErrMsg(
-            op,
-            strFormat(
-                "Resize Scales dimension invalid. Mode: %s Scale Size: %zu",
-                modeStr.c_str(), scales.size())));
+            op, strFormat(
+                    "Resize Scales dimension invalid. Mode: %s Scale Size: %zu",
+                    modeStr.c_str(), scales.size())));
 
     for (auto &val : scales) {
       RETURN_ERR_IF_NOT(

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2598,7 +2598,7 @@ Error ONNXModelLoader::loadResize(const ONNX_NAMESPACE::NodeProto &op,
         opErrMsg(
             op,
             strFormat(
-                "UpSample Scales dimension invalid. Mode: %s Scale Size: %zu",
+                "Resize Scales dimension invalid. Mode: %s Scale Size: %zu",
                 modeStr.c_str(), scales.size())));
 
     for (auto &val : scales) {


### PR DESCRIPTION
Summary: If the scale value of `Resize` in ONNX is invalid, the message says: "Upsample Scales dimension invalid.". Since it's confusing, it should state "Resize Scales dimension invalid."
