### PR TITLE
Add FusedRowwiseQuantizedSparseLengthsSum instruction

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5646,6 +5646,11 @@ void BoundInterpreterFunction::
   }
 }
 
+void BoundInterpreterFunction::fwdFusedRowwiseQuantizedSparseLengthsSumInst(
+    const FusedRowwiseQuantizedSparseLengthsSumInst *I) {
+  llvm_unreachable("Not supported");
+}
+
 template <typename T, typename AccumT>
 void BoundInterpreterFunction::fwdEmbeddingBagByteRowwiseOffsetsImpl(
     const EmbeddingBagByteRowwiseOffsetsInst *I) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -505,6 +505,18 @@ int main(int argc, char **argv) {
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
+  BB.newInstr("FusedRowwiseQuantizedSparseLengthsSum")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Data", OperandKind::In)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Lengths", OperandKind::In)
+      .addMember(MemberType::Boolean, "UseFP16Accumulation")
+      .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
+      .addMember(MemberType::Float, "AvgLength")
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int32ITy"});
+
   BB.newInstr("EmbeddingBagByteRowwiseOffsets")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Data", OperandKind::In)


### PR DESCRIPTION
Summary: While SLS can be expressed as SLWS with all weights being 1, it is not always the best idea when it comes to performance. Some backends may prefer to lower FusedRowwiseQuantizedSparseLengthsSum nodes into FusedRowwiseQuantizedSparseLengthsSum instructions.

Reviewed By: kunmingho

Differential Revision: D29685533

