### PR TITLE
[Tools] Add error message when profile file does not exist

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -624,8 +624,10 @@ quantization::QuantizationConfiguration Loader::getQuantizationConfiguration() {
   quantConfig.enableChannelwise = enableChannelwiseOpt;
   quantConfig.assertAllNodesQuantized = assertAllNodesQuantizedOpt;
   if (!loadProfileFileOpt.empty()) {
-    deserializeProfilingInfosFromYaml(
+    auto fileExists = deserializeProfilingInfosFromYaml(
         loadProfileFileOpt, quantConfig.graphPreLowerHash, quantConfig.infos);
+    CHECK(fileExists) << strFormat("Profile file \"%s\" does not exist!",
+                                   loadProfileFileOpt.c_str());
   }
   quantConfig.checkGraphPreLowerHash = true;
   return quantConfig;


### PR DESCRIPTION
**Summary**
When using the `model-compiler` front-end tool with a profile file provided with the `-load-profile` option the error handling was not treating the case when the file did not exist. Add a code section to return error when the file does not exist.
