### PR TITLE
Initial eager mode support for backends

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -99,7 +99,8 @@ public:
   virtual Expected<std::unique_ptr<CompiledResult>>
   compileFXToCompiledResults(const folly::dynamic &FXIR,
                              const llvm::StringMap<const void *> &constants,
-                             bool lowerToLLVMIR = true) const {
+                             bool /* lowerToLLVMIR */ = true,
+                             bool /* eagerMode */ = false) const {
     LOG(FATAL) << "Compiling FXIR is not supported by the backend";
   }
 #endif

--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -47,6 +47,12 @@ struct RuntimeSymbolInfo {
   bool output{true};
   /// Indicates what category the symbol is.
   SymbolCategory symbolCategory;
+  /// Logical id assigned during the codegen (-1 if unused).
+  /// This id is used during the codegen to order the tensor
+  /// information in memory (e.g. is an index in the offsets array),
+  /// it is also used in runtime to generate tensor metadata,
+  /// when eager mode is enabled.
+  int index{-1};
 };
 
 using SymbolTableTy = std::map<std::string, RuntimeSymbolInfo>;
@@ -84,6 +90,9 @@ public:
   const RuntimeSymbolInfo &getSymbolInfo(const Named *v) const;
   /// Get a const reference to the symbol table.
   const SymbolTableTy &getSymbolTable() const { return symbolTable_; }
+  void updateSymbolTable(const SymbolTableTy &symbolTable) {
+    symbolTable_ = symbolTable;
+  }
   /// At compile time condense constants to a single block of memory.
   /// This allows the graph to go away after compile time.
   /// Allocates a block of memory of size \p constantMaxSize then walks the

--- a/include/glow/LLVMIRCodeGen/AllocationsInfo.h
+++ b/include/glow/LLVMIRCodeGen/AllocationsInfo.h
@@ -84,6 +84,10 @@ public:
   }
   MemoryAllocator &getActivationsAllocator() { return activationsAllocator_; }
 
+  const glow::runtime::SymbolTableTy &getSymbolTable() const {
+    return symbolTable_;
+  }
+
 protected:
   /// Index to be used for a new value.
   size_t valueIdx_{0};

--- a/include/glow/LLVMIRCodeGen/BundleSaver.h
+++ b/include/glow/LLVMIRCodeGen/BundleSaver.h
@@ -75,6 +75,8 @@ public:
   /// Get flag for saving weights as text.
   bool getSaveWeightsAsText() const { return saveWeightsAsText_; }
 
+  const AllocationsInfo &getAllocationsInfo() const { return allocationsInfo_; }
+
 protected:
   /// Perform memory allocation for a bundle.
   virtual void performBundleMemoryAllocation();

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -192,8 +192,8 @@ protected:
                                  llvm::DenseMap<Value *, int> &bufferToArgNum);
   /// Generates LLVM IR that computes the size of the tensor of \p val using
   /// \p builder. The size type is native to the machine (size_t).
-  llvm::Value *emitValueSize(llvm::IRBuilder<> &builder,
-                             const glow::Value *val);
+  virtual llvm::Value *emitValueSize(llvm::IRBuilder<> &builder,
+                                     const glow::Value *val);
   /// Generates LLVM IR that materializes the constant \p val.
   llvm::Value *emitConstF32(llvm::IRBuilder<> &builder, float val);
   /// Generates LLVM IR that materializes the constant \p val.
@@ -250,8 +250,8 @@ protected:
 
   /// Generates LLVM IR that computes the dimensions of \p val using \p builder.
   /// The result type is "size_t*".
-  llvm::Value *emitValueDims(llvm::IRBuilder<> &builder,
-                             const glow::Value *val);
+  virtual llvm::Value *emitValueDims(llvm::IRBuilder<> &builder,
+                                     const glow::Value *val);
 
   /// Generates LLVM IR that materializes the float activation parameters for
   /// the instruction \p I.


### PR DESCRIPTION
This PR adds changes for the preliminary support of eager mode binaries (binaries that are used in eager mode with (potentially) inputs of variable shape).

Differential Revision: D31777431

