### PR TITLE
Allow Glow backends control if they want to strip the Glow module after deployment or compilation

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -128,6 +128,9 @@ public:
   /// Post-Lowering, false if it must be done after post-lowering.
   virtual bool shouldPreQuantizeConstants() const { return true; }
 
+  /// \returns true if a module should be stripped after deployment/compilation.
+  virtual bool shouldStripModule() const { return true; }
+
   /// \returns whether the provided \p NI is supported by the backend.
   virtual bool isOpSupported(const NodeInfo &NI) const = 0;
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -592,7 +592,9 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // Clear constants contents from the module then put it in a
   // shared_ptr to be shared between all of the networks created from each
   // function in the module.
-  if (!cctx.skipModuleStrip) {
+  auto targetBackendName = std::string(devices_[0]->getBackendName());
+  const auto &targetBackend = provisioner_->getBackend(targetBackendName);
+  if (targetBackend.shouldStripModule() && !cctx.skipModuleStrip) {
     module->strip();
   }
   VLOG(1) << "Cleanup";


### PR DESCRIPTION
Summary: Until now this setting was not under backend's control.

Reviewed By: gcatron

Differential Revision: D30164687

