### PR TITLE
Add Support for GreaterOrEqual ONNX Op and unit test.

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1421,7 +1421,9 @@ protected:
   }
 
   // Loads Less operator. Internally it's a cmpLT Node.
-  Error loadLess(const OpType &op, ArgumentDictionaryTy &dict) {
+  // Reused for GreaterOrEqual by setting swapInputs to true.
+  Error loadLess(const OpType &op, ArgumentDictionaryTy &dict,
+                 bool swapInputs = false) {
     // Input Type.
     NodeValue xNV;
     ASSIGN_VALUE_OR_RETURN_ERR(xNV, getNodeValueByName(op.input(0)));
@@ -1433,8 +1435,10 @@ protected:
     auto *xNode = xNV.getNode();
     auto *yNode = yNV.getNode();
 
-    Node *N = G_->createNodeWithBroadcast<CmpLTNode>(opName, /* axis */ -1,
-                                                     xNode, yNode);
+    Node *N = swapInputs ? G_->createNodeWithBroadcast<CmpLTNode>(
+                               opName, /* axis */ -1, yNode, xNode)
+                         : G_->createNodeWithBroadcast<CmpLTNode>(
+                               opName, /* axis */ -1, xNode, yNode);
 
     RETURN_IF_ERR(addNodeAsOutput(op, N));
     return Error::success();

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -5624,6 +5624,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   if (typeName == "Equal") {
     return loadCmpEQ(op, dict);
   }
+  if (typeName == "GreaterOrEqual") {
+    return loadLess(op, dict, true);
+  }
   if (typeName == "CmpLTE") {
     return loadCmpLTE(op, dict);
   }

--- a/tests/models/onnxModels/GreaterOrEqual.onnxtxt
+++ b/tests/models/onnxModels/GreaterOrEqual.onnxtxt
@@ -1,0 +1,90 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "Y"
+       input: "X"
+       output: "Out"
+       name: "GreaterOrEqualNode"
+       op_type: "GreaterOrEqual"
+       domain: ""
+   }
+
+output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3597,6 +3597,37 @@ TEST_F(OnnxImporterTest, importLess) {
   EXPECT_EQ(CMPLT->getResult().dims()[2], 1);
 }
 
+TEST_F(OnnxImporterTest, importGreaterOrEqual) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/GreaterOrEqual.onnxtxt");
+
+  Placeholder *out = nullptr;
+  {
+    Tensor X(ElemKind::FloatTy, {1, 4, 1});
+    Tensor Y(ElemKind::FloatTy, {4, 1, 1});
+    X.zero();
+    Y.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"X", "Y"},
+                           {&X.getType(), &Y.getType()}, *F);
+    out = EXIT_ON_ERR(onnxLD.getOutputByName("Out"));
+  }
+
+  auto *save = getSaveNodeFromDest(out);
+
+  CmpLTNode *CMPLT = llvm::dyn_cast<CmpLTNode>(save->getInput().getNode());
+
+  ASSERT_TRUE(CMPLT);
+  ASSERT_EQ(CMPLT->getResult().dims().size(), 3);
+  EXPECT_EQ(CMPLT->getResult().dims()[0], 4);
+  EXPECT_EQ(CMPLT->getResult().dims()[1], 4);
+  EXPECT_EQ(CMPLT->getResult().dims()[2], 1);
+}
+
 TEST_F(OnnxImporterTest, importLessEqual) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();


### PR DESCRIPTION
Summary:

Documentation:
Add Support for GreaterOrEqual ONNX Op (reusing Less operator)

[Optional Fixes #issue]

Test Plan:
Added OnnxImporterTest

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
