### PR TITLE
Add support for int32 inputs for NonZero

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -60,6 +60,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "batchedReduceMax_Int8/0",
     "batchedReduceMaxMultiAxis_Int8/0",
     "NonZero/0",
+    "NonZeroInt/0",
     "ReluSimple_BFloat16/0",
     "ReluSimple_Float16/0",
     "PReluSimple_BFloat16/0",

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -250,7 +250,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
          ElemKind::Int8QTy, ElemKind::Int16QTy, ElemKind::Int32ITy,
          ElemKind::Int64ITy, ElemKind::BoolTy});
   case Kinded::Kind::NonZeroNodeKind:
-    return NI.getInElemTy(NonZeroNode::CondIdx) == ElemKind::BoolTy &&
+    return (NI.getInElemTy(NonZeroNode::CondIdx) == ElemKind::BoolTy ||
+            NI.getInElemTy(NonZeroNode::CondIdx) == ElemKind::Int32ITy) &&
            NI.getOutElemTy(NonZeroNode::ResultIdx) == ElemKind::Int32ITy;
   case Kinded::Kind::SelectNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -146,6 +146,7 @@ struct BlacklistInitializer {
       {"ModuloInt64NoSignFollow/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ModuloInt64SignFollow/0", TestBlacklist::AnyDeviceAnyEngine},
       {"mul_int64/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"NonZeroInt/0", TestBlacklist::AnyDeviceAnyEngine},
       {"NonCubicKernelConv3DQuantized/0", TestBlacklist::AnyDeviceAnyEngine},
       {"NonSquarePaddingAveragePool/0", TestBlacklist::AnyDeviceAnyEngine},
       {"NonSquarePaddingMaxPool/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -61,6 +61,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ResizeBilinear_Int32_outTy/0",
     "BoolReshape/0",
     "NonZero/0",
+    "NonZeroInt/0",
     "replaceNaN_Float/0",
     "replaceNaN_Float16/0",
     "log/0",

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2707,8 +2707,13 @@ bool ReplaceNaNNode::verify() const {
 }
 
 bool NonZeroNode::verify() const {
-  return checkType(getCond(), ElemKind::BoolTy, this) &&
-         checkType(getResult(), ElemKind::Int32ITy, this);
+  bool isValid =
+      expectCompareTrue("Cond type should be bool or int32",
+                        getCond().getElementType() == ElemKind::BoolTy ||
+                            getCond().getElementType() == ElemKind::Int32ITy,
+                        true, this);
+  isValid &= checkType(getResult(), ElemKind::Int32ITy, this);
+  return isValid;
 }
 
 bool SelectNode::verify() const {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -18283,6 +18283,28 @@ TEST_P(OperatorTest, ReshapeInt) {
 }
 
 /// Verify that the NonZero operator works correctly.
+TEST_P(OperatorTest, NonZeroInt) {
+  CHECK_IF_ENABLED();
+
+  auto *Cond = mod_.createPlaceholder(ElemKind::Int32ITy, {8}, "Cond", false);
+  bindings_.allocate(Cond)->getHandle<int32_t>() = {1, 0, 2, 4, 0, 6, 2, 0};
+
+  auto *N = F_->createNonZero("nonZero", Cond);
+  auto *result = F_->createSave("saveNonZero", N);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  std::array<int, 5> expected{0, 2, 3, 5, 6};
+  auto resH = bindings_.get(result->getPlaceholder())->getHandle<int32_t>();
+
+  for (dim_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(resH.raw(i), expected[i]);
+  }
+}
+
+/// Verify that the NonZero operator works correctly.
 TEST_P(OperatorTest, NonZero) {
   CHECK_IF_ENABLED();
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -972,7 +972,7 @@ int main(int argc, char **argv) {
       .addOperand("Cond", OperandKind::In)
       .inplaceOperand({"Dest", "Cond"})
       .dataParallel()
-      .autoVerify(VerifyKind::SameElementType, {"Cond", "ElemKind::BoolTy"})
+      .autoVerify(VerifyKind::NoVerify)
       .autoIRGen("NonZero");
 
   BB.newInstr("ElementSelect")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -697,7 +697,7 @@ int main(int argc, char **argv) {
       .addInput("Cond")
       .addResultFromCtorArg()
       .dataParallel()
-      .setDocstring("Selects indices of the true elements in Cond");
+      .setDocstring("Selects indices of the nonzero elements in Cond");
 
   BB.newNode("Select")
       .addInput("Cond")


### PR DESCRIPTION
Summary: Add support for accepting indicator data as int32 in addition to boolean in NonZero operator

Differential Revision: D31085259

