### PR TITLE
Fix changed interface names for Fused8BitRowwiseQuantizedToFloat.

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -271,7 +271,7 @@ ShapeInferenceEngine::buildShapeSymbolMapping() {
       {"prim::dtype", ShapeInference(&primDtype, &SI::addShapeConstant)},
       {"prim::ListUnpack",
        ShapeInference(&listUnpack, &SI::addShapeDefaultList)},
-      {"fb::Fused8BitRowwiseQuantizedToFloat",
+      {"fbgemm::Fused8BitRowwiseQuantizedToFloat",
        ShapeInference(&fused8BitRowwiseQuantizedToFloat, &SI::addShapeDefault)},
       {"fb::compressed_indices_remap",
        ShapeInference(&compressedIndicesRemap, &SI::addShapeDefaultList)},


### PR DESCRIPTION
Summary: Correct namespace used for Fused8Bit operators.

Reviewed By: jianyuh

Differential Revision: D29561752

