### PR TITLE
Add error handling when parse batch shape map & fix typo in CachingGraphRunner

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -1403,7 +1403,7 @@ Error CachingGraphRunner::warmCache(
                 settings, info, cctx, f, spec,
                 glowAOTSerializationModelStrPtr));
             RETURN_IF_ERR(saveGlowDeserializationSpec(
-                spec, glowAOTSerializationModelStrPtr));
+                spec, glowAOTSerializationSpecStrPtr));
           }
         }
 

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -870,6 +870,9 @@ BatchShapesMapType parseBatchShapeMapFromInputMeta(
     const at::ArrayRef<torch::jit::IValue> inputRefs(inputs);
     ShapeInferenceEngine shapeInf(*graph, inputRefs, baseSymbol, true);
     auto e = shapeInf.run();
+    if (e) {
+      LOG(ERROR) << ERR_TO_STRING(std::move(e));
+    }
     const auto &shapeMap = shapeInf.getVariableMap();
     batchShapesMap[it.first] = shapeMap;
   }


### PR DESCRIPTION
Summary:
Change 1: Add error handling when parsing shape map;
Change 2: Fix typo in CachingGraphRunner;

Reviewed By: wfanzju

Differential Revision: D29109462

