### PR TITLE
Use cmake-3.21 for PyTorch CI to unbreak

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -88,6 +88,14 @@ fi
 # Since we are using llvm-7 in these two branches, we cannot use pip install cmake
 if [ "${CIRCLE_JOB}" != "PYTORCH" ] && [ "${CIRCLE_JOB}" != "CHECK_CLANG_AND_PEP8_FORMAT" ]; then
     sudo pip install cmake==3.17.3
+elif [ "${CIRCLE_JOB}" == "PYTORCH" ]; then
+    mkdir ~/cmake-3.21.2
+    cd ~/cmake-3.21.2
+    mkdir install
+    wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
+    echo "y" | sudo sh cmake-3.21.2-linux-x86_64.sh --prefix=${PWD}/install
+    export PATH=${PWD}/install/cmake-3.21.2-linux-x86_64/bin:${PATH}
+    cd -
 else
     sudo apt-get install cmake
 fi


### PR DESCRIPTION
Due to https://github.com/pytorch/pytorch/pull/63660, seeing issues like the following on CI. Trying to update to latest stable cmake 3.21 to unbreak.

```
+ python setup.py install
Building wheel torch-1.10.0a0+git5b548f6
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.10 or higher is required.  You are running version 3.5.1
```