### PR TITLE
Allow zero-sized memory allocations

### DIFF
--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -56,7 +56,10 @@ uint64_t MemoryAllocator::getEffectiveSize(uint64_t size) const {
 
 uint64_t MemoryAllocator::allocate(uint64_t size, Handle handle) {
   // Always allocate buffers properly aligned to hold values of any type.
-  uint64_t segmentSize = getEffectiveSize(size);
+  // Zero is a valid size and shows up in some shape computations and
+  // tests. To associate a Handle with the returned ptr, we
+  // need to allocate a segment.
+  uint64_t segmentSize = getEffectiveSize(std::max<uint64_t>(1, size));
   uint64_t prev = 0;
   for (auto it = segments_.begin(), e = segments_.end(); it != e; it++) {
     if (it->begin - prev >= segmentSize) {

--- a/tests/unittests/MemoryAllocatorTest.cpp
+++ b/tests/unittests/MemoryAllocatorTest.cpp
@@ -118,6 +118,8 @@ TEST(MemAlloc, dealloc) {
   void *handle2 = reinterpret_cast<void *>(2);
   void *handle3 = reinterpret_cast<void *>(3);
   void *handle4 = reinterpret_cast<void *>(4);
+  void *handle5 = reinterpret_cast<void *>(5);
+  void *handle6 = reinterpret_cast<void *>(6);
 
   auto p0 = MA.allocate(10, handle0);
   auto p1 = MA.allocate(10, handle1);
@@ -126,16 +128,23 @@ TEST(MemAlloc, dealloc) {
 
   auto p4 = MA.allocate(10, handle4);
 
+  auto p5 = MA.allocate(0, handle5);
+  auto p6 = MA.allocate(0, handle6);
+
   EXPECT_EQ(p0, 0);
   EXPECT_NE(p1, MemoryAllocator::npos);
   EXPECT_NE(p2, MemoryAllocator::npos);
   EXPECT_NE(p3, MemoryAllocator::npos);
   EXPECT_NE(p4, MemoryAllocator::npos);
+  EXPECT_NE(p5, MemoryAllocator::npos);
+  EXPECT_NE(p6, MemoryAllocator::npos);
 
   // Deallocate in some arbitrary order.
   MA.deallocate(handle0);
+  MA.deallocate(handle5);
   MA.deallocate(handle2);
   MA.deallocate(handle1);
+  MA.deallocate(handle6);
   MA.deallocate(handle3);
   // Check that it is possible to deallocate using the associated handle.
   MA.deallocate(handle4);


### PR DESCRIPTION
Summary: 
Zero-sized tensors are valid and can occur in some shape computations, but the computations fail during constant-folding because the allocator does not support zero-length allocations.

Since each handle must be associated with a unique pointer, an entire segment will be allocated. Operations involving zero-length tensors can almost always be optimized out of the graph, so these segments will be short-lived.

Test Plan:

Zero-sized allocations have been added to the MemAlloc.dealloc test.