### PR TITLE
Add ERF operator to torch_glow.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1793,6 +1793,9 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"fb::scale_gradient"},
        &PyTorchModelLoader::loadScaleGradient,
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
+      {{"aten::erf"},
+       &PyTorchModelLoader::loadErf,
+       &PyTorchModelLoader::getCorrectTypeFromInput<0>},
   });
 #undef UNARY_NODE_LOADER
 
@@ -9118,6 +9121,21 @@ Error PyTorchModelLoader::loadScaleGradient(const torch::jit::Node *ptNode) {
   // Currently PyTorch importer only supports inference,
   // therefore return the input as is.
   RETURN_ERR(addValueMapping(outputs[0], input));
+}
+
+Error PyTorchModelLoader::loadErf(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  auto node = F_.createErf("erf", input)->getResult();
+
+  RETURN_IF_ERR(addValueMapping(outputs[0], node));
+
+  return Error::success();
 }
 
 Error PyTorchModelLoader::loadAttributes(

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -1054,6 +1054,10 @@ private:
   // Load fb::scale_gradient.
   // \returns error on failure.
   Error loadScaleGradient(const torch::jit::Node *ptNode);
+
+  // Load aten::erf.
+  // \returns error on failure.
+  Error loadErf(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/erf_test.py
+++ b/torch_glow/tests/nodes/erf_test.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+from tests import utils
+
+
+class SimpleErfModule(torch.nn.Module):
+    def forward(self, input):
+        return torch.special.erf(input)
+
+
+class TestErf(utils.TorchGlowTestCase):
+    def test_erf_basic(self):
+        """Test of the PyTorch erf Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleErfModule(), torch.randn(4)
+        )


### PR DESCRIPTION
Summary:
Add the ERF operator to torch_glow. The node already existed and is used in the ONNX loader. The missing operator causes BertForQuestionAnswering to fail with Glow.

This addresses #5828 

Documentation:
https://pytorch.org/docs/stable/generated/torch.erf.html#torch.erf

Test Plan:

Added a simple erf_test.py node test.
