### PR TITLE
[importer] Fix compilation with protobuf version > 3.11.x

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -310,7 +310,11 @@ Caffe2ModelLoader::loadProtoFile(const std::string &filename) {
     google::protobuf::io::IstreamInputStream filestr(&ff);
     google::protobuf::io::CodedInputStream codedstr(&filestr);
     // Don't warn about large file sizes.
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+    codedstr.SetTotalBytesLimit(MAX_PROTO_SIZE);
+#else
     codedstr.SetTotalBytesLimit(MAX_PROTO_SIZE, MAX_PROTO_SIZE);
+#endif
     parseNet = net.ParseFromCodedStream(&codedstr);
   }
 
@@ -325,7 +329,11 @@ Expected<caffe2::NetDef> Caffe2ModelLoader::loadProto(const void *c2Model,
   google::protobuf::io::CodedInputStream codedStream(&arrayStream);
 
   // Don't warn about large file sizes.
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+  codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE);
+#else
   codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE, MAX_PROTO_SIZE);
+#endif
   caffe2::NetDef MP;
   bool parseNet = MP.ParseFromCodedStream(&codedStream);
   RETURN_ERR_IF_NOT(parseNet, "Failed to parse NetDef");

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -559,7 +559,11 @@ ONNX_NAMESPACE::GraphProto glow::parseOnnxFile(const std::string &fileName) {
   CHECK(inputFileStream) << "Can't find the input file for " << fileName;
   google::protobuf::io::IstreamInputStream protobufFileStream(&inputFileStream);
   google::protobuf::io::CodedInputStream codedStream(&protobufFileStream);
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+  codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE);
+#else
   codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE, MAX_PROTO_SIZE);
+#endif
   bool parsedSuccessfully = graphProto.ParseFromCodedStream(&codedStream);
   CHECK(parsedSuccessfully) << "Failed to parse GraphProto";
   return graphProto;
@@ -1126,7 +1130,11 @@ ONNXModelLoader::loadProto(google::protobuf::io::ZeroCopyInputStream &iStream) {
   google::protobuf::io::CodedInputStream codedStream(&iStream);
 
   // Don't warn about large file sizes.
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+  codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE);
+#else
   codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE, MAX_PROTO_SIZE);
+#endif
   ONNX_NAMESPACE::ModelProto MP;
   bool parseNet = MP.ParseFromCodedStream(&codedStream);
   RETURN_ERR_IF_NOT(parseNet, "Failed to parse ModelProto",

--- a/tests/unittests/NameScrambler.cpp
+++ b/tests/unittests/NameScrambler.cpp
@@ -129,7 +129,11 @@ bool parseIO(const std::string &filename, ::ONNX_NAMESPACE::GraphProto &g) {
   }
   google::protobuf::io::IstreamInputStream fileStream(&ff);
   google::protobuf::io::CodedInputStream codedStream(&fileStream);
+#if GOOGLE_PROTOBUF_VERSION >= 3002000
+  codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE);
+#else
   codedStream.SetTotalBytesLimit(MAX_PROTO_SIZE, MAX_PROTO_SIZE);
+#endif
   bool yes = g.ParseFromCodedStream(&codedStream);
   if (!yes) {
     return false;


### PR DESCRIPTION
Summary:
On protobuf v3.11 the API of SetTotalBytesLimit was changed.
Fix follow the discussion on: https://github.com/onnx/onnx/issues/2678

Documentation:
No change needed probably

Test Plan:
- Build test with protobuf 3.19.x - Done
- Unit tests - Passed (all except CPUBackendCorrectnessTest but it doesn't seem to be connected)
