### PR TITLE
Loading fixes for SparseLabelSplit in Caffe2 loader

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1260,13 +1260,22 @@ protected:
     NodeValue dataToInferDim;
     ASSIGN_VALUE_OR_RETURN_ERR(dataToInferDim, getNodeValueByName(op.input(2)));
 
-    RETURN_ERR_IF_NOT(indices.dims().size() == 1,
-                      opErrMsg(op, "Indices must be 1D tensor."));
+    RETURN_ERR_IF_NOT(indices.dims().size() == 1 || indices.dims().size() == 2,
+                      opErrMsg(op, "Indices must be 1D or 2D tensor."));
     RETURN_ERR_IF_NOT(indices.getElementType() == ElemKind::Int32ITy ||
                           indices.getElementType() == ElemKind::Int64ITy,
                       opErrMsg(op, "Indices must be of int32 or int64 type."));
 
     const std::string &opName = loadOperatorName(op);
+
+    if (indices.dims().size() == 1) {
+      indices = G_->createReshape(opName + ".indices2D", indices,
+                                  {indices.dims()[0], 1});
+    } else {
+      RETURN_ERR_IF_NOT(
+          indices.dims()[1] == 1,
+          opErrMsg(op, "Second dimension should be 1 in indices."));
+    }
 
     ShapeVector outDims{values.dims().begin(), values.dims().end()};
     outDims[0] = dataToInferDim.dims()[0];
@@ -1277,12 +1286,8 @@ protected:
     // SparseToDense has very similar behavior to ScatterND from ONNX
     // https://github.com/onnx/onnx/blob/master/docs/Operators.md#ScatterND,
     // therefore we can use ScatterND to implement SparseToDense.
-    // The difference is that SparseToDense requires 1D indices tensor,
-    // while ScatterND requires 2D indices tensor.
-    Node *indices2D = G_->createReshape(opName + ".indices2D", indices,
-                                        {indices.dims()[0], 1});
-    Node *result = G_->createScatterData(opName + ".scatterData", data,
-                                         indices2D, values, true);
+    Node *result = G_->createScatterData(opName + ".scatterData", data, indices,
+                                         values, true);
 
     RETURN_IF_ERR(addNodeAsOutput(op, result));
     return Error::success();

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2082,8 +2082,10 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                       opErrMsg(op, "Lengths should be of int32 type."));
     RETURN_ERR_IF_NOT(lengths.dims().size() == 1 || lengths.dims().size() == 2,
                       opErrMsg(op, "Lengths should be 1D or 2D tensor."));
-    RETURN_ERR_IF_NOT(indices.getElementType() == ElemKind::Int64ITy,
-                      opErrMsg(op, "Indices should be of int64 type."));
+    RETURN_ERR_IF_NOT(
+        indices.getElementType() == ElemKind::Int32ITy ||
+            indices.getElementType() == ElemKind::Int64ITy,
+        opErrMsg(op, "Indices should be of int32 or int64 type."));
     RETURN_ERR_IF_NOT(indices.dims().size() == 1 || indices.dims().size() == 2,
                       opErrMsg(op, "Indices should be 1D or 2D tensor."));
     RETURN_ERR_IF_NOT(values.getElementType() == ElemKind::FloatTy,
@@ -2101,6 +2103,10 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
           opErrMsg(op, "Second dimension should be 1 in lengths."));
       lengths = G_->createReshape(opName + ".lengths1D", lengths,
                                   {lengths.dims()[0]});
+    }
+    if (indices.getElementType() == ElemKind::Int32ITy) {
+      indices = G_->createConvertTo(opName + ".int32ToInt64", indices,
+                                    ElemKind::Int64ITy);
     }
     if (indices.dims().size() == 2) {
       RETURN_ERR_IF_NOT(

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -2176,8 +2176,10 @@ TEST_F(Caffe2ImporterTest, Swish) {
   EE.run(bindings);
 }
 
-// Test loading a SparseToDense operator.
-TEST_F(Caffe2ImporterTest, sparseToDense) {
+void testSparseToDense(llvm::ArrayRef<dim_t> indicesShape,
+                       llvm::ArrayRef<dim_t> valuesShape,
+                       llvm::ArrayRef<dim_t> dataToInferDimShape,
+                       int expectedNumberOfNodes) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2191,15 +2193,12 @@ TEST_F(Caffe2ImporterTest, sparseToDense) {
   PlaceholderBindings bindings;
 
   // Create inputs.
-  constexpr dim_t kNumIndices = 40;
-  constexpr dim_t kMaxIndex = 20;
-  constexpr dim_t kRows = 10;
-  constexpr dim_t kCols = 5;
-  Tensor indices(ElemKind::Int64ITy, {kNumIndices});
-  Tensor values(ElemKind::FloatTy, {kNumIndices, kRows, kCols});
-  Tensor dataToInferDim(ElemKind::FloatTy, {kMaxIndex});
+  Tensor indices(ElemKind::Int64ITy, indicesShape);
+  Tensor values(ElemKind::FloatTy, valuesShape);
+  Tensor dataToInferDim(ElemKind::FloatTy, dataToInferDimShape);
 
-  indices.getHandle<int64_t>().randomize(0, kMaxIndex - 1, mod.getPRNG());
+  indices.getHandle<int64_t>().randomize(0, dataToInferDimShape[0] - 1,
+                                         mod.getPRNG());
   values.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anything from the loader.
@@ -2215,13 +2214,14 @@ TEST_F(Caffe2ImporterTest, sparseToDense) {
   }
 
   // Check that the shape of the output matches that of the expected output.
-  const std::vector<dim_t> expectedOutputShape{kMaxIndex, kRows, kCols};
+  const std::vector<dim_t> expectedOutputShape{dataToInferDimShape[0],
+                                               valuesShape[1], valuesShape[2]};
   EXPECT_EQ(expectedOutputShape, outputPH->dims().vec());
 
   // High level checks on the content of the graph.
-  // We should have 1 Splat, 1 Reshape, 1 ScatterData and 1 Output node,
-  // i.e. 4 nodes in total.
-  EXPECT_EQ(F->getNodes().size(), 4);
+  // We should have 1 Splat, 1 optional Reshape, 1 ScatterData and 1 Output
+  // node, i.e. 4 nodes in total.
+  EXPECT_EQ(F->getNodes().size(), expectedNumberOfNodes);
 
   // Check that the graph has the expected shape (SparseToDense -> Save),
   // starting from the output.
@@ -2241,24 +2241,46 @@ TEST_F(Caffe2ImporterTest, sparseToDense) {
 
   // Initialize with zeroes
   std::vector<std::vector<std::vector<float>>> expected(
-      kMaxIndex,
-      std::vector<std::vector<float>>(kRows, std::vector<float>(kCols, 0)));
-  for (dim_t d1 = 0; d1 < kNumIndices; ++d1) {
+      expectedOutputShape[0],
+      std::vector<std::vector<float>>(
+          expectedOutputShape[1],
+          std::vector<float>(expectedOutputShape[2], 0)));
+  for (dim_t d1 = 0; d1 < valuesShape[0]; ++d1) {
     dim_t dest_d1 = indices.getHandle<int64_t>().at(d1);
-    for (dim_t d2 = 0; d2 < kRows; ++d2) {
-      for (dim_t d3 = 0; d3 < kCols; ++d3) {
+    for (dim_t d2 = 0; d2 < valuesShape[1]; ++d2) {
+      for (dim_t d3 = 0; d3 < valuesShape[2]; ++d3) {
         expected[dest_d1][d2][d3] += values.getHandle().at({d1, d2, d3});
       }
     }
   }
 
-  for (dim_t d1 = 0; d1 < kMaxIndex; ++d1) {
-    for (dim_t d2 = 0; d2 < kRows; ++d2) {
-      for (dim_t d3 = 0; d3 < kCols; ++d3) {
+  for (dim_t d1 = 0; d1 < expectedOutputShape[0]; ++d1) {
+    for (dim_t d2 = 0; d2 < expectedOutputShape[1]; ++d2) {
+      for (dim_t d3 = 0; d3 < expectedOutputShape[2]; ++d3) {
         EXPECT_NEAR(expected[d1][d2][d3], outputH.at({d1, d2, d3}), 1e-3);
       }
     }
   }
+}
+
+// Test loading a SparseToDense operator.
+TEST_F(Caffe2ImporterTest, sparseToDense_indices1D) {
+  constexpr dim_t kNumIndices = 40;
+  constexpr dim_t kMaxIndex = 20;
+  constexpr dim_t kRows = 10;
+  constexpr dim_t kCols = 5;
+
+  testSparseToDense({kNumIndices}, {kNumIndices, kRows, kCols}, {kMaxIndex}, 4);
+}
+
+TEST_F(Caffe2ImporterTest, sparseToDense_indices2D) {
+  constexpr dim_t kNumIndices = 40;
+  constexpr dim_t kMaxIndex = 20;
+  constexpr dim_t kRows = 10;
+  constexpr dim_t kCols = 5;
+
+  testSparseToDense({kNumIndices, 1}, {kNumIndices, kRows, kCols}, {kMaxIndex},
+                    3);
 }
 
 TEST_F(Caffe2ImporterTest, SparseToDenseMask) {


### PR DESCRIPTION
Summary: Making sure we support int32 indices too as we saw from the real models.

Differential Revision: D30242666

