### PR TITLE
EmbeddingBagByteRowwise support for int64 indices and offsets for Interpreter backend

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -461,7 +461,7 @@ private:
   template <typename T>
   void fwdBBoxTransformInstFloatImpl(glow::BBoxTransformInst const *I);
 
-  template <typename T, typename AccumT>
+  template <typename T, typename AccumT, typename IndexT>
   void fwdEmbeddingBagByteRowwiseOffsetsImpl(
       const EmbeddingBagByteRowwiseOffsetsInst *I);
 

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -489,10 +489,14 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
             ElemKind::Int32ITy);
 
   case Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind: {
-    if (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::IndicesIdx) !=
-            ElemKind::Int32ITy ||
-        NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::OffsetsIdx) !=
-            ElemKind::Int32ITy) {
+    if (!((NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::IndicesIdx) ==
+               ElemKind::Int32ITy &&
+           NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::OffsetsIdx) ==
+               ElemKind::Int32ITy) ||
+          (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::IndicesIdx) ==
+               ElemKind::Int64ITy &&
+           NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::OffsetsIdx) ==
+               ElemKind::Int64ITy))) {
       return false;
     }
 


### PR DESCRIPTION
Summary: Add support for handling int64 indices-offsets for EmbeddingBagByteRowwise fp16-8bit-4bit operator compiling for Interpreter backend

Reviewed By: jfix71

Differential Revision: D31289062

