### PR TITLE
Add DEBUG_LLVM_12 CI coverage

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -72,14 +72,15 @@ elif [ "${CIRCLE_JOB}" == "PYTORCH" ]; then
     sudo apt-get install -y ${GLOW_DEPS}
     install_fmt
 elif [ "${CIRCLE_JOB}" == "DEBUG_LLVM_11" ]; then
-    # Download/add llvm-11 and clang-11 to paths.
-    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    echo "c691a558967fb7709fb81e0ed80d1f775f4502810236aa968b4406526b43bee1  clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz" | sha256sum -c
-    tar xf clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-    export PATH=${PWD}/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04/bin:${PATH}
-    export LD_LIBRARY_PATH=${PWD}/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04/lib:${PATH}
-
+    # Install Glow dependencies
     sudo apt-get update
+    sudo apt-get install -y llvm-11
+    # Redirect clang
+    sudo ln -s /usr/bin/clang-11 /usr/bin/clang
+    sudo ln -s /usr/bin/clang++-11 /usr/bin/clang++
+    sudo ln -s /usr/bin/llvm-symbolizer-11 /usr/bin/llvm-symbolizer
+    sudo ln -s /usr/bin/llvm-config-11 /usr/bin/llvm-config-11.0
+
     sudo apt-get install -y ${GLOW_DEPS}
     install_fmt
 else

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -71,6 +71,17 @@ elif [ "${CIRCLE_JOB}" == "PYTORCH" ]; then
 
     sudo apt-get install -y ${GLOW_DEPS}
     install_fmt
+elif [ "${CIRCLE_JOB}" == "DEBUG_LLVM_11" ]; then
+    # Download/add llvm-11 and clang-11 to paths.
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    echo "c691a558967fb7709fb81e0ed80d1f775f4502810236aa968b4406526b43bee1  clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz" | sha256sum -c
+    tar xf clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    export PATH=${PWD}/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04/bin:${PATH}
+    export LD_LIBRARY_PATH=${PWD}/clang+llvm-11.1.0-x86_64-linux-gnu-ubuntu-16.04/lib:${PATH}
+
+    sudo apt-get update
+    sudo apt-get install -y ${GLOW_DEPS}
+    install_fmt
 else
     # Install Glow dependencies
     sudo apt-get update
@@ -110,7 +121,11 @@ if [[ "${CIRCLE_JOB}" != "PYTORCH" ]]; then
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
 fi
 
-CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")
+# Temporarily disable warnings as errors for LLVM 11 builds.
+if [[ "${CIRCLE_JOB}" != "DEBUG_LLVM_11" ]]; then
+    CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")
+fi
+
 CMAKE_ARGS+=("-DGLOW_WITH_CPU=ON")
 CMAKE_ARGS+=("-DGLOW_WITH_HABANA=OFF")
 

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -71,15 +71,15 @@ elif [ "${CIRCLE_JOB}" == "PYTORCH" ]; then
 
     sudo apt-get install -y ${GLOW_DEPS}
     install_fmt
-elif [ "${CIRCLE_JOB}" == "DEBUG_LLVM_11" ]; then
+elif [ "${CIRCLE_JOB}" == "DEBUG_LLVM_12" ]; then
     # Install Glow dependencies
     sudo apt-get update
-    sudo apt-get install -y llvm-11
-    # Redirect clang
-    sudo ln -s /usr/bin/clang-11 /usr/bin/clang
-    sudo ln -s /usr/bin/clang++-11 /usr/bin/clang++
-    sudo ln -s /usr/bin/llvm-symbolizer-11 /usr/bin/llvm-symbolizer
-    sudo ln -s /usr/bin/llvm-config-11 /usr/bin/llvm-config-11.0
+    # sudo apt-get install -y llvm-11
+    # # Redirect clang
+    # sudo ln -s /usr/bin/clang-11 /usr/bin/clang
+    # sudo ln -s /usr/bin/clang++-11 /usr/bin/clang++
+    # sudo ln -s /usr/bin/llvm-symbolizer-11 /usr/bin/llvm-symbolizer
+    # sudo ln -s /usr/bin/llvm-config-11 /usr/bin/llvm-config-11.0
 
     sudo apt-get install -y ${GLOW_DEPS}
     install_fmt
@@ -122,8 +122,8 @@ if [[ "${CIRCLE_JOB}" != "PYTORCH" ]]; then
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
 fi
 
-# Temporarily disable warnings as errors for LLVM 11 builds.
-if [[ "${CIRCLE_JOB}" != "DEBUG_LLVM_11" ]]; then
+# Temporarily disable warnings as errors for LLVM 12 builds.
+if [[ "${CIRCLE_JOB}" != "DEBUG_LLVM_12" ]]; then
     CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")
 fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
     <<: *linux_default
   DEBUG_LLVM_11:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9:ab1632df-fa59-40e6-8c23-98e004f61148"
     <<: *linux_default
   FEATURE_COMPILATION:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
+  DEBUG_LLVM_11:
+    environment:
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
+    <<: *linux_default
   FEATURE_COMPILATION:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
@@ -106,6 +110,7 @@ workflows:
   build:
     jobs:
       - DEBUG
+      - DEBUG_LLVM_11
       - FEATURE_COMPILATION
       - OPENCL
       - ASAN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,9 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
-  DEBUG_LLVM_11:
+  DEBUG_LLVM_12:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-py3.6-clang9:ab1632df-fa59-40e6-8c23-98e004f61148"
+      DOCKER_IMAGE: "pytorch/llvm:12.0.0"
     <<: *linux_default
   FEATURE_COMPILATION:
     environment:
@@ -110,7 +110,7 @@ workflows:
   build:
     jobs:
       - DEBUG
-      - DEBUG_LLVM_11
+      - DEBUG_LLVM_12
       - FEATURE_COMPILATION
       - OPENCL
       - ASAN

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -107,7 +107,7 @@ case ${CIRCLE_JOB} in
         run_unit_tests check
         run_unit_tests test_unopt
         ;;
-    DEBUG_LLVM_11)
+    DEBUG_LLVM_12)
         run_unit_tests check
         run_unit_tests test_unopt
         ;;

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -107,6 +107,10 @@ case ${CIRCLE_JOB} in
         run_unit_tests check
         run_unit_tests test_unopt
         ;;
+    DEBUG_LLVM_11)
+        run_unit_tests check
+        run_unit_tests test_unopt
+        ;;
     SHARED)
         # No tests with shared libs; it's similar to DEBUG.
         ;;

--- a/lib/Backend/BackendUtils.cpp
+++ b/lib/Backend/BackendUtils.cpp
@@ -472,7 +472,7 @@ static void allocateConstantsImpl(const ConstantsTy &constants,
     symbol.input = false;
     symbol.output = false;
     symbol.symbolCategory = glow::runtime::SymbolCategory::Constant;
-    symbolTable.emplace(C->getName(), symbol);
+    symbolTable.emplace(C->getName().str(), symbol);
     DEBUG_GLOW(LOG(INFO) << strFormat(
                    "Assigned address to constant %s: %zx (%zd bytes)\n",
                    C->getName().data(), symbol.offset, symbol.size));

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -788,7 +788,7 @@ bool glow::flags::processBackendSpecificOpts(
       LOG(ERROR) << "No '=' found in backend-specific opt " << opt.str();
       return false;
     }
-    optsMap.emplace(keyValPair.first, keyValPair.second);
+    optsMap.emplace(keyValPair.first.str(), keyValPair.second.str());
   }
   return true;
 }


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/glow/pull/5680#issuecomment-847527711

There were many breaking changes for llvm's StringRef in llvm-12, so add CI to cover it.