### PR TITLE
torch_glow: skip onnxification of inputs tensors, not required by the graph

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -680,8 +680,14 @@ writeGlowTensorsToOnnx(const std::string &filePrefix,
 
   ONNX_NAMESPACE::GraphProto onnxGraph;
   for (size_t i = 0; i < placeholders.size(); ++i) {
-    auto *onnxT = onnxGraph.add_initializer();
     const auto *ph = placeholders[i];
+    if (ph->getNumUsers() == 0) {
+      LOG(INFO) << "Tensor onnxification not required. Not being used: "
+                << ph->getName().str() << "\n";
+      continue;
+    }
+
+    auto *onnxT = onnxGraph.add_initializer();
     const auto &t = glowTensors[i];
     onnxT->set_name(ph->getName());
     size_t unpaddedSize = t.getUnpaddedSizeInBytes();


### PR DESCRIPTION
Summary: In torch_glow, instead of onnxifying all input tensors, only onnxify tensors used by the graph.

Reviewed By: jfix71

Differential Revision: D30658418

