### PR TITLE
Add support for convolution 3D in ONNX importer and exporter

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -226,6 +226,14 @@ class ONNXModelLoader
   Error loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
                    ArgumentDictionaryTy &dict);
 
+  /// Load Conv operator with 2D input
+  Error loadConv2D(const ONNX_NAMESPACE::NodeProto &op,
+                   ArgumentDictionaryTy &dict);
+
+  /// Load Conv operator with 3D input
+  Error loadConv3D(const ONNX_NAMESPACE::NodeProto &op,
+                   ArgumentDictionaryTy &dict);
+
   /// Load MaxPool or AveragePool ONNX operator. \p typeName is the name of the
   /// ONNX operator being loaded, either MaxPool or AveragePool.
   Error loadPool(const ONNX_NAMESPACE::NodeProto &op,

--- a/tests/models/onnxModels/simpleConv3D.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3D.onnxtxt
@@ -1,0 +1,168 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadSameLower.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadSameLower.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_LOWER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadSameUpper.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadSameUpper.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_UPPER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DAutoPadValid.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DAutoPadValid.onnxtxt
@@ -1,0 +1,163 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "VALID"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DNonCubicPads.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DNonCubicPads.onnxtxt
@@ -1,0 +1,151 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: 3
+      ints: 3
+      ints: 1
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    data_type: 1
+    float_data: 1.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 7
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConv3DNonSquareDilation.onnxtxt
+++ b/tests/models/onnxModels/simpleConv3DNonSquareDilation.onnxtxt
@@ -1,0 +1,168 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 3
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 0.5
+    float_data: 0.25
+    float_data: 0.5
+    float_data: 0.25
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/unittests/ImporterTestUtils.h
+++ b/tests/unittests/ImporterTestUtils.h
@@ -40,6 +40,26 @@ void getNCHWData(Tensor *result, dim_t n, dim_t c, dim_t h, dim_t w) {
     RH.raw(i) = i;
 }
 
+/// Populate \p result with increasing number following the NCTHW format.
+/// E.g.:
+/// N=1, T=2:
+///               T=0              T=1
+///               W=3
+///             <---->
+///      ^  +---+---+---+    +----+----+----+
+///  C=1/   | 0 | 1 | 2 |    |  9 | 10 | 11 |  ^
+///    /    +---+---+---+    +----+----+----+  | H=3
+///   v     | 3 | 4 | 5 |    | 12 | 13 | 14 |  v
+///         +---+---+---+    +----+----+----+
+///         | 6 | 7 | 8 |    | 15 | 16 | 17 |
+///         +---+---+---+    +----+----+----+
+void getNCTHWData(Tensor *result, dim_t n, dim_t c, dim_t t, dim_t h, dim_t w) {
+  result->reset(ElemKind::FloatTy, {n, c, t, h, w});
+  auto RH = result->getHandle<>();
+  for (size_t i = 0, e = n * c * t * h * w; i < e; i++)
+    RH.raw(i) = i;
+}
+
 /// \returns the number of nodes in \p F of kind \p kind.
 unsigned countNodeKind(Function *F, Kinded::Kind kind) {
   unsigned count = 0;

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -458,7 +458,9 @@ TEST(exporter, onnxModels) {
         name.find("simpleConvTransposeAutoPadSameUpper.onnxtxt") !=
             std::string::npos ||
         name.find("sliceInvalidAxes.onnxtxt") != std::string::npos ||
-        name.find("sliceWithUnsupportedStep.onnxtxt") != std::string::npos) {
+        name.find("sliceWithUnsupportedStep.onnxtxt") != std::string::npos ||
+        name.find("simpleConv3DNonSquareDilation.onnxtxt") !=
+            std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";
       continue;


### PR DESCRIPTION
Summary:
Add 3D convolution support to the ONNX importer and exporter.

Test Plan:

Added simple Conv3D and various padding tests.

