### PR TITLE
cleaning up FX -> LLVM IR Gen.

### DIFF
--- a/include/glow/Graph/FXIRWrapper.h
+++ b/include/glow/Graph/FXIRWrapper.h
@@ -127,7 +127,9 @@ public:
     return constants_;
   }
 
-  const FXNode &getSingleUserNode(const FXNode &node) const;
+  /// When FXIR has the notion of memory/buffers. This function returns
+  /// the memory buffer a node(operator) writes to.
+  const FXNode &getDestinationBufferForNode(const FXNode &node) const;
 };
 
 } // namespace glow

--- a/lib/Graph/FXIRWrapper.cpp
+++ b/lib/Graph/FXIRWrapper.cpp
@@ -78,13 +78,17 @@ const FXNode &FXIRWrapper::getFXNodeByName(llvm::StringRef nodeName) const {
   return it->second;
 }
 
-const FXNode &FXIRWrapper::getSingleUserNode(const FXNode &node) const {
+const FXNode &
+FXIRWrapper::getDestinationBufferForNode(const FXNode &node) const {
 
   CHECK(node.find("users") != node.items().end())
       << "users field doesn't exist in node " << node;
+  CHECK_EQ(node["users"].size(), 1);
   auto users = node["users"].at(0);
   auto user_name = users["name"].getString();
-  return getFXNodeByName(user_name);
+  auto &dest_node = getFXNodeByName(user_name);
+  auto &dest = (getNodeOpCode(dest_node) == "output") ? node : dest_node;
+  return dest;
 }
 
 } // namespace glow


### PR DESCRIPTION
Summary: Using the new getSingleUserNode, and cleaning up implementation.

Differential Revision: D30214174

