### PR TITLE
Return Glow serialized onnx model string in AOT compilation

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -346,6 +346,15 @@ struct CompilationContext {
   /// Whether to serialize the DAG that has been optimized and partitioned.
   bool serializeCompiledDAG{false};
 
+  /// Whether to return the Glow AOT serialized ONNX model as a string;
+  /// If false, dump the model as an ONNX model file in local;
+  /// If true, return the model string to glowAOTSerializationModelStrPtr;
+  /// This is for Glow AOT compilation
+  bool returnGlowSerializedModelStr{false};
+
+  /// Placeholder for the returned Glow AOT serialized ONNX model string
+  std::shared_ptr<std::string> glowAOTSerializationModelStrPtr{nullptr};
+
   /// Whether to use Zip mode to serialize the DAG that has been optimized and
   /// partitioned.
   bool useZipModeForSerializeCompiledDAG{false};

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -509,7 +509,10 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
           /* includeConstantData */ cctx.saveConstantInSerializeCompiledDAG,
           extraMetadataProps, record, cctx.backendOpts.backendSpecificNodeInfo,
           cctx.skipProvisioning ? &cctx.loadedPHNames : nullptr,
-          cctx.skipProvisioning ? &cctx.staticPlaceholderTypesForAOT : nullptr);
+          cctx.skipProvisioning ? &cctx.staticPlaceholderTypesForAOT : nullptr,
+          cctx.returnGlowSerializedModelStr
+              ? cctx.glowAOTSerializationModelStrPtr.get()
+              : nullptr);
       RETURN_IF_ERR(writeErr);
     }
 

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -232,13 +232,15 @@ public:
   /// settings enable different settings for each compilation. If \p
   /// useMaxSizeCompilation , compile only a single Glow graph with an
   /// upper-bound on the input sizes (smaller inputs will be padded by Glow.)
-  Error
-  warmCache(const std::vector<InputMetaStack> &metaStacks,
-            const PyTorchLoaderSettings &settings,
-            runtime::DeferredWeightLoader *loader,
-            bool useMaxSizeCompilation = true, bool useDeserialize = false,
-            std::shared_ptr<std::unordered_map<std::string, std::vector<char>>>
-                nameToFunctions = nullptr);
+  Error warmCache(
+      const std::vector<InputMetaStack> &metaStacks,
+      const PyTorchLoaderSettings &settings,
+      runtime::DeferredWeightLoader *loader, bool useMaxSizeCompilation = true,
+      bool useDeserialize = false,
+      std::shared_ptr<std::unordered_map<std::string, std::vector<char>>>
+          nameToFunctions = nullptr,
+      std::shared_ptr<std::string> glowAOTSerializationSpecStrPtr = nullptr,
+      std::shared_ptr<std::string> glowAOTSerializationModelStrPtr = nullptr);
 
   /// Warmup Graphoutput shape Map by getting output value shapes for each
   /// batch size.

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -318,18 +318,20 @@ at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 void glowAOTFusion(
     torch::jit::Module &module, const std::string &inputMetaStr,
     runtime::DeferredWeightLoader *loader,
-    const PyTorchLoaderSettings &settings,
-    const std::string method_name = "forward",
-    const std::unordered_map<int, std::string> &batchShapes = {});
+    const PyTorchLoaderSettings &settings, std::string method_name = "forward",
+    const std::unordered_map<int, std::string> &batchShapes = {},
+    std::shared_ptr<std::string> glowAOTSerializationSpecStrPtr = nullptr,
+    std::shared_ptr<std::string> glowAOTSerializationModelStrPtr = nullptr);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMeta is a
 /// vector containing the meta data of the model inputs.
 void glowAOTFusionWithShapeInference(
     torch::jit::Module &module, const glow::InputMetaStack &metaStack,
     runtime::DeferredWeightLoader *loader,
-    const PyTorchLoaderSettings &settings,
-    const std::string method_name = "forward",
-    const std::unordered_map<int, std::string> &batchShapes = {});
+    const PyTorchLoaderSettings &settings, std::string method_name = "forward",
+    const std::unordered_map<int, std::string> &batchShapes = {},
+    std::shared_ptr<std::string> glowAOTSerializationSpecStrPtr = nullptr,
+    std::shared_ptr<std::string> glowAOTSerializationModelStrPtr = nullptr);
 
 /// Enable overriding signal handlers while exeucting torch_glow code. This
 /// should only be used in Python to enable easier debugging and not in


### PR DESCRIPTION
Summary:
Context
Current Glow serialization logic dumps the output onnx model file in local. The content of this file will be added as a string into extra_files during model transformation (in MTS). However, involving local file storage could cause issues. To prevent those issues, we add support to return the onnx model as a string directly to avoid local storage.
Change
Modify API of glowAOTFusion, glowAOTFusionWithShapeInference, warmCache to support returning the onnx model (output of Glow AOT compilation) as a string

Reviewed By: wfanzju

Differential Revision: D28981082

