### PR TITLE
Fix the isInput logic

### DIFF
--- a/lib/Backend/BackendUtils.cpp
+++ b/lib/Backend/BackendUtils.cpp
@@ -150,26 +150,51 @@ bool isOutput(const Placeholder *PH, const IRFunction &F) {
   return isOutput(weight);
 }
 
-/// If \p W is a weight that is read from \returns true.
+/// If \p W is a weight that is first read from \returns true.
 bool isInput(const Value *W) {
   auto *weight = llvm::dyn_cast<WeightVar>(W);
-  DCHECK(weight) << "Expected WeightVar";
-
-  for (const auto &use : ValueUses(weight)) {
-    Instruction *user = use.get();
-    // Ignore deallocs.
-    if (isa<DeallocActivationInst>(user)) {
-      continue;
-    }
+  const glow::Instruction *firstUser = nullptr;
+  bool hasReads = false;
+  for (const auto &U : ValueUses(weight)) {
+    const auto *user = U.get();
     // TensorView instruction doesn't read from a placeholder.
     if (isa<TensorViewInst>(user)) {
       continue;
     }
-    OperandKind kind = use.getOperand().second;
+    // Remember the earliest use.
+    if (!firstUser || firstUser->getIterator() > user->getIterator()) {
+      firstUser = user;
+    }
+    // Ignore deallocs.
+    if (isa<DeallocActivationInst>(user)) {
+      continue;
+    }
+    OperandKind kind = U.getOperand().second;
     if (kind == OperandKind::In || kind == OperandKind::InOut) {
-      return true;
+      hasReads = true;
     }
   }
+
+  if (!hasReads) {
+    return false;
+  }
+
+  // Check if the first use is a read.
+  if (firstUser) {
+    // If this instruction has reads, then the first use is an @in.
+    auto *weightOrigin = getOrigin(weight);
+    for (int idx = 0, e = firstUser->getNumOperands(); idx < e; ++idx) {
+      const auto op = firstUser->getOperand(idx);
+      auto *opOrigin = getOrigin(op.first);
+      auto opKind = op.second;
+      if (opOrigin == weightOrigin && opKind == OperandKind::In) {
+        return true;
+      }
+    }
+    // No reads were found, thus the first use is a write.
+    return false;
+  }
+  // If there are no users, it is not an input.
   return false;
 }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -487,9 +487,10 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
   EXPECT_EQ(table.find(ex->getName().str())->second.output, false);
   EXPECT_EQ(table.find(input->getName().str())->second.input, true);
   EXPECT_EQ(table.find(input->getName().str())->second.output, false);
+  // HistogramPlaceholder node is not an input node, it is an output node.
   EXPECT_EQ(
       table.find(qp->getHistogramPlaceholder()->getName().str())->second.input,
-      true);
+      false);
   EXPECT_EQ(
       table.find(qp->getHistogramPlaceholder()->getName().str())->second.output,
       true);
@@ -523,6 +524,39 @@ TEST(IR, testInputToTensorView) {
   // should not be marked as an input buffer since that doesn't include any
   // reads of the buffer.
   EXPECT_EQ(isInput(output), false);
+}
+
+// Test the correctness of isInput.
+TEST(IR, testIsInput) {
+  Module mod;
+  Function *F = mod.createFunction("main");
+  IRFunction M(F);
+  IRBuilder builder(&M);
+  auto T0 = mod.uniqueType(ElemKind::FloatTy, {1024, 1024});
+  auto T1 = mod.uniqueType(ElemKind::FloatTy, {512, 1024});
+  auto *input0 = builder.createWeightVar(T1, "A");
+  auto *input1 = builder.createWeightVar(T1, "B");
+  auto *output0 = builder.createWeightVar(T0, "C0");
+  auto *output1 = builder.createWeightVar(T0, "C1");
+  auto *tvo0 =
+      builder.createTensorViewInst("output_view0", output0, T0, {0, 0});
+  auto *tvo1 =
+      builder.createTensorViewInst("output_view1", output1, T0, {512, 0});
+  // tv0 is used as src and dest in this instruction. This is a first operation
+  // using output0 and it first reads from it. Thus output0 should be reported
+  // as input.
+  builder.createElementAddInst("add0", tvo0, tvo0, input1);
+  // Write into tvo1. This is the first operation touching output1 and it is a
+  // write.
+  builder.createElementAddInst("add1", tvo1, input0, input1);
+  // Read from tvo1 and then write into it.
+  builder.createElementAddInst("add2", tvo1, tvo1, input1);
+  // output is used as an input to a TensorView instruction tvo0, which doesn't
+  // count. But then tvo0 is  used an input and output for the same add
+  // instruction. Thus, it is an input.
+  EXPECT_EQ(isInput(output0), true);
+  // output1 was first written into and then read. Therefore it is not an input.
+  EXPECT_EQ(isInput(output1), false);
 }
 
 // Test if the placeholders are allocated contiguously as


### PR DESCRIPTION
Summary: Take into account the order of instructions using a given buffer. If the first use is a write, this buffer is not an input.

Reviewed By: SameerAsal, chenccfb

Differential Revision: D29047164

