### PR TITLE
Fix const-correctness of runDCEPass parameters

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPassManager.h
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPassManager.h
@@ -26,7 +26,7 @@ namespace glow {
 using FunctionPassManager = PassManager<FunctionPassPipeline, FunctionPass>;
 
 /// Helper to run a DCE pass on \p F given \p cctx. \returns if \p was modified.
-bool runDCEPass(Function *F, CompilationContext &cctx);
+bool runDCEPass(Function *F, const CompilationContext &cctx);
 
 } // namespace glow
 

--- a/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
+++ b/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
@@ -75,7 +75,8 @@ bool ThePassManager::runPassHook(const PassConfigBase &passConfig, PassBase &P,
                                           cctx);
 }
 
-bool runDCEPass(ThePassManager::IRContainerTy *F, CompilationContext &cctx) {
+bool runDCEPass(ThePassManager::IRContainerTy *F,
+                const CompilationContext &cctx) {
   auto pipeline = glow::make_unique<FunctionPassPipeline>();
   pipeline->pushBack(getDCEPassConfig());
   return FunctionPassManager("DCE_FPM", std::move(pipeline)).run(F, cctx);


### PR DESCRIPTION
Summary: Trivial change to pass CompilationContext as a const.

Reviewed By: protonu

Differential Revision: D29969738

