### PR TITLE
EmbeddingBag supporting int64 indices and offsets for Interpreter backend

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -410,7 +410,7 @@ private:
                             int64_t padIdx, bool sparse, bool scale,
                             dim_t embedding_dim);
 
-  template <typename ElemTy>
+  template <typename ElemTy, typename IndexTy>
   void fwdEmbeddingBagInstFloatImpl(const EmbeddingBagInst *I);
 
   template <typename ElemTy>

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -442,12 +442,17 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
             NI.getInElemTy(EmbeddingNode::IndicesIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::EmbeddingBagNodeKind:
-    return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty},
-               {EmbeddingBagNode::IndicesIdx, EmbeddingBagNode::OffsetsIdx}) &&
-           (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) ==
-            ElemKind::Int32ITy) &&
-           (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int32ITy);
+    return (NI.allInputsAndOutputsHaveSameElemKind(
+                {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty},
+                {EmbeddingBagNode::IndicesIdx, EmbeddingBagNode::OffsetsIdx}) &&
+            (((NI.getInElemTy(EmbeddingBagNode::IndicesIdx) ==
+               ElemKind::Int64ITy) &&
+              (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) ==
+               ElemKind::Int64ITy)) ||
+             ((NI.getInElemTy(EmbeddingBagNode::IndicesIdx) ==
+               ElemKind::Int32ITy) &&
+              (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) ==
+               ElemKind::Int32ITy))));
 
   case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
     // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5328,7 +5328,7 @@ void BoundInterpreterFunction::fwdSparseLengthsWeightedSumGradInst(
   }
 }
 
-template <typename ElemTy>
+template <typename ElemTy, typename IndexType>
 void BoundInterpreterFunction::fwdEmbeddingBagInstFloatImpl(
     const EmbeddingBagInst *I) {
   staticAssertFloatingPointType(ElemTy);
@@ -5342,8 +5342,8 @@ void BoundInterpreterFunction::fwdEmbeddingBagInstFloatImpl(
 
   out->zero();
 
-  auto IH = indices->getHandle<int32_t>();
-  auto OFFH = offsets->getHandle<int32_t>();
+  auto IH = indices->getHandle<IndexType>();
+  auto OFFH = offsets->getHandle<IndexType>();
 
   // If an end offset is present to mark the end of the last segment then this
   // must be subtracted to get the correct number of segments
@@ -5387,8 +5387,9 @@ void BoundInterpreterFunction::fwdEmbeddingBagInstFloatImpl(
 }
 
 void BoundInterpreterFunction::fwdEmbeddingBagInst(const EmbeddingBagInst *I) {
-  dispatchFloatingPointImpl(fwdEmbeddingBagInstFloatImpl,
-                            I->getData()->getElementType(), I);
+  dispatchFloatingPointAndIndexImpl(fwdEmbeddingBagInstFloatImpl,
+                                    I->getData()->getElementType(),
+                                    I->getIndices()->getElementType(), I);
 }
 
 template <typename ElemTy>

--- a/torch_glow/tests/nodes/fmod_test.py
+++ b/torch_glow/tests/nodes/fmod_test.py
@@ -14,17 +14,23 @@ class SimpleFmodModule(torch.nn.Module):
             c = a.fmod(b.item())
         else:
             c = a.fmod(b)
-        return c.fmod(1.0)
+        return c.fmod(torch.tensor(1.0, dtype=c.dtype))
 
 
 class TestFmod(utils.TorchGlowTestCase):
     @utils.deterministic_expand(
         [
             lambda: (
-                "int_tensor",
+                "int64_tensor",
                 SimpleFmodModule(),
                 torch.tensor([14]),
                 torch.tensor([10]),
+            ),
+            lambda: (
+                "int32_tensor",
+                SimpleFmodModule(),
+                torch.tensor([14], dtype=torch.int32),
+                torch.tensor([10], dtype=torch.int32),
             ),
             lambda: (
                 "float_tensor",


### PR DESCRIPTION
Summary: Added support in EmbeddingBag op for handling int32 & int64 based indices and offsets

Reviewed By: jfix71

Differential Revision: D31190611

