### PR TITLE
Improve IRGen for InsertTensorNode and improve lowering of TileNode

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5646,6 +5646,11 @@ void BoundInterpreterFunction::
   }
 }
 
+void BoundInterpreterFunction::fwdFusedRowwiseQuantizedSparseLengthsSumInst(
+    const FusedRowwiseQuantizedSparseLengthsSumInst *I) {
+  llvm_unreachable("Not supported");
+}
+
 template <typename T, typename AccumT>
 void BoundInterpreterFunction::fwdEmbeddingBagByteRowwiseOffsetsImpl(
     const EmbeddingBagByteRowwiseOffsetsInst *I) {

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -344,7 +344,13 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *small = valueForNode(IT->getSmall());
     auto *dest = builder_.createAllocActivationInst(IT->getName(),
                                                     IT->getResult().getType());
-    builder_.createCopyInst(DECORATE_NODE_NAME(N, "copy"), dest, big);
+    if (small->getSizeInBytes() * count < big->getSizeInBytes()) {
+      builder_.createCopyInst(DECORATE_NODE_NAME(N, "copy"), dest, big);
+    } else {
+      // Small tensor completely fills the big tensor, thus no need to
+      // initialize the destination.
+      builder_.createTouchInst(DECORATE_NODE_NAME(N, "init"), dest);
+    }
     builder_.createInsertTensorInst(IT->getName(), dest, small, start, count,
                                     axis);
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -505,6 +505,18 @@ int main(int argc, char **argv) {
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
+  BB.newInstr("FusedRowwiseQuantizedSparseLengthsSum")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Data", OperandKind::In)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Lengths", OperandKind::In)
+      .addMember(MemberType::Boolean, "UseFP16Accumulation")
+      .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
+      .addMember(MemberType::Float, "AvgLength")
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int32ITy"});
+
   BB.newInstr("EmbeddingBagByteRowwiseOffsets")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Data", OperandKind::In)


### PR DESCRIPTION
Summary:
If InsertTensorNode completely fills the bigger tensor with the copies of the smaller one (which may happen e.g. when a TileNode is lowered into InsertTensorNode), then there is no need to first copy the old value of the big tensor as it will be completely overwritten anyways.

Improve the lowering of TileNode so that it does not use Splat to initialize the big tensor as this tensor will be completely overwritten by the copies of the small tensor represented by a tile content. Use a Touch node instead.

Reviewed By: jfix71

Differential Revision: D29685531

