### PR TITLE
Fix LLVM 11 compile issues

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1683,12 +1683,12 @@ Error ONNXModelWriter::writeInstanceNormalization(
   // Add dictionary entries.
   addValueAttribute(proto, "epsilon", node->getEpsilon());
 
-  proto->set_name(node->getName());
+  proto->set_name(node->getName().str());
   proto->set_op_type("InstanceNormalization");
 
-  proto->add_input(node->getInput().getNode()->getName());
-  proto->add_input(node->getScale().getNode()->getName());
-  proto->add_input(node->getBias().getNode()->getName());
+  proto->add_input(node->getInput().getNode()->getName().str());
+  proto->add_input(node->getScale().getNode()->getName().str());
+  proto->add_input(node->getBias().getNode()->getName().str());
 
   outputsToProto(node, graph, proto);
   return Error::success();

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -669,7 +669,7 @@ writeGlowTensorsToOnnx(const std::string &filePrefix,
     auto *onnxT = onnxGraph.add_initializer();
     const auto *ph = placeholders[i];
     const auto &t = glowTensors[i];
-    onnxT->set_name(ph->getName());
+    onnxT->set_name(ph->getName().str());
     size_t unpaddedSize = t.getUnpaddedSizeInBytes();
     size_t tensorSize = t.getSizeInBytes();
     if (unpaddedSize == tensorSize) {

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3362,7 +3362,7 @@ PyTorchModelLoader::loadArithmeticNode(llvm::StringRef name,
   }
 
   std::pair<NodeValue, at::ScalarType> pp = {
-      F_.createNodeWithBroadcast<GlowNode>(name, /*axis*/ -1, lhsInput,
+       F_.createNodeWithBroadcast<GlowNode>(name.str(), /*axis*/ -1, lhsInput,
                                            rhsInput)
           ->getNthResult(0),
       correctType};


### PR DESCRIPTION

Summary:

There are a few places where an llvm::StringRef is passed to functions requiring std::string. This causes compile failures when using llvm-11.

