### PR TITLE
Fix build of benchmarks for LLVM-7

### DIFF
--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 8 || argc == 9);
   size_t n = atoi(argv[1]);
   size_t numLayers = atoi(argv[2]);

--- a/tests/benchmark/BERTProxyLayerBench.cpp
+++ b/tests/benchmark/BERTProxyLayerBench.cpp
@@ -428,7 +428,7 @@ int main(int argc, char *argv[]) {
       "numReps numAsyncLaunches backendStr dtypeStr useInt8FCs\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 11);
   size_t maxSequenceLength = atoi(argv[1]);
   size_t batchSize = atoi(argv[2]);

--- a/tests/benchmark/BatchGemmBench.cpp
+++ b/tests/benchmark/BatchGemmBench.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
 
   assert(argc == 10 || argc == 11);
   size_t batchSize = atoi(argv[1]);

--- a/tests/benchmark/Bench.h
+++ b/tests/benchmark/Bench.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "glow/Base/DimType.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace glow {
 
@@ -63,6 +64,15 @@ std::vector<dim_t> getBatchSizePerCore(size_t batchSize, dim_t numCores) {
     batchSizePerCore[core] = (endIdx - startIdx);
   }
   return batchSizePerCore;
+}
+
+inline void benchParseGlowOpts(int argc, const char *const *argv,
+                               const char *envvar = "GLOW_OPTS") {
+#if LLVM_VERSION_MAJOR < 8
+  llvm::cl::ParseEnvironmentOptions(argv[0], envvar);
+#else
+  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, envvar);
+#endif
 }
 
 } // namespace glow

--- a/tests/benchmark/ConcatBench.cpp
+++ b/tests/benchmark/ConcatBench.cpp
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 9 || argc == 10);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[]) {
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
 
   std::vector<GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -156,7 +156,7 @@ public:
 };
 
 int main(int argc, char *argv[]) {
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 9);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/Int8AvgPool2dParallelBench.cpp
+++ b/tests/benchmark/Int8AvgPool2dParallelBench.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8Conv2dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv2dParallelBench.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8Conv3dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv3dParallelBench.cpp
@@ -269,7 +269,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8GemmBench.cpp
+++ b/tests/benchmark/Int8GemmBench.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[]) {
          "dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
 
   std::vector<Int8GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/Int8GemmParallelBench.cpp
+++ b/tests/benchmark/Int8GemmParallelBench.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[]) {
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 8 || argc == 9);
   if (argc > 8) {
     dev_id = argv[8];

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -519,7 +519,7 @@ int main(int argc, char *argv[]) {
   printf("\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
 
   std::vector<SLSParam> params;
   std::string runHeader;

--- a/tests/benchmark/TransposeBench.cpp
+++ b/tests/benchmark/TransposeBench.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
   printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
          "environment variable\n");
-  llvm::cl::ParseCommandLineOptions(1, argv, "", nullptr, "GLOW_OPTS");
+  benchParseGlowOpts(argc, argv);
   assert(argc == 9 || argc == 10);
   size_t batchSize = atoi(argv[1]);
   size_t n = atoi(argv[2]);


### PR DESCRIPTION
Summary:

Add 'benchParseGlowOpts()' to isolate LLVM ParseEnvironmentOptions/ParseCommandLineOptions API differences in LLVM 7 versus later releases.

Documentation:
N/A