### PR TITLE
Add the name of the most recent git tag to the GLOW_VERSION define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,11 +99,18 @@ execute_process(COMMAND
   OUTPUT_VARIABLE GIT_DATE
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 add_definitions("-DGIT_DATE=\"${GIT_DATE}\"")
+# Get the name of the most recent tag.
+execute_process(COMMAND
+  "${GIT_EXECUTABLE}" describe --tags --abbrev=0
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  OUTPUT_VARIABLE GIT_TAG
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+add_definitions("-DGIT_TAG=\"${GIT_TAG}\"")
 
 # Compile definition for Glow build date in Y-M-D format.
 string(TIMESTAMP GLOW_BUILD_DATE "%Y-%m-%d")
 add_definitions("-DGLOW_BUILD_DATE=\"${GLOW_BUILD_DATE}\"")
-add_definitions("-DGLOW_VERSION=\"${GLOW_BUILD_DATE} (${GIT_SHA1})\"")
+add_definitions("-DGLOW_VERSION=\"${GLOW_BUILD_DATE} (${GIT_SHA1}) (${GIT_TAG})\"")
 
 if(GLOW_USE_PNG_IF_REQUIRED)
   find_package(PNG)


### PR DESCRIPTION
**Summary**
The previous `GLOW_VERSION` definition captured the date and commit hash, like this:
```
$ model-compiler -version
Glow Tools version: 2021-11-02 (03be9ff)
```
Within NXP we have a rudimentary tool versioning scheme in which we use a git tag to mark a given release. Therefore I would like to include the name of the most recent tag in the version string, something like this:
```
$ model-compiler -version
Glow Tools version: 2021-11-02 (03be9ff) (MCUXpresso_SDK_2.11)
```

**Test Plan**
Tested what the model-compiler outputs when using the `-version` command line option.
