### PR TITLE
Update LLVMBackend::getHostTarget()

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -596,7 +596,7 @@ LLVMBackendOptions::LLVMBackendOptions() {
 LLVMBackend::LLVMBackend() {}
 
 std::string LLVMBackend::getHostTarget() {
-  return llvm::sys::getDefaultTargetTriple();
+  return llvm::sys::getProcessTriple();
 }
 
 std::string LLVMBackend::getHostCPU() {


### PR DESCRIPTION
Summary:
This API was returning the Default Target for the underlying LLVM
  instead of the target of the Host we are running on.

Reviewed By: garimag-llvm

Differential Revision: D32228226

