### PR TITLE
[GLOW] erf support for CPU kernel

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -465,7 +465,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Reciprocal_Int8QTy/0",
     "Sin_Int8QTy/0",
     "Cos_Int8QTy/0",
-    "Erf_FloatTy/0",
     "Erf_Int8QTy/0",
     "rowwiseQuantizedFCTestAsymmetric_Int8_BiasFloat32/0",
     "rowwiseQuantizedFCTestSymmetric_Int8_BiasFloat32/0",

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -371,6 +371,7 @@ bool LLVMBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::CeilNodeKind:
   case Kinded::Kind::RoundNodeKind:
   case Kinded::Kind::SqrtNodeKind:
+  case Kinded::Kind::ErfNodeKind:
   case Kinded::Kind::RsqrtNodeKind:
   case Kinded::Kind::ReciprocalNodeKind:
   case Kinded::Kind::SinNodeKind:

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1297,6 +1297,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     ARITHMETIC_UNARY_OP_CASE(ElementCeil, "element_ceil");
     ARITHMETIC_UNARY_OP_CASE(ElementRound, "element_round");
     ARITHMETIC_UNARY_OP_CASE(ElementSqrt, "element_sqrt");
+    ARITHMETIC_UNARY_OP_CASE(ElementErf, "element_erf");
     ARITHMETIC_UNARY_OP_CASE(ElementRsqrt, "element_rsqrt");
     ARITHMETIC_UNARY_OP_CASE(ElementReciprocal, "element_reciprocal");
     ARITHMETIC_UNARY_OP_CASE(ElementSin, "element_sin");

--- a/lib/LLVMIRCodeGen/libjit/libjit.cpp
+++ b/lib/LLVMIRCodeGen/libjit/libjit.cpp
@@ -1662,6 +1662,8 @@ DEFINE_DATA_PARALLEL_KERNEL(libjit_element_round_kernel_f, float,
                             std::nearbyintf(LHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_sqrt_kernel_f, float,
                             std::sqrt(LHS[idx]))
+DEFINE_DATA_PARALLEL_KERNEL(libjit_element_erf_kernel_f, float,
+                            std::erf(LHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_rsqrt_kernel_f, float,
                             1 / std::sqrt(LHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_reciprocal_kernel_f, float,


### PR DESCRIPTION
erf function currently is missing CPU support. This change is to enable CPU support. 