### PR TITLE
Add extra error checks for loading DotProduct and FillExamplesWithIndicator

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1194,6 +1194,8 @@ protected:
     ASSIGN_VALUE_OR_RETURN_ERR(X, getNodeValueByName(op.input(0)));
     NodeValue Y;
     ASSIGN_VALUE_OR_RETURN_ERR(Y, getNodeValueByName(op.input(1)));
+    RETURN_ERR_IF_NOT(X.dims() == Y.dims(),
+                      opErrMsg(op, "X and Y must have the same dimensions"));
     auto *node = G_->createDotProduct(loadOperatorName(op), X, Y);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return Error::success();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1721,7 +1721,16 @@ ReshapeNode *Function::createExpandDims(llvm::StringRef name, NodeValue input,
 
 ReshapeNode *Function::createFlatten(llvm::StringRef name, NodeValue input,
                                      unsigned_t axis) {
-  auto xDim = flattenCdr(input.getType()->dims(), axis);
+  std::pair<dim_t, dim_t> xDim;
+  if (axis == 0) {
+    dim_t d = 1;
+    for (int i = 0; i < input.getType()->dims().size(); ++i) {
+      d *= input.getType()->dims()[i];
+    }
+    xDim = {1, d};
+  } else {
+    xDim = flattenCdr(input.getType()->dims(), axis);
+  }
   return createReshape(name, input, {xDim.first, xDim.second});
 }
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2018,6 +2018,12 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     auto nzIndices = G_->createNonZero(opName + ".nonzero", indicatorBool);
 
     auto nzIndicesFixed = fixNonZero(G_, mod_, opName, nzIndices);
+    auto nonZeroCount = data.dims()[0];
+    RETURN_ERR_IF_NOT(nonZeroCount <= nzIndicesFixed->getNthResult(0).dims()[0],
+                      opErrMsg(op,
+                               "The number of "
+                               "non-zero elements in the indicator must be at "
+                               "least that of the first dimension of data"));
 
     auto indices = G_->createSlice(opName + ".indices", nzIndicesFixed, {0, 0},
                                    {data.dims()[0], 1});

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1540,7 +1540,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   }
 
   if (typeName == "ConstantFill" || typeName == "GivenTensorIntFill" ||
-      typeName == "GivenTensorInt64Fill" || typeName == "GaussianFill") {
+      typeName == "GivenTensorInt64Fill" || typeName == "GaussianFill" ||
+      typeName == "UniformFill") {
     RETURN_IF_ERR(loadWeight(op));
     return Error::success();
   }
@@ -2758,7 +2759,36 @@ Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     const auto &name = op.output(0);
     Tensor T;
     std::vector<dim_t> dim;
-    ASSIGN_VALUE_OR_RETURN_ERR(dim, getShape<dim_t>(dict["shape"]));
+    if (dict.count("shape")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(dim, getShape<dim_t>(dict["shape"]));
+    } else {
+      RETURN_ERR_IF_NOT(op.input_size() > 0,
+                        "If no shape provided, must have input shape.");
+
+      bool inputAsShape = false;
+      if (dict.count("input_as_shape")) {
+        ASSIGN_VALUE_OR_RETURN_ERR(inputAsShape,
+                                   loadInt(dict["input_as_shape"]));
+      }
+
+      if (inputAsShape) {
+        Constant *in;
+        ASSIGN_VALUE_OR_RETURN_ERR(in, getConstantByName(op.input(0)));
+        RETURN_ERR_IF_NOT(in->dims().size() == 1,
+                          opErrMsg(op, "Input must be 1D tensor."));
+        RETURN_ERR_IF_NOT(in->getElementType() == ElemKind::Int64ITy,
+                          opErrMsg(op, "Input must be of int64 type."));
+        const auto handle = in->getHandle<int64_t>();
+        dim.reserve(in->dims().size());
+        for (auto d : handle) {
+          dim.push_back(d);
+        }
+      } else {
+        NodeValue input;
+        ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
+        dim = input.dims();
+      }
+    }
     T.reset(ElemKind::FloatTy, dim);
     auto TH = T.getHandle<>();
     float tensorMin;

--- a/tests/models/caffe2Models/uniform_fill_input_as_shape.pbtxt
+++ b/tests/models/caffe2Models/uniform_fill_input_as_shape.pbtxt
@@ -1,0 +1,21 @@
+name: "uniform_fill_input_as_shape"
+op {
+  input: "inputs_0"
+  output: "result"
+  name: ""
+  type: "UniformFill"
+  arg {
+    name: "min"
+    f: 0.0
+  }
+  arg {
+    name: "max"
+    f: 10.0
+  }
+  arg {
+    name: "input_as_shape"
+    i: 1
+  }
+}
+external_input: "inputs_0"
+external_output: "result"

--- a/tests/models/caffe2Models/uniform_fill_use_input_shape.pbtxt
+++ b/tests/models/caffe2Models/uniform_fill_use_input_shape.pbtxt
@@ -1,0 +1,17 @@
+name: "uniform_fill_use_input_shape"
+op {
+  input: "inputs_0"
+  output: "result"
+  name: ""
+  type: "UniformFill"
+  arg {
+    name: "min"
+    f: 0.0
+  }
+  arg {
+    name: "max"
+    f: 10.0
+  }
+}
+external_input: "inputs_0"
+external_output: "result"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -4779,6 +4779,104 @@ TEST_F(Caffe2ImporterTest, gaussianFillExtraShape) {
   EXPECT_NEAR(0, result.calculateMeanVariance().first, 3);
 }
 
+// Here we use expect input to be 1D tensor and act like shape
+TEST_F(Caffe2ImporterTest, uniformFillInputAsShape) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/uniform_fill_input_as_shape.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/gaussian_fill_input_as_shape_init.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {}, {});
+  }
+
+  // Shape is defined in .pbtxt file
+  const std::vector<dim_t> expectedShape{4, 5, 6, 7};
+  EXPECT_EQ(expectedShape, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+  for (dim_t dim1 = 0; dim1 < expectedShape[0]; ++dim1) {
+    for (dim_t dim2 = 0; dim2 < expectedShape[1]; ++dim2) {
+      for (dim_t dim3 = 0; dim3 < expectedShape[2]; ++dim3) {
+        for (dim_t dim4 = 0; dim4 < expectedShape[3]; ++dim4) {
+          // As defined in the .pbtxt file
+          EXPECT_LE(0.0f, result.at({dim1, dim2, dim3, dim4}));
+          EXPECT_GT(10.0f, result.at({dim1, dim2, dim3, dim4}));
+        }
+      }
+    }
+  }
+}
+
+// Here we use input's shape for the result
+TEST_F(Caffe2ImporterTest, uniformFillUseInputShape) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/uniform_fill_use_input_shape.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  const std::vector<dim_t> inputShape{4, 5, 6, 7};
+  Tensor inputs_0(ElemKind::Int64ITy, inputShape);
+  inputs_0.getHandle<int64_t>().randomize(-10, 10, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
+                               {&inputs_0.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"inputs_0"}, {&inputs_0});
+  }
+
+  // Check that the shape of the output matches what Caffe2 expects.
+  EXPECT_EQ(inputShape, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+  for (dim_t dim1 = 0; dim1 < inputShape[0]; ++dim1) {
+    for (dim_t dim2 = 0; dim2 < inputShape[1]; ++dim2) {
+      for (dim_t dim3 = 0; dim3 < inputShape[2]; ++dim3) {
+        for (dim_t dim4 = 0; dim4 < inputShape[3]; ++dim4) {
+          // As defined in the .pbtxt file
+          EXPECT_LE(0.0f, result.at({dim1, dim2, dim3, dim4}));
+          EXPECT_GT(10.0f, result.at({dim1, dim2, dim3, dim4}));
+        }
+      }
+    }
+  }
+}
+
 // Here we use a shape that is provided as an argument
 TEST_F(Caffe2ImporterTest, constantFillUseProvidedShape) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Summary: Add extra checks to ensure input dims are the same when loading dot product and check the first dim of examples is at most the size of the first dim of the indicator (it should be equal to the number of nonzero elements in the indicator but we have no way to check that).

Differential Revision: D31653690

