### PR TITLE
Fix bundle_with_multiple_entries unit test for Debug

### DIFF
--- a/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
+++ b/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
@@ -55,23 +55,27 @@ int main(int argc, char **argv) {
   Function *F1 = M.createFunction("F1");
   auto *inputPH1 =
       M.createPlaceholder(ElemKind::FloatTy, {tensorSize}, "input1", false);
-  auto *reshapeNode11 = F1->createReshape("reshape", inputPH1, {1, tensorSize});
-  auto *matMulNode11 = F1->createMatMul("matmul", reshapeNode11, matMulConst1);
-  auto *matMulNode12 = F1->createMatMul("matmul", matMulNode11, matMulConst2);
+  auto *reshapeNode11 =
+      F1->createReshape("reshape11", inputPH1, {1, tensorSize});
+  auto *matMulNode11 =
+      F1->createMatMul("matmul11", reshapeNode11, matMulConst1);
+  auto *matMulNode12 = F1->createMatMul("matmul12", matMulNode11, matMulConst2);
   auto *reshapeNode12 =
-      F1->createReshape("reshape", matMulNode12, {tensorSize});
+      F1->createReshape("reshape12", matMulNode12, {tensorSize});
   auto *save1 = F1->createSave("output1", reshapeNode12);
 
   // Create a simple graph with 3 MatMul layers.
   Function *F2 = M.createFunction("F2");
   auto *inputPH2 =
       M.createPlaceholder(ElemKind::FloatTy, {tensorSize}, "input2", false);
-  auto *reshapeNode21 = F2->createReshape("reshape", inputPH2, {1, tensorSize});
-  auto *matMulNode21 = F2->createMatMul("matmul", reshapeNode21, matMulConst1);
-  auto *matMulNode22 = F2->createMatMul("matmul", matMulNode21, matMulConst2);
-  auto *matMulNode23 = F2->createMatMul("matmul", matMulNode22, matMulConst3);
+  auto *reshapeNode21 =
+      F2->createReshape("reshape21", inputPH2, {1, tensorSize});
+  auto *matMulNode21 =
+      F2->createMatMul("matmul21", reshapeNode21, matMulConst1);
+  auto *matMulNode22 = F2->createMatMul("matmul22", matMulNode21, matMulConst2);
+  auto *matMulNode23 = F2->createMatMul("matmul23", matMulNode22, matMulConst3);
   auto *reshapeNode22 =
-      F2->createReshape("reshape", matMulNode23, {tensorSize});
+      F2->createReshape("reshape22", matMulNode23, {tensorSize});
   auto *save2 = F2->createSave("output2", reshapeNode22);
 
   // Save a bundle with multiple functions.

--- a/include/glow/Optimizer/GraphOptimizer/NodeSplitting.h
+++ b/include/glow/Optimizer/GraphOptimizer/NodeSplitting.h
@@ -288,9 +288,9 @@ inline SplitNodeConstraint SplitNodeMaxMemConstraint(unsigned maxMem) {
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 splitNode(Node *node, const SplitNodeOption *splitOption,
@@ -303,9 +303,9 @@ splitNode(Node *node, const SplitNodeOption *splitOption,
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 Expected<std::vector<Node *>> splitNode(Node *node,
@@ -318,9 +318,9 @@ Expected<std::vector<Node *>> splitNode(Node *node,
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 Expected<std::vector<Node *>>
@@ -391,9 +391,9 @@ Expected<SplitNodeMap> splitNodes(Function *F,
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 Expected<SplitNodeMap>
@@ -413,9 +413,9 @@ splitNodeRecursively(Node *node, const SplitNodeOption *splitOption,
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 Expected<SplitNodeMap> splitNodeRecursively(Node *node,
@@ -433,9 +433,9 @@ Expected<SplitNodeMap> splitNodeRecursively(Node *node,
 /// NOTE: The original node is deleted from the graph after being split. When
 /// using this function while iterating the nodes of a function make sure to
 /// reverse iterate in order to not invalidate the iterator:
-///   auto &nodes = F->getNodes(); 
+///   auto &nodes = F->getNodes();
 ///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
-///     Node *node = &*(it++); 
+///     Node *node = &*(it++);
 ///     splitNode(node, ...);
 ///   }
 Expected<SplitNodeMap>

--- a/include/glow/Optimizer/GraphOptimizer/NodeSplitting.h
+++ b/include/glow/Optimizer/GraphOptimizer/NodeSplitting.h
@@ -285,8 +285,14 @@ inline SplitNodeConstraint SplitNodeMaxMemConstraint(unsigned maxMem) {
 /// then an error is thrown. \returns a vector with the nodes obtained after
 /// splitting \p node. The node is split only if there is a splitting logic
 /// implemented for the node type, otherwise an empty vector is returned.
-/// NOTE: The original node is deleted from the graph after being split.
-Expected<std::vector<Node *>>
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 splitNode(Node *node, const SplitNodeOption *splitOption,
           const SplitNodeConstraint *splitConstraint);
 
@@ -294,7 +300,14 @@ splitNode(Node *node, const SplitNodeOption *splitOption,
 /// \returns a vector with the nodes obtained after splitting \p node. The node
 /// is split only if there is a splitting logic implemented for the node type,
 /// otherwise an empty vector is returned.
-/// NOTE: The original node is deleted from the graph after being split.
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 Expected<std::vector<Node *>> splitNode(Node *node,
                                         const SplitNodeOption &splitOption);
 
@@ -302,7 +315,14 @@ Expected<std::vector<Node *>> splitNode(Node *node,
 /// \returns a vector with the nodes obtained after splitting \p node. The node
 /// is split only if there is a splitting logic implemented for the node type,
 /// otherwise an empty vector is returned.
-/// NOTE: The original node is deleted from the graph after being split.
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 Expected<std::vector<Node *>>
 splitNode(Node *node, const SplitNodeConstraint &splitConstraint);
 
@@ -368,7 +388,14 @@ Expected<SplitNodeMap> splitNodes(Function *F,
 /// - when a node is encountered for which there is no split support.
 /// - when a node is encountered for which the split constraint is not met.
 /// \returns a split node map for those nodes which were actually split.
-/// NOTE: The original nodes are deleted from the graph after being split.
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 Expected<SplitNodeMap>
 splitNodeRecursively(Node *node, const SplitNodeOption *splitOption,
                      const SplitNodeConstraint *splitConstraint,
@@ -383,7 +410,14 @@ splitNodeRecursively(Node *node, const SplitNodeOption *splitOption,
 /// If \p singleUseOnly is given then the recursive split procedure stops when
 /// encountering a node which has multiple uses.
 /// \returns a split node map for those nodes which were actually split.
-/// NOTE: The original nodes are deleted from the graph after being split.
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 Expected<SplitNodeMap> splitNodeRecursively(Node *node,
                                             const SplitNodeOption &splitOption,
                                             unsigned maxDepth,
@@ -396,7 +430,14 @@ Expected<SplitNodeMap> splitNodeRecursively(Node *node,
 /// If \p singleUseOnly is given then the recursive split procedure stops when
 /// encountering a node which has multiple uses.
 /// \returns a split node map for those nodes which were actually split.
-/// NOTE: The original nodes are deleted from the graph after being split.
+/// NOTE: The original node is deleted from the graph after being split. When
+/// using this function while iterating the nodes of a function make sure to
+/// reverse iterate in order to not invalidate the iterator:
+///   auto &nodes = F->getNodes(); 
+///   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e;) {
+///     Node *node = &*(it++); 
+///     splitNode(node, ...);
+///   }
 Expected<SplitNodeMap>
 splitNodeRecursively(Node *node, const SplitNodeConstraint &splitConstraint,
                      unsigned maxDepth, bool singleUseOnly = false);


### PR DESCRIPTION
**Summary**
During #5146 the *bundle_with_multiple_entries* was modified to use multiple intermediate layers in order to have a meaningful testing of the activations allocations for multiple functions (previous test did not use activations at all). The test worked inside the `RELEASE_WITH_EXPENSIVE_TESTS`. A hidden problem was that the two functions had some identical names for some symbols resulting in the bundle compilation failing for DEBUG build. This was solved by renaming the symbols such that the two functions do not share symbols with same name. This solved #5769.
Unrelated to this, I added more comments in NodeSplitting.h in order to avoid problems like those signaled in #5789.

**Fixes**
#5769
#5789

**Test Plan**
Current tests are passing.
