### PR TITLE
Enrich the log output from deserializeFromYaml

### DIFF
--- a/include/glow/PassManager/PassConfigUtils.h
+++ b/include/glow/PassManager/PassConfigUtils.h
@@ -64,7 +64,7 @@ template <typename Helper> struct SequenceTraits<std::vector<Helper>> {
 
 template <typename T> static T deserializeFromYaml(llvm::StringRef fileName) {
   T result;
-  llvm::outs() << fileName << "\n";
+  llvm::outs() << "Deserialize from " << fileName << "\n";
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> text =
       llvm::MemoryBuffer::getFileAsStream(fileName);
   assert(!text.getError() && "Unable to open file");

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -253,7 +253,7 @@ const char *getDotFileNodeColor(size_t index) {
 
 template <typename T> static T deserializeFromYaml(llvm::StringRef fileName) {
   T result;
-  llvm::outs() << fileName << "\n";
+  llvm::outs() << "Deserialize from " << fileName << "\n";
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> text =
       llvm::MemoryBuffer::getFileAsStream(fileName);
   assert(!text.getError() && "Unable to open file");


### PR DESCRIPTION
Summary:
Since `deserializeFromYaml` prints the file name without any other information, users might be confused about how to interpret the message. Printing the additional information will help us avoid digging deeper into the code to know what the message is and where it comes from.
