### PR TITLE
More Glow LLVM 12 fixes

### DIFF
--- a/lib/Backends/NNPI/NNPIOptions.h
+++ b/lib/Backends/NNPI/NNPIOptions.h
@@ -132,8 +132,8 @@ template <> uint64_t NNPIOptions::getStringAsType<uint64_t>(std::string sVal);
         llvm::formatv("{0} Default: {1} Environment Variable:",                \
                       VAR_NAME.getDefault(), VAR_NAME.getEnv())                \
             .str();                                                            \
-    std::string stVal =                                                        \
-        getFromMap(map, VAR_NAME.getName(), VAR_NAME.getDefault());            \
+    std::string stVal = getFromMap(map, VAR_NAME.getName().str(),              \
+                                   VAR_NAME.getDefault().str());               \
     stVal = NNPIOptions::getFromEnv(VAR_NAME.getEnv(), stVal);                 \
     this->VAR_NAME.setValFromString(stVal);                                    \
     this->loadedOptions_[VAR_NAME.getEnv()] =                                  \

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -629,7 +629,7 @@ Error HostManager::addNetworkFX(
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
     auto functions = module->getFunctions();
     for (auto &F : functions) {
-      std::string name = F->getName();
+      const auto name = F->getName().str();
       auto it = networks_.find(name);
       if (it != networks_.end() ||
           processingNetworks_.find(name) != processingNetworks_.end()) {


### PR DESCRIPTION
Summary:
Glow has some warnings under LLVM 12 that this diff fixes:
```
glow/glow/lib/Backends/NNPI/NNPIOptions.h:173:5: error: no matching member function for call to 'getFromMap'
    INIT_NNPI_OPTIONS(useIceT, llvm::StringMap<std::string>());
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glow/glow/lib/Backends/NNPI/NNPIOptions.h:173:23: error: no viable conversion from 'llvm::StringRef' to 'std::string' (aka 'basic_string<char>')
    INIT_NNPI_OPTIONS(useIceT, llvm::StringMap<std::string>());
    ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glow/glow/lib/Backends/NNPI/NNPIOptions.h:174:5: error: no matching member function for call to 'getFromMap'
    INIT_NNPI_OPTIONS(inferOnDevice, llvm::StringMap<std::string>());
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glow/glow/lib/Backends/NNPI/NNPIOptions.h:174:23: error: no viable conversion from 'llvm::StringRef' to 'std::string' (aka 'basic_string<char>')
    INIT_NNPI_OPTIONS(inferOnDevice, llvm::StringMap<std::string>());
    ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
glow/glow/lib/Backends/NNPI/NNPIOptions.h:175:5: error: no matching member function for call to 'getFromMap'
    INIT_NNPI_OPTIONS(showVars, llvm::StringMap<std::string>());
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Differential Revision: D30494912

