### PR TITLE
Fix aten::rsub test

### DIFF
--- a/torch_glow/tests/nodes/rsub_test.py
+++ b/torch_glow/tests/nodes/rsub_test.py
@@ -38,6 +38,14 @@ class TestRsub(utils.TorchGlowTestCase):
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
+        ]
+    )
+    def test_rsub_as_sub(self, _, module, tensor, other):
+        # aten::rsub is normalized as aten::sub
+        utils.compare_tracing_methods(module, tensor, other, fusible_ops={"aten::sub"})
+
+    @utils.deterministic_expand(
+        [
             lambda: ("float", SimpleRsubModel(), torch.randn(4), torch.tensor(13.293)),
             lambda: ("int", SimpleRsubModel(), torch.randn(4), torch.tensor(4)),
         ]


### PR DESCRIPTION
Summary: After a recent optimization https://github.com/pytorch/pytorch/pull/65014 we started to normalize `aten::rsub` as `aten::sub`, so the test started to fail. This diff makes sure the test is passing.

Reviewed By: wushirong

Differential Revision: D31153947

