### PR TITLE
[CPU] Add some fixes for Softmax 

### DIFF
--- a/lib/LLVMIRCodeGen/libjit/libjit.cpp
+++ b/lib/LLVMIRCodeGen/libjit/libjit.cpp
@@ -2981,6 +2981,7 @@ void libjit_softmax_i8(const int8_t *inW, int8_t *outW, const dim_t *dims,
     inW -= dims[1];
 
     // Compute the sum of exponentials.
+    // The exponentials from the LookUp Table are in Q1.31 format.
     uint32_t sum = 0;
     for (int i = 0; i < dims[1]; i++) {
       sum += (expData[*inW++ - max] >> (integerPoint - 1));
@@ -3000,7 +3001,7 @@ void libjit_softmax_i8(const int8_t *inW, int8_t *outW, const dim_t *dims,
     uint32_t division = (invScale + sum / 2) / sum;
     int size = (16 - invScalePoint + sumPoint);
     int point = 31 + size;
-  
+
     // Multiply with exp and bring the result into the right range.
     uint64_t rnd = 1 << (point - 1);
     for (int i = 0; i < dims[1]; i++) {


### PR DESCRIPTION
Summary:

Some toolchains do not support 64-bit divisions, so I replace this operation with a 32-bit division. To maintain the same maximum error, I reformat the fixed-point representation of some variables.

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
