### PR TITLE
[PyTorchModelLoader] Implementation of pixel_shuffle and pixel_unshuffle

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -1038,6 +1038,14 @@ private:
   /// Load PyTorch aten::narrow
   /// \returns error on failure.
   Error loadNarrow(const torch::jit::Node *ptNode);
+
+  // Load a PyTorch aten::pixel_shuffle.
+  // \returns error on failure.
+  Error loadPixelShuffle(const torch::jit::Node *ptNode);
+
+  // Load a PyTorch aten::pixel_unshuffle.
+  // \returns error on failure.
+  Error loadPixelUnshuffle(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/pixel_shuffle_test.py
+++ b/torch_glow/tests/nodes/pixel_shuffle_test.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import random
+import torch
+from tests import utils
+
+
+class SimplePixelShuffleModel(torch.nn.Module):
+    def __init__(self, upscale_factor):
+        super(SimplePixelShuffleModel, self).__init__()
+        self.upscale_factor = upscale_factor
+        self.ps = torch.nn.PixelShuffle(self.upscale_factor)
+
+    def forward(self, tensor):
+        return self.ps(tensor)
+
+
+class TestPixelShuffle(utils.TorchGlowTestCase):
+    def test_pixel_shuffle(self):
+        """Test of the PyTorch pixel_shuffle Node on Glow."""
+
+        for _ in range(0, 20):
+            c = random.randint(1, 3)
+            r = random.randint(2, 5)
+            w = random.randint(1, 100)
+            h = random.randint(1, 100)
+            b = random.randint(1, 10)
+
+            utils.compare_tracing_methods(
+                SimplePixelShuffleModel(r),
+                torch.randn(b, c * r ** 2, w, h),
+                fusible_ops={"aten::pixel_shuffle"},
+            )

--- a/torch_glow/tests/nodes/pixel_unshuffle_test.py
+++ b/torch_glow/tests/nodes/pixel_unshuffle_test.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import random
+import torch
+from tests import utils
+
+
+class SimplePixelUnshuffleModel(torch.nn.Module):
+    def __init__(self, downscale_factor):
+        super(SimplePixelUnshuffleModel, self).__init__()
+        self.downscale_factor = downscale_factor
+        self.ps = torch.nn.PixelUnshuffle(self.downscale_factor)
+
+    def forward(self, tensor):
+        return self.ps(tensor)
+
+
+class TestPixelUnshuffle(utils.TorchGlowTestCase):
+    def test_pixel_unshuffle(self):
+        """Test of the PyTorch pixel_unshuffle Node on Glow."""
+
+        for _ in range(0, 20):
+            c = random.randint(1, 3)
+            r = random.randint(2, 5)
+            w = random.randint(1, 100)
+            h = random.randint(1, 100)
+            b = random.randint(1, 10)
+
+            utils.compare_tracing_methods(
+                SimplePixelUnshuffleModel(r),
+                torch.randn(b, c, w * r, h * r),
+                fusible_ops={"aten::pixel_unshuffle"},
+            )


### PR DESCRIPTION
Summary:

Provides an implementation of pixel_shuffle and pixel_unshuffle for torch_glow. pixel_shuffle is needed to run AlphaPose. The code is a port of the PyTorch implementation at https://github.com/pytorch/pytorch/blob/3a66a1cb99d7e1c1fe7abf8f390e177b9183a436/aten/src/ATen/native/PixelShuffle.cpp

Documentation:

https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html
https://pytorch.org/docs/stable/generated/torch.nn.PixelUnshuffle.html

Test Plan:

Added pixel_shuffle_test.py and pixel_unshuffle_test.py which run some random test cases. 
Ran alphapose demo and verified that PyTorch CPU result matches Glow CPU result.
