### PR TITLE
[ONNX] Add support for convolution 3D in ONNX importer and exporter

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -257,6 +257,27 @@ inline std::pair<dim_t, dim_t> calculateConvTransposeOutputDims(
   return {outsx, outsy};
 }
 
+/// Calculate the size of the output tensor based on the ConvTranspose
+/// parameters.
+inline std::tuple<dim_t, dim_t, dim_t> calculateConv3DTransposeOutputDims(
+    size_t sz, size_t sx, size_t sy, llvm::ArrayRef<unsigned_t> kernels,
+    llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
+    llvm::ArrayRef<unsigned_t> dilation = {1, 1, 1}) {
+  PaddingNFTBLR pdim(pads);
+  ShapeTHW kdim(kernels);
+  ShapeTHW sdim(strides);
+
+  size_t outsz = (sz - 1) * sdim.temporal_frames +
+                 (kdim.temporal_frames - 1) * dilation[0] + 1 - pdim.near -
+                 pdim.far;
+  size_t outsx = (sx - 1) * sdim.height + (kdim.height - 1) * dilation[1] + 1 -
+                 pdim.top - pdim.bottom;
+  size_t outsy = (sy - 1) * sdim.width + (kdim.width - 1) * dilation[2] + 1 -
+                 pdim.left - pdim.right;
+
+  return std::make_tuple(outsz, outsx, outsy);
+}
+
 /// Modes of the padding operation.
 enum PaddingMode { CONSTANT = 0, REFLECT, EDGE };
 

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -226,6 +226,12 @@ class ONNXModelLoader
   Error loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
                    ArgumentDictionaryTy &dict);
 
+  Error loadConv2D(const ONNX_NAMESPACE::NodeProto &op,
+                   ArgumentDictionaryTy &dict);
+
+  Error loadConv3D(const ONNX_NAMESPACE::NodeProto &op,
+                   ArgumentDictionaryTy &dict);
+
   /// Load MaxPool or AveragePool ONNX operator. \p typeName is the name of the
   /// ONNX operator being loaded, either MaxPool or AveragePool.
   Error loadPool(const ONNX_NAMESPACE::NodeProto &op,

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -2257,6 +2257,7 @@ Error ONNXModelWriter::writeConvolution3D(const Convolution3DNode *node,
   }
 
   // Add dictionary entries.
+  addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -359,9 +359,11 @@ Error writeMatMulKind(const T *node, ONNX_TRAITS::GraphProto &graph,
 // Reuses given \p proto pointer and create a new proto adding it to \p graph.
 template <typename T>
 void writeTransposeResult(const T *node, ONNX_NAMESPACE::NodeProto *&proto,
-                          ONNX_TRAITS::GraphProto &graph) {
+                          ONNX_TRAITS::GraphProto &graph,
+                          std::vector<unsigned_t> shuffleIn = NCHW2NHWC) {
   // Add dictionary entries.
-  std::vector<unsigned_t> shuffle(NCHW2NHWC);
+  std::vector<unsigned_t> shuffle = shuffleIn;
+
   llvm::ArrayRef<unsigned_t> container(shuffle);
   addValueAttribute(proto, "perm", container);
   // Re-use proto for Transpose node.
@@ -381,7 +383,8 @@ void writeTransposeResult(const T *node, ONNX_NAMESPACE::NodeProto *&proto,
 // Reuses given \p proto pointer and create a new proto adding it to \p graph.
 void writeTransposeInput(const Node *node, const Node *input,
                          ONNX_NAMESPACE::NodeProto *proto,
-                         ONNX_TRAITS::GraphProto &graph) {
+                         ONNX_TRAITS::GraphProto &graph,
+                         std::vector<unsigned_t> shuffleIn = NHWC2NCHW) {
   // Write "mirror" Transform input, i.e. NHWC2NCHW
   auto newName =
       node->getName().str() + "_" + input->getName().str() + "_in_transpose";
@@ -390,7 +393,8 @@ void writeTransposeInput(const Node *node, const Node *input,
   transformProto->set_op_type("Transpose");
 
   // Add dictionary entries.
-  std::vector<unsigned_t> shuffle(NHWC2NCHW);
+  std::vector<unsigned_t> shuffle = shuffleIn;
+
   llvm::ArrayRef<unsigned_t> container(shuffle);
   addValueAttribute(transformProto, "perm", container);
   transformProto->add_input(input->getName().str());
@@ -1381,6 +1385,7 @@ Error ONNXModelWriter::writeTranspose(const TransposeNode *node,
   // Some nodes create transpose for outputs.
   auto *input = node->getInput().getNode();
   if (llvm::dyn_cast<ConvolutionNode>(input) ||
+      llvm::dyn_cast<Convolution3DNode>(input) ||
       llvm::dyn_cast<AvgPoolNode>(input) ||
       llvm::dyn_cast<MaxPoolNode>(input) ||
       llvm::dyn_cast<SpaceToDepthNode>(input)) {
@@ -2225,14 +2230,66 @@ Error ONNXModelWriter::writeMaxPool(const MaxPoolNode *node, GraphType &graph) {
 
 Error ONNXModelWriter::writeConvolution3D(const Convolution3DNode *node,
                                           GraphType &graph) {
+  // Loading convolution creates a sandwich with Transpose nodes for Input,
+  // Weights, and Result. The lowering algorithm can remove Transpose nodes and
+  // replace one set of nodes with another ones. When saving a graph to ONNX
+  // format, keep in mind that when it will be loaded again a Transpose nodes
+  // sandwich will be created again. The steps will be:
+  // Remove Transpose nodes for Input and Weights, if such Transpose are not
+  // found (they are supposed to be NCTHW2NTHWC then create a "mirror"
+  // Transpose, i.e. NTHWC2NCTHW for correspondent Input or/and Weights.
+  // The similar algorithm will be applied for Result. If Transpose NTHWC2NCTHW
+  // node is found for Result user then remove it, otherwise create a "mirror"
+  // Transpose, i.e. NCTHW2NTHWC.
+  // assert(node->getLayout() == NTHWC && "can only write NTHWC Convolutions");
+
+  // Delegate writing quantized Convs to writeTensorwiseQuantizedConvolution.
+  // if (isQuantizedElemKind(node->getInput().getElementType())) {
+  //   return writeTensorwiseQuantizedConvolution(node, graph);
+  // }
+
   auto *proto = graph.add_node();
+
+  // Use the output of transpose node.
+  if (!outputKindToProto(Kinded::Kind::TransposeNodeKind, node, graph, proto)) {
+    // Apparently Result Transpose has been removed, add NCTHW2NTHWC Transpose.
+    writeTransposeResult(node, proto, graph, NCTHW2NTHWC);
+  }
+
   // Add dictionary entries.
-  addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
+  // addValueAttribute(proto, "dilations", node->getDilation());
 
-  return writeAllWithNode("Convolution3D", node, graph, proto);
+  const Node *input = node->getInput().getNode();
+  if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {
+    proto->add_input(TN->getInput().getNode()->getName().str());
+    reportedNodes_.insert(TN);
+  } else if (const ReshapeNode *RSN = llvm::dyn_cast<ReshapeNode>(input)) {
+    proto->add_input(RSN->getInput().getNode()->getName().str());
+    reportedNodes_.insert(RSN);
+  } else {
+    writeTransposeInput(node, input, proto, graph, NTHWC2NCTHW);
+  }
+
+  const Node *filter = node->getFilter().getNode();
+  if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(filter)) {
+    proto->add_input(TN->getInput().getNode()->getName().str());
+    reportedNodes_.insert(TN);
+  } else if (const ReshapeNode *RSN = llvm::dyn_cast<ReshapeNode>(filter)) {
+    proto->add_input(RSN->getInput().getNode()->getName().str());
+    reportedNodes_.insert(RSN);
+  } else {
+    writeTransposeInput(node, filter, proto, graph, NTHWC2NCTHW);
+  }
+
+  proto->add_input(node->getBias().getNode()->getName().str());
+
+  proto->set_name(node->getName().str());
+  proto->set_op_type("Conv");
+
+  return Error::success();
 }
 
 Error ONNXModelWriter::writeSpaceToDepth(const SpaceToDepthNode *node,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1199,12 +1199,13 @@ ONNXModelLoader::loadProto(const std::string &filename, bool zipMode,
   }
 
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
-  if (inputStringPtr == nullptr) {
-    RETURN_ERR_IF_NOT(ff,
-                      strFormat("Can't find the model or network files for %s.",
-                                filename.c_str()),
-                      ErrorValue::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
-  }
+  // if (inputStringPtr == nullptr) {
+  //   RETURN_ERR_IF_NOT(ff,
+  //                     strFormat("Can't find the model or network files for
+  //                     %s.",
+  //                               filename.c_str()),
+  //                     ErrorValue::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
+  // }
 
   // TODO: intend to find a way to reuse the following function later
   // for the text format onnx model:
@@ -1266,14 +1267,24 @@ Expected<Pads> getPads(ArgumentDictionaryTy &dict,
     }
     return getShape<unsigned_t>(dict["pads"]);
   }
+
+  // Set the default zero pads. Number of pads is dependent on input dims
+  auto zeroPads = [idim]() {
+    if (idim.size() == 3) {
+      return Pads({0, 0, 0, 0, 0, 0});
+    } else {
+      return Pads({0, 0, 0, 0});
+    }
+  };
+
   if (dict.count("auto_pad")) {
     std::string padStr;
     ASSIGN_VALUE_OR_RETURN_ERR(padStr, loadStr(dict.at("auto_pad")));
     if (padStr == "VALID") {
       // Return default value 0 for pads.
-      return Pads({0, 0, 0, 0});
+      return zeroPads();
     } else if (padStr == "SAME_UPPER" || padStr == "SAME_LOWER") {
-      unsigned_t top, left, bottom, right;
+      unsigned_t near, far, top, left, bottom, right;
       // From https://arxiv.org/pdf/1603.07285.pdf 2.4,
       // o = floor((i + 2*p - k)/s) + 1
       // Also, from https://github.com/onnx/onnx/blob/master/docs/Operators.md
@@ -1283,27 +1294,56 @@ Expected<Pads> getPads(ArgumentDictionaryTy &dict,
       //     (output_spatial_shape[i] - 1) * strides_spatial_shape[i]
       //         + kernel_spatial_shape[i] - input_spatial_shape[i]
       // Use the smallest padding possible out of the possible options.
-      llvm::SmallVector<unsigned_t, 2> pdim(2); // Total Paddding, HW.
       unsigned_t odim;
-      for (size_t i = 0, e = pdim.size(); i < e; i++) {
-        odim = ceil<unsigned_t>((float)idim[i] / (float)sdim[i]);
-        pdim[i] = sdim[i] * (odim - 1) + kdim[i] - idim[i];
-      }
-      if (padStr == "SAME_UPPER") {
-        // SAME_UPPPER: if odd number for pdim[i], use extra padding at the end.
-        top = pdim[0] / 2;
-        bottom = top + (pdim[0] & 0x1);
-        left = pdim[1] / 2;
-        right = left + (pdim[1] & 0x1);
+      if (idim.size() == 3) {
+        llvm::SmallVector<unsigned_t, 3> pdim(3); // Total Paddding, HW.
+        for (size_t i = 0, e = pdim.size(); i < e; i++) {
+          odim = ceil<unsigned_t>((float)idim[i] / (float)sdim[i]);
+          pdim[i] = sdim[i] * (odim - 1) + kdim[i] - idim[i];
+        }
+        if (padStr == "SAME_UPPER") {
+          // SAME_UPPPER: if odd number for pdim[i], use extra padding at the
+          // end.
+          near = pdim[0] / 2;
+          far = near + (pdim[0] & 0x1);
+          top = pdim[1] / 2;
+          bottom = top + (pdim[1] & 0x1);
+          left = pdim[2] / 2;
+          right = left + (pdim[2] & 0x1);
+        } else {
+          // SAME_LOWER: if odd number for pdim[i], use extra padding at the
+          // beginning.
+          far = pdim[0] / 2;
+          near = far + (pdim[0] & 0x1);
+          bottom = pdim[1] / 2;
+          top = bottom + (pdim[1] & 0x1);
+          right = pdim[2] / 2;
+          left = right + (pdim[2] & 0x1);
+        }
+        return Pads({near, far, top, bottom, left, right});
       } else {
-        // SAME_LOWER: if odd number for pdim[i], use extra padding at the
-        // beginning.
-        bottom = pdim[0] / 2;
-        top = bottom + (pdim[0] & 0x1);
-        right = pdim[1] / 2;
-        left = right + (pdim[1] & 0x1);
+        llvm::SmallVector<unsigned_t, 2> pdim(2); // Total Paddding, HW.
+        for (size_t i = 0, e = pdim.size(); i < e; i++) {
+          odim = ceil<unsigned_t>((float)idim[i] / (float)sdim[i]);
+          pdim[i] = sdim[i] * (odim - 1) + kdim[i] - idim[i];
+        }
+        if (padStr == "SAME_UPPER") {
+          // SAME_UPPPER: if odd number for pdim[i], use extra padding at the
+          // end.
+          top = pdim[0] / 2;
+          bottom = top + (pdim[0] & 0x1);
+          left = pdim[1] / 2;
+          right = left + (pdim[1] & 0x1);
+        } else {
+          // SAME_LOWER: if odd number for pdim[i], use extra padding at the
+          // beginning.
+          bottom = pdim[0] / 2;
+          top = bottom + (pdim[0] & 0x1);
+          right = pdim[1] / 2;
+          left = right + (pdim[1] & 0x1);
+        }
+        return Pads({top, left, bottom, right});
       }
-      return Pads({top, left, bottom, right});
     } else if (padStr == "NOTSET") {
       // We use explicit pads (if not given we assume its all zeros).
       if (dict.count("pads")) {
@@ -1313,14 +1353,14 @@ Expected<Pads> getPads(ArgumentDictionaryTy &dict,
         }
         return getShape<unsigned_t>(dict["pads"]);
       } else {
-        return Pads({0, 0, 0, 0});
+        return zeroPads();
       }
     }
     return MAKE_ERR("Only auto_pad==VALID, SAME_UPPER, SAME_LOWER and NOTSET "
                     "are supported");
   }
   // Return default value 0 for pads.
-  return Pads({0, 0, 0, 0});
+  return zeroPads();
 }
 
 /// Get the Pads value based on setting for auto_pad.
@@ -1725,6 +1765,26 @@ Error ONNXModelLoader::loadErf(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
+                                ArgumentDictionaryTy &dict) {
+  // Load the inputs
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  if (in.dims().size() == 3) {
+    return loadConv1D(op, dict);
+  } else if (in.dims().size() == 4) {
+    return loadConv2D(op, dict);
+  } else if (in.dims().size() == 5) {
+    return loadConv3D(op, dict);
+  } else {
+    return MAKE_ERR(strFormat(
+        "Only 1D (3 dims), 2D (4 dims) and 3D (5 dims) convolution are "
+        "supported by the ONNX loader but there are %zu input dims.",
+        in.dims().size()));
+  }
+}
+
 Error ONNXModelLoader::loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
                                   ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
@@ -1815,17 +1875,13 @@ Error ONNXModelLoader::loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
-Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
-                                ArgumentDictionaryTy &dict) {
+Error ONNXModelLoader::loadConv2D(const ONNX_NAMESPACE::NodeProto &op,
+                                  ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
 
   // Load the inputs
   NodeValue in;
   ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-
-  if (in.dims().size() == 3) {
-    return loadConv1D(op, dict);
-  }
 
   NodeValue filterValue;
   ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
@@ -1845,7 +1901,7 @@ Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
                              getDilations(dict, std::vector<unsigned_t>{1, 1}));
   RETURN_ERR_IF_NOT(
       dilations.size() == 2,
-      opErrMsg(op, strFormat("Conv dilations must be specified for 2 axes "
+      opErrMsg(op, strFormat("2D Conv dilations must be specified for 2 axes "
                              " found axes %zu",
                              dilations.size())));
 
@@ -1921,6 +1977,124 @@ Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
 
   // Transpose the output back.
   auto *N = G_->createTranspose(opName, node, NHWC2NCHW);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+
+  return Error::success();
+}
+
+Error ONNXModelLoader::loadConv3D(const ONNX_NAMESPACE::NodeProto &op,
+                                  ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  // Load the inputs
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  NodeValue filterValue;
+  ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
+
+  // Load the attributes
+  std::vector<unsigned_t> strides(3, 1);
+  if (dict.count("strides")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(strides, getShape<unsigned_t>(dict["strides"]));
+  }
+  unsigned_t group = 1;
+  if (dict.count("group")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict.at("group")));
+  }
+
+  std::vector<unsigned_t> dilations;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      dilations, getDilations(dict, std::vector<unsigned_t>{1, 1, 1}));
+  RETURN_ERR_IF_NOT(
+      dilations.size() == 3,
+      opErrMsg(op, strFormat("3D Conv dilations must be specified for 3 axes "
+                             " found axes %zu",
+                             dilations.size())));
+
+  // Transpose the filter to the right format. Glow expects to read the
+  // weights in the format CRSK. ONNX stores the operators as KCRS.
+  // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
+  TransposeNode *filterTransposeNode =
+      G_->createTranspose(opName, filterValue, NCTHW2NTHWC);
+
+  // The structure of the conv weights is: CRSK. We take the C, which is the
+  // number of filters. We use this value to calculate the size of the bias
+  // if it is not specified.
+  const NodeValue filterTransposedValue = filterTransposeNode->getResult();
+  dim_t depth = filterTransposedValue.dims()[0];
+
+  // Get the kernel shape from the input.
+  llvm::SmallVector<unsigned_t, 3> kernelShape(3);
+  kernelShape[0] = filterTransposedValue.dims()[1];
+  kernelShape[1] = filterTransposedValue.dims()[2];
+  kernelShape[2] = filterTransposedValue.dims()[3];
+
+  // Extra check when the 'kernel_shape' attribute exists.
+  // The 'kernel_shape' attribute is redundant not mandatory.
+  if (dict.count("kernel_shape")) {
+    std::vector<unsigned_t> kernelShapeAttribute;
+    ASSIGN_VALUE_OR_RETURN_ERR(kernelShapeAttribute,
+                               getShape<unsigned_t>(dict["kernel_shape"]));
+    bool cond = (kernelShape[0] == kernelShapeAttribute[0] &&
+                 kernelShape[1] == kernelShapeAttribute[1] &&
+                 (kernelShape[2] == kernelShapeAttribute[2]));
+    std::string msg = strFormat(
+        "The 'kernel_shape' attribute [%d, %d, %d] is not consistent with the "
+        "actual convolution kernel shape [%d, %d, %d].",
+        kernelShapeAttribute[0], kernelShapeAttribute[1],
+        kernelShapeAttribute[2], kernelShape[0], kernelShape[1],
+        kernelShape[2]);
+    RETURN_ERR_IF_NOT(cond, opErrMsg(op, msg));
+    (void)kernelShapeAttribute; // Avoids compilation warning in release mode.
+  }
+
+  // Construct the Bias field.
+  NodeValue B;
+  // Check if we have a serialized bias vector.
+  if (op.input_size() > 2) {
+    auto &biasTensorName = op.input(2);
+    // Load the serialized bias vector as NodeValue.
+    ASSIGN_VALUE_OR_RETURN_ERR(B, getNodeValueByName(biasTensorName));
+  }
+
+  // If a serialized bias wasn't found then create a zero bias.
+  if (op.input_size() == 2) {
+    auto biasTy = mod_.uniqueTypeWithNewShape(in.getType(), {depth});
+    Tensor biasTensor(biasTy);
+    biasTensor.zero();
+    B = mod_.createConstant("conv.bias", std::move(biasTensor));
+  }
+
+  // ONNX passes the input as NCTHW, and we expect the input to be NTHWC.
+  auto *tr = G_->createTranspose(opName, in, NCTHW2NTHWC);
+
+  // Calculate the size and allocate the output buffer.
+  ShapeNTHWC idim(tr->getResult().dims());
+
+  llvm::SmallVector<unsigned_t, 3> idimTHW(3);
+  idimTHW = {static_cast<glow::unsigned_t>(idim.t),
+             static_cast<glow::unsigned_t>(idim.h),
+             static_cast<glow::unsigned_t>(idim.w)};
+
+  // Pads : {pad_top, pad_left, pad_bottom, pad_right}
+  Pads pads;
+  ASSIGN_VALUE_OR_RETURN_ERR(pads,
+                             getPads(dict, kernelShape, strides, idimTHW));
+
+  auto outSz = calculate3DConvPoolOutputDims(idim.t, idim.h, idim.w,
+                                             kernelShape, strides, pads);
+  std::array<dim_t, 5> outDims = {
+      {idim.n, outSz.temporal_frames, outSz.height, outSz.width, depth}};
+  auto outTy = mod_.uniqueTypeWithNewShape(in.getType(), outDims);
+
+  auto *node = G_->createConv3D(opName, tr, filterTransposeNode, B, outTy,
+                                kernelShape, strides, pads, group);
+
+  // Transpose the output back.
+  auto *N = G_->createTranspose(opName, node, NTHWC2NCTHW);
+
   RETURN_IF_ERR(addNodeAsOutput(op, N));
 
   return Error::success();

--- a/tests/models/onnxModels/simpleConv3D.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3D.onnxtxt
@@ -1,0 +1,168 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadSameLower.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadSameLower.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_LOWER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }    
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadSameUpper.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadSameUpper.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_UPPER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }    
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadValid.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadValid.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "VALID"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }    
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DNonSquareDilation.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DNonSquareDilation.onnxtxt
@@ -1,0 +1,168 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/unittests/ImporterTestUtils.h
+++ b/tests/unittests/ImporterTestUtils.h
@@ -40,6 +40,26 @@ void getNCHWData(Tensor *result, dim_t n, dim_t c, dim_t h, dim_t w) {
     RH.raw(i) = i;
 }
 
+/// Populate \p result with increasing number following the NCTHW format.
+/// E.g.:
+/// N=1, T=2:
+///               T=0              T=1
+///               W=3
+///             <---->
+///      ^  +---+---+---+    +----+----+----+
+///  C=1/   | 0 | 1 | 2 |    |  9 | 10 | 11 |  ^
+///    /    +---+---+---+    +----+----+----+  | H=3
+///   v     | 3 | 4 | 5 |    | 12 | 13 | 14 |  v
+///         +---+---+---+    +----+----+----+
+///         | 6 | 7 | 8 |    | 15 | 16 | 17 |
+///         +---+---+---+    +----+----+----+
+void getNCTHWData(Tensor *result, dim_t n, dim_t c, dim_t t, dim_t h, dim_t w) {
+  result->reset(ElemKind::FloatTy, {n, c, t, h, w});
+  auto RH = result->getHandle<>();
+  for (size_t i = 0, e = n * c * t * h * w; i < e; i++)
+    RH.raw(i) = i;
+}
+
 /// \returns the number of nodes in \p F of kind \p kind.
 unsigned countNodeKind(Function *F, Kinded::Kind kind) {
   unsigned count = 0;

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -459,7 +459,8 @@ TEST(exporter, onnxModels) {
             std::string::npos ||
         name.find("sliceInvalidAxes.onnxtxt") != std::string::npos ||
         name.find("sliceWithUnsupportedStep.onnxtxt") != std::string::npos ||
-        name.find("simpleConv3DNonSquareDilation.onnxtxt") != std::string::npos) {
+        name.find("simpleConv3DNonSquareDilation.onnxtxt") !=
+            std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";
       continue;

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -458,7 +458,8 @@ TEST(exporter, onnxModels) {
         name.find("simpleConvTransposeAutoPadSameUpper.onnxtxt") !=
             std::string::npos ||
         name.find("sliceInvalidAxes.onnxtxt") != std::string::npos ||
-        name.find("sliceWithUnsupportedStep.onnxtxt") != std::string::npos) {
+        name.find("sliceWithUnsupportedStep.onnxtxt") != std::string::npos ||
+        name.find("simpleConv3DNonSquareDilation.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";
       continue;

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1047,6 +1047,73 @@ static void convTestHelper(std::string &filename,
   }
 }
 
+/// Helper method to run the Conv operator test cases.
+/// \p filename contains the model .onnxtxt.
+/// \p expectedDims: output Tensor dimensions.
+/// \p expectedValues : output Tensor values expected.
+/// The input is N*C*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 1, 1}, group is 1. Pads can vary.
+static void conv3DTestHelper(std::string &filename,
+                             llvm::ArrayRef<dim_t> inputDims,
+                             llvm::ArrayRef<dim_t> expectedDims,
+                             llvm::ArrayRef<float> expectedValues) {
+
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename =
+      std::string(GLOW_DATA_PATH "tests/models/onnxModels/") + filename;
+
+  PlaceholderBindings bindings;
+  Placeholder *graphOutputVar;
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Tensor data;
+    getNCTHWData(&data, inputDims[0], inputDims[1], inputDims[2], inputDims[3],
+                 inputDims[4]);
+    ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
+    graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"data"}, {&data});
+  }
+
+  // ONNX importer loads a conv node and converts it to 4 ops:
+  // Transpose (input)   -> Conv -> Transpose
+  // Transpose (filter) ->
+  // A save node is added in the network as well. Therefore there are 5 nodes:
+  // Transpose (input)   -> Conv -> Transpose -> Save
+  // Transpose (filter) ->
+  // Note that in case the convolution filter is a constant tensor, the filter
+  // transpose node will be later optimized out by the optimizer.
+  EXPECT_EQ(F->getNodes().size(), 5);
+  EXPECT_EQ(mod.getPlaceholders().size(), 2);
+  EXPECT_EQ(mod.getConstants().size(), 2);
+
+  auto *saveNode = getSaveNodeFromDest(graphOutputVar);
+  auto *node = saveNode->getInput().getNode();
+
+  EXPECT_TRUE(node->getKind() == Kinded::Kind::TransposeNodeKind);
+  auto *convNode = llvm::dyn_cast<TransposeNode>(node)->getInput().getNode();
+
+  EXPECT_TRUE(convNode->getKind() == Kinded::Kind::Convolution3DNodeKind);
+  auto *tInNode =
+      llvm::dyn_cast<Convolution3DNode>(convNode)->getInput().getNode();
+  auto *tFilterNode =
+      llvm::dyn_cast<Convolution3DNode>(convNode)->getFilter().getNode();
+  EXPECT_TRUE(tInNode->getKind() == Kinded::Kind::TransposeNodeKind);
+  EXPECT_TRUE(tFilterNode->getKind() == Kinded::Kind::TransposeNodeKind);
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+  auto result = bindings.get(graphOutputVar)->getHandle();
+  EXPECT_TRUE(result.dims() == expectedDims);
+  for (size_t i = 0, e = expectedValues.size(); i < e; i++) {
+    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  }
+}
+
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is {1, 1, 1, 1}, group is 1.
@@ -1096,6 +1163,69 @@ TEST_F(OnnxImporterTest, importConvAutoPadSameLower) {
   std::vector<dim_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {2, 3, 5, 5, 10, 14, 11, 22, 26};
   convTestHelper(filename, expectedDims, expectedValues);
+}
+
+/// Test loading conv 3D op from a ONNX model.
+/// The input is N*C*T*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 1, 1}, pads is {1, 1, 1, 1, 1, 1}, group is 1.
+TEST_F(OnnxImporterTest, importConv3D) {
+  std::string filename("simpleConv3D.onnxtxt");
+  std::vector<dim_t> inputDims = {1, 1, 2, 3, 3};
+  std::vector<dim_t> expectedDims = {1, 1, 3, 3, 3};
+  std::vector<float> expectedValues = {
+      3.0,   6.0,  6.0,   10.0, 16.0, 14.0, 12.0,  18.0, 15.0,
+      26.25, 39.0, 32.25, 47.0, 68.0, 55.0, 44.25, 63.0, 50.25,
+      23.25, 33.0, 26.25, 37.0, 52.0, 41.0, 32.25, 45.0, 35.25};
+  conv3DTestHelper(filename, inputDims, expectedDims, expectedValues);
+}
+
+/// Test loading conv 3D op from a ONNX model.
+/// The input is N*C*T*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 1, 1}, pads is {1, 1, 1, 1, 1, 1}, group is 1.
+/// Dilation is {1, 2, 1}.
+// TEST_F(OnnxImporterTest, importConv3DNonSquareDilation) {
+//  std::string filename("simpleConv3D.onnxtxt");
+//  std::vector<dim_t> inputDims = {1, 1, 2, 3, 3};
+//  std::vector<dim_t> expectedDims = {1, 1, 3, 1, 3};
+//  std::vector<float> expectedValues = {
+//      5.0, 8.0, 7.0, 23.5, 34.0, 27.5, 18.5, 26.0, 20.5
+//  };
+//  conv3DTestHelper(filename, inputDims, expectedDims, expectedValues);
+//}
+
+/// Test loading conv 3D op from a ONNX model.
+/// The input is N*C*T*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 1, 1}, auto_pad VALID (i.e. no padding), group is 1.
+TEST_F(OnnxImporterTest, importConv3DAutoPadValid) {
+  std::string filename("simpleConv3DAutoPadValid.onnxtxt");
+  std::vector<dim_t> inputDims = {1, 1, 2, 3, 3};
+  std::vector<dim_t> expectedDims = {1, 1, 1, 1, 1};
+  std::vector<float> expectedValues = {68.0};
+  conv3DTestHelper(filename, inputDims, expectedDims, expectedValues);
+}
+
+/// Test loading conv 3D op from a ONNX model.
+/// The input is N*C*T*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 2, 2}, auto_pad SAME_LOWER, group is 1.
+TEST_F(OnnxImporterTest, importConv3DAutoPadSameLower) {
+  std::string filename("simpleConv3DAutoPadSameLower.onnxtxt");
+  std::vector<dim_t> inputDims = {1, 1, 2, 3, 3};
+  std::vector<dim_t> expectedDims = {1, 1, 2, 2, 2};
+  std::vector<float> expectedValues = {3.0,   6.0,   12.0,  15.0,
+                                       26.25, 32.25, 44.25, 50.25};
+  conv3DTestHelper(filename, inputDims, expectedDims, expectedValues);
+}
+
+/// Test loading conv 3D op from a ONNX model.
+/// The input is N*C*T*H*W (1*1*2*3*3), the kernels is {2, 3, 3},
+/// strides is {1, 2, 2}, auto_pad SAME_UPPER, group is 1.
+TEST_F(OnnxImporterTest, importConv3DAutoPadSameUpper) {
+  std::string filename("simpleConv3DAutoPadSameUpper.onnxtxt");
+  std::vector<dim_t> inputDims = {1, 1, 2, 3, 3};
+  std::vector<dim_t> expectedDims = {1, 1, 2, 2, 2};
+  std::vector<float> expectedValues = {26.25, 32.25, 44.25, 50.25,
+                                       23.25, 26.25, 32.25, 35.25};
+  conv3DTestHelper(filename, inputDims, expectedDims, expectedValues);
 }
 
 /// Import conv1D


### PR DESCRIPTION
Summary:
This change adds support for convolution 3D to the ONNX importer and exporter. loadConv() is split into loadConv2D() and loadConv3D(). The exporter's writeConvolution3D() is changed to deal with the inserted transposes as done in writeConvolution().

This partially addresses #3773 but  does not add dilation.

Test Plan:
Updated OnnxImporterTest unittest with new tests for convolution 3D. The new tests mirror the existing simple, auto padding and non-square dilation tests for convolution 2D. The non-square dilation test is currently disabled since the Conv3D node does not currently support dilation.