### PR TITLE
Unfuse glow ops after glow fusion

### DIFF
--- a/torch_glow/src/FuseKnownPatterns.h
+++ b/torch_glow/src/FuseKnownPatterns.h
@@ -26,6 +26,8 @@ void fuseKnownPatterns(
     std::shared_ptr<torch::jit::Graph> &graph,
     const std::unordered_set<torch::jit::Symbol> &opBlacklist);
 
+void unfuseDummyOperators(std::shared_ptr<torch::jit::Graph> &graph);
+
 /// Passes in detail namespace should not be used directly except for by
 /// unittests.
 namespace detail {

--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -464,6 +464,8 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
     unfuseSmallGraphs(graph, minFusionGroupSize, kind);
   }
 
+  unfuseDummyOperators(graph);
+
   EliminateCommonSubexpression(graph);
 
   EliminateDeadCode(graph);


### PR DESCRIPTION
Summary: During jit to glow lowering, some ops are replaced with dummy glow ops to simplify the lowering process. Due to `minFusionGroupSize`, small fusion groups are unfused and may lead to glow ops not being lowered to glow and the jit interpreter throwing an error since these ops aren't runnable on CPU. Thus, this fixes the issue by unfusing the glow ops back to their previous patterns in the `unfuseDummyOperators` pass.

Reviewed By: khabinov

Differential Revision: D30849396

