### PR TITLE
Support dynamically quantized FC in Caffe2 loader

### DIFF
--- a/tests/models/caffe2Models/dynamic_quantized_fc_init.pbtxt
+++ b/tests/models/caffe2Models/dynamic_quantized_fc_init.pbtxt
@@ -1,0 +1,38 @@
+name: "init"
+op {
+  output: "weights"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 3
+  }
+  arg {
+    name: "values"
+    s: "\x0\x1\x2\x3\x4\x5\x6\x7\x8\x9\xa\xb"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+op {
+  output: "bias"
+  name: ""
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 0
+    floats: 1
+    floats: 2
+    floats: 3
+  }
+}

--- a/tests/models/caffe2Models/dynamic_quantized_fc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/dynamic_quantized_fc_predict_net.pbtxt
@@ -1,0 +1,29 @@
+name: "int8_fc_dequantized"
+op {
+  input: "input"
+  input: "weights"
+  input: "bias"
+  output: "output"
+  name: ""
+  type: "Int8FC"
+  arg {
+    name: "axis"
+    i: 1
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+  arg {
+    name: "dequantize_output"
+    i: 1
+  }
+}
+external_input: "input"
+external_input: "weights"
+external_input: "bias"
+external_output: "output"


### PR DESCRIPTION
Summary: Support loading dynamic quantized FC in caffe2 loader for when the `dequantize_output` field is set to true

Reviewed By: khabinov

Differential Revision: D27601746

