### PR TITLE
Move concat/tanh into SLS partitions (#5814)

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -79,6 +79,8 @@ extern bool SparseNNPartitioningAddSLSConcats;
 extern bool SparseNNPartitioningBalancePerfModel;
 extern bool SparseNNPartitioningPairLNWithSLS;
 extern bool SparseNNPartitioningPairTileWithSLS;
+extern std::string SparseNNPartitioningPairSLSWith;
+extern int32_t SparseNNPartitioningConcatSplitSize;
 
 // Dag Optimizer Constants
 extern bool UseDAGOptimizer;

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -195,21 +195,31 @@ struct OptimizationOptions {
   /// scheme
   bool useSparseNNPartitioningScheme{false};
 
-  /// If true, SparseNN partiitoning scheme will add extra concats to the
+  /// If true, SparseNN partitioning scheme will add extra concats to the
   /// SLS partition for more efficient inter-partition transfers
   bool sparseNNPartitioningAddSLSConcats{false};
 
-  /// If true, SparseNN partiitoning scheme will balance SLS tables across
+  /// If true, SparseNN partitioning scheme will balance SLS tables across
   /// cards using a performance model
   bool sparseNNPartitioningBalancePerfModel{false};
 
-  /// If true, SparseNN partiitoning scheme will move Layer Normalization
+  /// If true, SparseNN partitioning scheme will move Layer Normalization
   /// nodes immediately following SLS into SLS partitions
   bool sparseNNPartitioningPairLNWithSLS{false};
 
-  /// If true, SparseNN partiitoning scheme will move Tile
+  /// If true, SparseNN partitioning scheme will move Tile
   /// nodes immediately following SLS for user embeddings into SLS partitions
   bool sparseNNPartitioningPairTileWithSLS{false};
+
+  /// SparseNN partitioning scheme will move nodes specified
+  /// in a comma-separated string which immediately follow SLS nodes into SLS
+  /// partitions. For example, to move Tanh and Concat, use "Tanh,Concat".
+  std::string sparseNNPartitioningPairSLSWith{""};
+
+  // If "Concat" and "Tanh" are specified in sparseNNPartitioningPairSLSWith,
+  // this will split large Concats going into a Tanh sink to the specified size
+  // before moving them into SLS partitions
+  unsigned int sparseNNPartitioningConcatSplitSize{1};
 
   /// The number of cards over which to split SLS tables when using SparseNN
   /// partitioning scheme

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -81,6 +81,12 @@ void printSlsDeviceInfo(const std::vector<SLSDeviceInfo> &slsDevices,
                         const std::vector<NodesSet> &nodesets,
                         const unsigned contextCount, bool verbose_only);
 
+// Returns whether \p node is an SLS node
+bool isSLSNode(const Node *node);
+
+// Returns whether all inputs to \p node are of the kind \p kind
+bool checkNodeInputsAllKind(const Node *node, glow::Kinded::Kind kind);
+
 /// Loop through slsDevices, assign \p table to first available \p slsDevices
 /// that can fit \p table.
 /// \returns Error if we could not find one.

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -90,6 +90,8 @@ bool SparseNNPartitioningAddSLSConcats = false;
 bool SparseNNPartitioningBalancePerfModel = false;
 bool SparseNNPartitioningPairLNWithSLS = false;
 bool SparseNNPartitioningPairTileWithSLS = false;
+std::string SparseNNPartitioningPairSLSWith = "";
+int32_t SparseNNPartitioningConcatSplitSize = 1;
 
 // Dag Optimizer Constants
 bool UseDAGOptimizer = false;
@@ -354,6 +356,26 @@ DEFINE_bool(
 DEFINE_validator(glow_sparsenn_partitioning_pair_tile_with_sls,
                  [](const char *, bool val) {
                    glow::flags::SparseNNPartitioningPairTileWithSLS = val;
+                   return true;
+                 });
+DEFINE_string(
+    glow_sparsenn_partitioning_pair_sls_with,
+    glow::flags::SparseNNPartitioningPairSLSWith,
+    "Put nodes specified immediately following SLS into SLS partitions."
+    "Supported for LayerNorm, Tile, Concat, and Tanh nodes"
+    "Comma separated list of node names, e.g. LayerNorm,Tile.");
+DEFINE_validator(glow_sparsenn_partitioning_pair_sls_with,
+                 [](const char *, const std::string &val) {
+                   glow::flags::SparseNNPartitioningPairSLSWith = val;
+                   return true;
+                 });
+DEFINE_int32(glow_sparsenn_partitioning_concat_split_size,
+             glow::flags::SparseNNPartitioningConcatSplitSize,
+             "The number of inputs to split each concat to be moved into SLS "
+             "partitions to");
+DEFINE_validator(glow_sparsenn_partitioning_concat_split_size,
+                 [](const char *, const int32_t val) {
+                   glow::flags::SparseNNPartitioningConcatSplitSize = val;
                    return true;
                  });
 DEFINE_bool(glow_clip_fp16, glow::flags::ClipToFP16,

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -96,6 +96,18 @@ static llvm::cl::opt<bool, true> GlowSparseNNPartitioningPairTileWithSLSOpt(
                    "for user embeddings into SLS partition"),
     llvm::cl::location(glow::flags::SparseNNPartitioningPairTileWithSLS));
 
+static llvm::cl::opt<std::string, true> GlowSparseNNPartitioningPairSLSWithOpt(
+    "glow_sparsenn_partitioning_pair_sls_with",
+    llvm::cl::desc("Place specified nodes immediately following SLS "
+                   "into SLS partition"),
+    llvm::cl::location(glow::flags::SparseNNPartitioningPairSLSWith));
+
+static llvm::cl::opt<int32_t, true> GlowSparseNNPartitioningConcatSplitSizeOpt(
+    "glow_sparsenn_partitioning_concat_split_size",
+    llvm::cl::desc("Split concat going into tanh sink into smaller concats of "
+                   "specified size to move into SLS partition"),
+    llvm::cl::location(glow::flags::SparseNNPartitioningConcatSplitSize));
+
 std::unique_ptr<runtime::HostManager>
 HostManagerBackend::createHostManager(llvm::StringRef backendName) {
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
@@ -241,6 +253,10 @@ onnxStatus HostManagerBackend::addNetwork(
         glow::flags::SparseNNPartitioningPairLNWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
         glow::flags::SparseNNPartitioningPairTileWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairSLSWith =
+        glow::flags::SparseNNPartitioningPairSLSWith;
+    cctx.optimizationOpts.sparseNNPartitioningConcatSplitSize =
+        glow::flags::SparseNNPartitioningConcatSplitSize;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         glow::flags::SparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -124,6 +124,10 @@ Error initializeCompilationContextFromGlowFlags(
         glow::flags::SparseNNPartitioningPairLNWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
         glow::flags::SparseNNPartitioningPairTileWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairSLSWith =
+        glow::flags::SparseNNPartitioningPairSLSWith;
+    cctx.optimizationOpts.sparseNNPartitioningConcatSplitSize =
+        glow::flags::SparseNNPartitioningConcatSplitSize;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         glow::flags::SparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =
@@ -272,6 +276,8 @@ void initializeCompilationContextFromSettings(
         settings.sparseNNPartitioningPairLNWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningPairTileWithSLS =
         settings.sparseNNPartitioningPairTileWithSLS;
+    cctx.optimizationOpts.sparseNNPartitioningPairSLSWith =
+        settings.sparseNNPartitioningPairSLSWith;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         settings.sparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -114,6 +114,9 @@ DEFINE_bool(sparseNNPartitioningPairLNWithSLS, false,
             "See PyTorchLoaderSettings");
 DEFINE_bool(sparseNNPartitioningPairTileWithSLS, false,
             "See PyTorchLoaderSettings");
+DEFINE_string(sparseNNPartitioningPairSLSWith, "", "See PyTorchLoaderSettings");
+DEFINE_int32(sparseNNPartitioningConcatSplitSize, 1,
+             "See PyTorchLoaderSettings");
 DEFINE_int32(sparseNNPartitioningSchemeNumCards, 1,
              "See PyTorchLoaderSettings");
 DEFINE_int64(sparseNNPartitioningSchemeSLSTableKBytesPerCard, 1,
@@ -391,6 +394,9 @@ void PyTorchLoaderSettings::initSettings() {
   sparseNNPartitioningPairLNWithSLS = FLAGS_sparseNNPartitioningPairLNWithSLS;
   sparseNNPartitioningPairTileWithSLS =
       FLAGS_sparseNNPartitioningPairTileWithSLS;
+  sparseNNPartitioningPairSLSWith = FLAGS_sparseNNPartitioningPairSLSWith;
+  sparseNNPartitioningConcatSplitSize =
+      FLAGS_sparseNNPartitioningConcatSplitSize;
   sparseNNPartitioningSchemeNumCards = FLAGS_sparseNNPartitioningSchemeNumCards;
   sparseNNPartitioningSchemeSLSTableKBytesPerCard =
       FLAGS_sparseNNPartitioningSchemeSLSTableKBytesPerCard;

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -264,6 +264,8 @@ public:
   bool sparseNNPartitioningBalancePerfModel = false;
   bool sparseNNPartitioningPairLNWithSLS = false;
   bool sparseNNPartitioningPairTileWithSLS = false;
+  std::string sparseNNPartitioningPairSLSWith = "";
+  int32_t sparseNNPartitioningConcatSplitSize = 1;
   int32_t sparseNNPartitioningSchemeNumCards = 1;
   int64_t sparseNNPartitioningSchemeSLSTableKBytesPerCard = 1;
   int32_t SparseNNPartitioningSchemeNumCoresSLS = 1;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/glow/pull/5814

Use "Tanh,Concat" in flag `glow_sparsenn_partitioning_pair_sls_with` and specify concat size `glow_sparsenn_partitioning_concat_split_size` to split large concats into smaller concats of the specified size move them into SLS partitions with tanh.

Differential Revision: D30816244

