### PR TITLE
Create assembly file along with .o file from glow

### DIFF
--- a/include/glow/LLVMIRCodeGen/CommandLine.h
+++ b/include/glow/LLVMIRCodeGen/CommandLine.h
@@ -68,6 +68,9 @@ extern llvm::cl::opt<std::string> llvmOpt;
 /// Set of options to pass to the external LLVM compiler.
 extern llvm::cl::list<std::string> llvmCompilerOptions;
 
+/// Option to create an asm file from llvm compiler.
+extern llvm::cl::opt<bool> llvmSaveAsm;
+
 /// Option to set float ABI. Used as -float-abi=<abi-type>.
 extern llvm::cl::opt<llvm::FloatABI::ABIType> floatABI;
 

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -87,6 +87,11 @@ llvm::cl::list<std::string> llvmCompilerOptions(
     llvm::cl::desc("Options to pass to the external LLVM compiler"),
     llvm::cl::ZeroOrMore);
 
+llvm::cl::opt<bool> llvmSaveAsm(
+    "llvm-save-asm",
+    llvm::cl::desc("Create and save asm file along with Bundle object file."),
+    llvm::cl::init(false), llvm::cl::cat(getLLVMBackendCat()));
+
 llvm::cl::opt<llvm::FloatABI::ABIType>
     floatABI("float-abi", llvm::cl::desc("Option to set float ABI type"),
              llvm::cl::values(clEnumValN(llvm::FloatABI::Default, "default",


### PR DESCRIPTION
Summary: Addition of an option to generate the asm file from glow. Generating the asm file from glow gives us more information in the assembly file, instead of generating it using obj-dump.

Reviewed By: opti-mix

Differential Revision: D30090236

