### PR TITLE
Add support for lowering info during serialize_module, and add padding/partial to it (#64725)

### DIFF
--- a/lib/Backends/NNPI/FXIRImporter.cpp
+++ b/lib/Backends/NNPI/FXIRImporter.cpp
@@ -1045,6 +1045,14 @@ NNPINetwork FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
       } else {
         DBG("[--IO--] Unused Placeholder: " << name);
       }
+
+      // Gather Placeholders that allow partial input and require padding.
+      if (getValOrDefault(node, "allow_partial", false)) {
+        allowPartialPlaceholderNames_.insert(name);
+      }
+      if (getValOrDefault(node, "requires_padding", false)) {
+        requiresPaddingPlaceholderNames_.insert(name);
+      }
     } else if (opCode == "output") {
       const auto &args = node["args"];
 

--- a/lib/Backends/NNPI/FXIRImporter.h
+++ b/lib/Backends/NNPI/FXIRImporter.h
@@ -24,6 +24,7 @@
 #include "nnpi_transformer.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/raw_ostream.h"
 #include <folly/dynamic.h>
 #include <unordered_set>
@@ -123,6 +124,14 @@ public:
   bool isZeroes(const std::string &name, const utils::DTYPE &dtype,
                 const size_t &size) const;
 
+  /// \returns const references to allow partial and requires paddding names.
+  const llvm::StringSet<> &getAllowPartialPlaceholderNames() {
+    return allowPartialPlaceholderNames_;
+  }
+  const llvm::StringSet<> &getRequiresPaddingPlaceholderNames() {
+    return requiresPaddingPlaceholderNames_;
+  };
+
 private:
   /// NNPI network handle.
   NNPINetwork network_;
@@ -148,6 +157,10 @@ private:
 
   /// Set of tensors already defined.
   std::unordered_set<std::string> definedTensors_;
+
+  /// Sets of placeholder names that allow partial tensors or require padding.
+  llvm::StringSet<> allowPartialPlaceholderNames_;
+  llvm::StringSet<> requiresPaddingPlaceholderNames_;
 };
 
 /// Interface class for all node specific importers.

--- a/lib/Backends/NNPI/FXNNPI.cpp
+++ b/lib/Backends/NNPI/FXNNPI.cpp
@@ -26,7 +26,8 @@ NNPIBackend::compileFX(const folly::dynamic &FXIR, const std::string &submod,
                        const BackendOptions &opts, Module *glowModule) const {
   auto compiledFunc = std::make_unique<NNPICompiledFunction>(
       FXIR, submod, constants, glowModule);
-  auto compileHasError = compiledFunc->compileFX(FXIR, submod, constants, opts);
+  auto compileHasError =
+      compiledFunc->compileFX(FXIR, submod, constants, opts, glowModule);
 
   return compileHasError ? std::move(compileHasError)
                          : Expected<std::unique_ptr<CompiledFunction>>(

--- a/lib/Backends/NNPI/NNPICompiledFunction.h
+++ b/lib/Backends/NNPI/NNPICompiledFunction.h
@@ -151,7 +151,7 @@ public:
 #if FACEBOOK_INTERNAL
   Error compileFX(const folly::dynamic &FXIR, const std::string &submod,
                   const llvm::StringMap<const void *> &constants,
-                  const BackendOptions &opts);
+                  const BackendOptions &opts, Module *glowModule);
 #endif
 
   NNPICompilationOptions getCompilationOptions() const {


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/64725

- Any info added to the dict in node.meta["lowering_info"] will be added to the node_rep during serialization.
- Use this to add annotations on placeholders that allow partial inputs and require padding.
- Check for these annotations and set them in the NNPICompiledFunction as expected

Differential Revision: D30824192

