### PR TITLE
Enable running partitioned Recsys on multiple cards

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -51,10 +51,12 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend,
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
   if (!ignoreUserDeviceConfig_ &&
       loadDeviceConfigsFromFile(configs, deviceMemory_)) {
-    // Loaded from file, so verify that there is just a single device configured
-    // and that it matches the expected backend name.
-    CHECK_EQ(configs.size(), 1)
-        << "Expected a single device for the ExecutionEngine";
+    // Warning if there is more than a single device configured.
+    if (configs.size() != 1) {
+      LOG(WARNING) << "Found " << configs.size()
+                   << " devices configured for the ExecutionEngine";
+    }
+    // Verify that all configured devices match the expected backend name.
     CHECK(backendName_ == configs[0]->backendName)
         << "Expected backend name to match the ExecutionEngine";
   } else {

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -142,6 +142,12 @@ llvm::cl::opt<unsigned> numDevicesOpt(
     "num-devices", llvm::cl::desc("Number of devices to use for partitioning."),
     llvm::cl::Optional, llvm::cl::init(2), llvm::cl::cat(recSysTestCat));
 
+llvm::cl::opt<unsigned> partitioningNumDevicesOpt(
+    "partitioning-num-devices",
+    llvm::cl::desc(
+        "Number of devices to override sparseNNPartitioningNumCards."),
+    llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(recSysTestCat));
+
 llvm::cl::opt<std::string> traceDir(
     "trace-dir",
     llvm::cl::desc("Directory used to store Glow trace events files. If not "
@@ -1513,7 +1519,7 @@ TEST_P(RecommendationSystemTest,
   // Options for SparseNN Partitioning
   useSparseNNPartitioning = true;
   sparseNNPartitioningAddSLSConcats = true;
-  sparseNNPartitioningNumCards = 1;
+  sparseNNPartitioningNumCards = partitioningNumDevicesOpt;
   sparseNNPartitioningSLSKbytes = 1000000;
   sparseNNPartitioningNumCoresSLS = 6;
   sparseNNPartitioningNumCoresOther = 4;


### PR DESCRIPTION
Summary: This enables running partitioned Recsys on two cards with small changes.

Differential Revision: D30687162

