### PR TITLE
[GraphOptimizer] Extend Reshape sinking pass for binary eltwise ops

### DIFF
--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -699,6 +699,8 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::BatchNormalizationNodeKind:
   case Kinded::Kind::BatchNormalizationGradNodeKind:
   case Kinded::Kind::PadNodeKind:
+  case Kinded::Kind::NonZeroNodeKind:
+  case Kinded::Kind::IntLookupTableNodeKind:
   case Kinded::Kind::ReshapeNodeKind:
   case Kinded::Kind::MeanVarNormalizationNodeKind:
   case Kinded::Kind::MatMulNodeKind:

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -673,7 +673,6 @@ int main(int argc, char **argv) {
       .addResultFromCtorArg()
       .dataParallel()
       .setDocstring("Performs element-wise exponential to the Input.");
-  // clang-format on
 
   BB.newNode("Logit")
       .addInput("Input")
@@ -685,8 +684,8 @@ int main(int argc, char **argv) {
   BB.newNode("NonZero")
       .addInput("Cond")
       .addResultFromCtorArg()
-      .dataParallel()
       .setDocstring("Selects indices of the true elements in Cond");
+  // clang-format on
 
   BB.newNode("Select")
       .addInput("Cond")
@@ -1432,7 +1431,6 @@ int main(int argc, char **argv) {
       .addInput("Input")
       .addInput("Mapping")
       .addResultFromCtorArg()
-      .dataParallel()
       .setDocstring("Simple mapping between quantized numbers."
                     "This can be used as quantized sigmoid or tanh functions.");
 


### PR DESCRIPTION
Summary:
Extend Reshape sinking pass for binary eltwise ops in GraphOptimizer.

Documentation:
N/A

Fixes #5247 

Test Plan:
Added GraphOptz unit test.