### PR TITLE
Modify loadSplit to support negative dimensions.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -8517,10 +8517,15 @@ Error PyTorchModelLoader::loadSplit(const torch::jit::Node *ptNode) {
   RETURN_IF_ERR(
       checkInputAndOutputSizes(ptNode->inputs(), 3, ptNode->outputs(), 1));
   glow::NodeValue input;
-  unsigned int dimension;
+  int64_t dimension;
   ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(ptNode->input(0)));
   ASSIGN_VALUE_OR_RETURN_ERR(
       dimension, iValToInt(getGlowIValueForValue(ptNode->input(2))));
+
+  // Handle negative dimensions
+  if (dimension < 0) {
+    dimension += input.dims().size();
+  }
 
   uint64_t chunkSize;
   ASSIGN_VALUE_OR_RETURN_ERR(
@@ -8548,10 +8553,16 @@ Error PyTorchModelLoader::loadSplitWithSizes(const torch::jit::Node *ptNode) {
   RETURN_IF_ERR(
       checkInputAndOutputSizes(ptNode->inputs(), 3, ptNode->outputs(), 1));
   glow::NodeValue input;
-  unsigned int dimension;
+  int64_t dimension;
   ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(ptNode->input(0)));
   ASSIGN_VALUE_OR_RETURN_ERR(
       dimension, iValToInt(getGlowIValueForValue(ptNode->input(2))));
+
+  // Handle negative dimensions
+  if (dimension < 0) {
+    dimension += input.dims().size();
+  }
+
   std::vector<int64_t> *signedSizes;
   ASSIGN_VALUE_OR_RETURN_ERR(
       signedSizes, iValToIntList(getGlowIValueForValue(ptNode->input(1))));

--- a/torch_glow/tests/nodes/split_test.py
+++ b/torch_glow/tests/nodes/split_test.py
@@ -21,6 +21,8 @@ class TestSplit(utils.TorchGlowTestCase):
             lambda: (torch.randn(10), [1, 2, 3, 4], 0),
             lambda: (torch.randn(10, 10, 10), 3, 2),
             lambda: (torch.randn(100, 100), [25, 50, 25], 1),
+            lambda: (torch.randn(100, 100), [25, 50, 25], -2),
+            lambda: (torch.randn(100, 100), 25, -1),
         ]
     )
     def test_split(self, tensor, split_size_or_sections, dimension):


### PR DESCRIPTION
Summary:
Modify loadSplit and loadSplitWithSizes to support negative dimension parameters. PyTorch specs dimension to be int but loadSplit* were implemented using unsigned int. 

This addresses #5830

Documentation:
https://pytorch.org/docs/stable/generated/torch.split.html#torch.split

Test Plan:

Updated split_test.py to include a negative dimension test with split_size_or_sections as both an int and a list of ints.
