### PR TITLE
Free memory more aggressively after constant folding

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -128,6 +128,9 @@ public:
   /// Post-Lowering, false if it must be done after post-lowering.
   virtual bool shouldPreQuantizeConstants() const { return true; }
 
+  /// \returns true if a module should be stripped after deployment/compilation.
+  virtual bool shouldStripModule() const { return true; }
+
   /// \returns whether the provided \p NI is supported by the backend.
   virtual bool isOpSupported(const NodeInfo &NI) const = 0;
 

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -414,6 +414,8 @@ static bool constantFoldFun(Function *F, const CompilationContext &cctx,
       // Replace the old result by the new constant result.
       N->getNthResult(idx).replaceAllUsesOfWith(constResult);
     }
+    // Perform Dead Code Elimination.
+    runDCEPass(F, cctx);
     changed = true;
   }
   return changed;

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -592,7 +592,9 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // Clear constants contents from the module then put it in a
   // shared_ptr to be shared between all of the networks created from each
   // function in the module.
-  if (!cctx.skipModuleStrip) {
+  auto targetBackendName = std::string(devices_[0]->getBackendName());
+  const auto &targetBackend = provisioner_->getBackend(targetBackendName);
+  if (targetBackend.shouldStripModule() && !cctx.skipModuleStrip) {
     module->strip();
   }
   VLOG(1) << "Cleanup";


### PR DESCRIPTION
Summary: Call DCE after constant folding to free memory occupied by big constant tensors much sooner than before

Reviewed By: gcatron

Differential Revision: D30164688

