### PR TITLE
LLVM IR instrumentation techniques.

### DIFF
--- a/docs/LLVMDebugInstrumentation.md
+++ b/docs/LLVMDebugInstrumentation.md
@@ -1,0 +1,134 @@
+# Instrumenting LLVM IR
+
+This document provides a short description about LLVM IR instrumentation techniques. The motivation for this feature is to increase transparency of model execution on a target and ease bug investigation process.
+
+
+## Overview
+There are two types of implementation supported: function body and function call instrumentations.
+- Function body instrumentation. One can specify what function bodies he\she wants to trace. It can be achieved by specializing function name or by giving regular expression. Below example shows that every line in the libjit_element_div_kernel_i32 function will be complemented by printouts. I.e. after every line (except alloca and some specific instructions) there will be trace showing what value was written out. The trace consist of instruction number (which is global counter, i.e. if few functions body is instrumented then every new function will have counter continued from previous). On top of that one can specify the printout function that needs to be used to output traces.
+If there is a function call in the body then it will be handled in default manner: there will be trace saying that we are about to call function, then all its parameters (integers will be printed always but complex structs only if there is corresponding function with name pretty_print_<struct_name>(struct_name* ) in the context) and exit trace will also be added.
+
+    **-llvm-code-debug-trace-instrumentation="libjit_element_div_kernel_i32:body"**
+
+- Function calls instrumentation. By default it will wrap all function calls that corresponds to given regular expression into traces before and after. Before and after can be either default instrumentation that prints function name and its input parameters or one can specify the functions to use. The specified functions have to have the same signature as original function.
+
+    **-llvm-code-debug-trace-instrumentation="foo:call[:before_foo[:after_foo]]"**
+
+On top of that there is possibility to specify printing function by giving its name. The print out function has to have the same signature as printf
+
+**-llvm-debug-trace-print-function-name=my_printf**
+
+There is option to output instrumented IR by providing in command line (works only with debug glow build):
+
+**-debug-glow-only=debug-instrumentation**
+
+## Examples
+
+- Body instrumentation example
+image-classifier --backend=CPU -expected-labels=0 -image-mode=0to1 -model-input-name=data_0 **-llvm-code-debug-trace-instrumentation=libjit_element_div_kernel_i32:body -llvm-debug-trace-print-function-name=printf -debug-glow-only=debug-instrumentation** -m=mnist.onnx 0_1009.png
+
+Before:
+```
+; Function Attrs: nounwind optnone uwtable
+define internal i32 @libjit_element_div_kernel_i32(i64, i32*, i32*, i32*) #0 {
+  %5 = alloca i64, align 8
+  %6 = alloca i32*, align 8
+  %7 = alloca i32*, align 8
+  %8 = alloca i32*, align 8
+  store i64 %0, i64* %5, align 8
+  store i32* %1, i32** %6, align 8
+  store i32* %2, i32** %7, align 8
+  store i32* %3, i32** %8, align 8
+  %9 = load i32*, i32** %6, align 8
+  %10 = load i64, i64* %5, align 8
+  %11 = getelementptr inbounds i32, i32* %9, i64 %10
+  %12 = load i32, i32* %11, align 4
+  %13 = load i32*, i32** %7, align 8
+  %14 = load i64, i64* %5, align 8
+  %15 = getelementptr inbounds i32, i32* %13, i64 %14
+  %16 = load i32, i32* %15, align 4
+  %17 = sdiv i32 %12, %16
+  ret i32 %17
+}
+```
+
+
+After:
+```
+@.str.9 = private unnamed_addr constant [40 x i8] c"Instruction number %u ,stored value %d\0A\00", align 1
+@.str.12 = private unnamed_addr constant [40 x i8] c"Instruction number %u ,stored value %p\0A\00", align 1
+@.str.14 = private unnamed_addr constant [20 x i8] c"Function called %s\0A\00", align 1
+@.str.16 = private unnamed_addr constant [20 x i8] c"Function exited %s\0A\00", align 1
+
+; Function Attrs: nounwind optnone uwtable
+define internal i32 @libjit_element_div_kernel_i32(i64, i32*, i32*, i32*) #0 {
+  %5 = alloca i64, align 8
+  %6 = alloca i32*, align 8
+  %7 = alloca i32*, align 8
+  %8 = alloca i32*, align 8
+  store i64 %0, i64* %5, align 8
+  %9 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.12, i32 0, i32 0), i64 0, i64* %5)
+  store i32* %1, i32** %6, align 8
+  %10 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.12, i32 0, i32 0), i64 1, i32** %6)
+  store i32* %2, i32** %7, align 8
+  %11 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.12, i32 0, i32 0), i64 2, i32** %7)
+  store i32* %3, i32** %8, align 8
+  %12 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.12, i32 0, i32 0), i64 3, i32** %8)
+  %13 = load i32*, i32** %6, align 8
+  %14 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 4, i32* %13)
+  %15 = load i64, i64* %5, align 8
+  %16 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 5, i64 %15)
+  %17 = getelementptr inbounds i32, i32* %13, i64 %15
+  %18 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 6, i32* %17)
+  %19 = load i32, i32* %17, align 4
+  %20 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 7, i32 %19)
+  %21 = load i32*, i32** %7, align 8
+  %22 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 8, i32* %21)
+  %23 = load i64, i64* %5, align 8
+  %24 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 9, i64 %23)
+  %25 = getelementptr inbounds i32, i32* %21, i64 %23
+  %26 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 10, i32* %25)
+  %27 = load i32, i32* %25, align 4
+  %28 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 11, i32 %27)
+  %29 = sdiv i32 %19, %27
+  %30 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([40 x i8], [40 x i8]* @.str.9, i32 0, i32 0), i64 12, i32 %29)
+  ret i32 %29
+}
+```
+
+- Call example
+image-classifier --backend=CPU -expected-labels=0 -image-mode=0to1 -model-input-name=data_0 **-llvm-code-debug-trace-instrumentation=libjit_element_relu_f:call -llvm-debug-trace-print-function-name=printf -debug-glow-only=debug-instrumentation** -m=mnist.onnx 0_1009.png
+
+Before:
+```
+  %1 = phi i64 [ 0, %entry ], [ %nextvar, %loop ]
+  %2 = call float @libjit_element_relu_f(i64 %1, float* %0)
+  %buffer.element.addr = getelementptr float, float* %0, i64 %1
+```
+
+After:
+```
+@.str.9 = private unnamed_addr constant [40 x i8] c"Instruction number %u ,stored value %d\0A\00", align 1
+@.str.12 = private unnamed_addr constant [40 x i8] c"Instruction number %u ,stored value %p\0A\00", align 1
+@.str.14 = private unnamed_addr constant [20 x i8] c"Function called %s\0A\00", align 1
+@.str.16 = private unnamed_addr constant [20 x i8] c"Function exited %s\0A\00", align 1
+@.str.18 = private unnamed_addr constant [22 x i8] c"libjit_element_relu_f\00", align 1
+@.str.20 = private unnamed_addr constant [10 x i8] c"\09arg: %d\0A\00", align 1
+@.str.37 = private unnamed_addr constant [11 x i8] c"\09arg: ...\0A\00", align 1
+@.str.39 = private unnamed_addr constant [22 x i8] c"libjit_element_relu_f\00", align 1
+@.str.44 = private unnamed_addr constant [10 x i8] c"\09arg: %d\0A\00", align 1
+@.str.45 = private unnamed_addr constant [11 x i8] c"\09arg: ...\0A\00", align 1
+
+%1 = phi i64 [ 0, %entry ], [ %nextvar, %loop ]
+%2 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @.str.14, i32 0, i32 0), i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.18, i32 0, i32 0))
+%3 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([10 x i8], [10 x i8]* @.str.20, i32 0, i32 0), i64 %1)
+%4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @.str.37, i32 0, i32 0))
+%5 = call float @libjit_element_relu_f(i64 %1, float* %0)
+%6 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @.str.16, i32 0, i32 0), i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.18, i32 0, i32 0))
+%buffer.element.addr = getelementptr float, float* %0, i64 %1
+```
+
+## Further improvements
+1. Provide possibility to consume lib or LLVM bitcode file that will provide pretty_print_* functions
+2. Improve stability, i.e. customize body printouts based on LLVM instruction result type
+3. Add printout of debug information: file names and line numbers. Or llvm IR line mapping that can be used by gdb at live time debugging.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -401,6 +401,8 @@ public:
   virtual void optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM);
   /// Performs specialization of operations based on constant parameters.
   virtual void performSpecialization();
+  /// Insert debug traces in appropriate places.
+  virtual void performDebugInstrumentation();
   /// \returns allocations info.
   virtual AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
   /// \returns the name of the bundle, to be used for filename when saving.

--- a/lib/LLVMIRCodeGen/CMakeLists.txt
+++ b/lib/LLVMIRCodeGen/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(LLVMIRCodeGen
             DebugInfo.cpp
             JITFilePrinter.cpp
             FunctionSpecializer.cpp
+            DebugInstrumentation.cpp
             GlowJIT.cpp
             Pipeline.cpp
             LLVMIRGen.cpp

--- a/lib/LLVMIRCodeGen/DebugInstrumentation.cpp
+++ b/lib/LLVMIRCodeGen/DebugInstrumentation.cpp
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/LLVMIRCodeGen/CommandLine.h"
+#include "glow/LLVMIRCodeGen/LLVMIRGen.h"
+#include "glow/Support/Debug.h"
+#include "llvm/Support/Regex.h"
+
+#define DEBUG_TYPE "debug-instrumentation"
+
+using namespace glow;
+
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+
+namespace {
+
+/// Supported types of instrumentations.
+enum FunctionInstrumentationType {
+  // Every single LLVM IR instruction
+  // of selected functions will be instrumented.
+  BODY = 1,
+  // Function calls will be wrapped in traces.
+  CALL = 2,
+};
+
+/// Metadata about instrumentation.
+struct InstrumentationMetaInformation {
+  // Regular expression of function.
+  llvm::Regex funcReg;
+  // Instrumentation style.
+  FunctionInstrumentationType style;
+  // If instrumentation style is CALL, then
+  // it allows to specify funciton to call before
+  llvm::Function *callBefore;
+  // and after.
+  llvm::Function *callAfter;
+};
+
+/// Perform code instrumentation for selected functions.
+/// The syntax is array of sections separated by coma ",".
+/// Every section starts with function regex, then body/call clause.
+/// PE Ex: "func1*:body,func2:call[:before_func2[:after_func2]];..."
+static llvm::cl::list<std::string> llvmIrInstrumentation(
+    "llvm-code-debug-trace-instrumentation",
+    llvm::cl::desc(
+        "Create trace instructions for functions bodies or function calls"),
+    llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated,
+    llvm::cl::cat(getLLVMBackendCat()));
+
+static llvm::cl::opt<std::string> llvmIrInstrPrintoutFuncName(
+    "llvm-debug-trace-print-function-name",
+    llvm::cl::desc("Select function that will do prints, function must be with "
+                   "signature int f(const char *)"),
+    llvm::cl::init("printf"), llvm::cl::cat(getLLVMBackendCat()));
+
+/// Inserts code to generate logs or traces into the generated LLVM IR to make
+/// debugging easier.
+class DebugInstrumentation {
+public:
+  explicit DebugInstrumentation(LLVMIRGen &irgen) : irgen_{irgen} {
+    // Bail if there is nothing to be instrumented.
+    if (llvmIrInstrumentation.empty()) {
+      return;
+    }
+
+    formatInstrArgD_ = irgen_.emitStringConst(
+        irgen_.getBuilder(), "Instruction number %u ,stored value %d\n");
+    formatInstrArgP_ = irgen_.emitStringConst(
+        irgen_.getBuilder(), "Instruction number %u ,stored value %p\n");
+    formatFuncInArg_ =
+        irgen_.emitStringConst(irgen_.getBuilder(), "Function called %s\n");
+    formatFuncOutArg_ =
+        irgen_.emitStringConst(irgen_.getBuilder(), "Function exited %s\n");
+
+    // Parse input llvm-code-instrumentation option and convert it to
+    // InstrumentationMetaInformation vector.
+    for (auto &section : llvmIrInstrumentation) {
+      llvm::SmallVector<llvm::StringRef, 4> elements;
+      llvm::StringRef(section).split(elements, ":");
+      InstrumentationMetaInformation funcToInstrument{
+          llvm::Regex(elements[0]), (elements[1] == "body" ? BODY : CALL),
+          nullptr, nullptr};
+
+      if (funcToInstrument.style == CALL) {
+        if (elements.size() >= 3) {
+          funcToInstrument.callBefore =
+              irgen_.getModule().getFunction(elements[3]);
+          CHECK(funcToInstrument.callBefore)
+              << "Cannot find " << elements[3].data() << " function";
+        }
+        if (elements.size() >= 4) {
+          funcToInstrument.callAfter =
+              irgen_.getModule().getFunction(elements[3]);
+          CHECK(funcToInstrument.callAfter)
+              << "Cannot find " << elements[3].data() << " function";
+        }
+      }
+      funcsToInstrument_.emplace_back(std::move(funcToInstrument));
+    }
+  }
+
+  void run() {
+    // Bail if there is nothing to be instrumented.
+    if (llvmIrInstrumentation.empty()) {
+      return;
+    }
+
+    auto *printfF =
+        irgen_.getModule().getFunction(llvmIrInstrPrintoutFuncName.getValue());
+    CHECK(printfF) << "Cannot find " << llvmIrInstrPrintoutFuncName.getValue()
+                   << " function";
+
+    int64_t traceCounter = 0;
+    // Iterating over all functions in the module.
+    for (auto &F : irgen_.getModule().functions()) {
+      bool instrumentFunctionBody = false;
+      // Checking if function's body is requested to be instrumented.
+      for (auto &funcToInstrument : funcsToInstrument_) {
+        if (!funcToInstrument.funcReg.match(F.getName()) ||
+            funcToInstrument.style != BODY) {
+          continue;
+        }
+        instrumentFunctionBody = true;
+      }
+
+      // Getting down to LLVM IR instruction to insert
+      // instrumentation traces.
+      for (auto &BB : F) {
+        for (auto &I : BB) {
+          // Skipping instruction that doesn't change memory.
+          if (I.getOpcode() == llvm::Instruction::Alloca ||
+              I.getOpcode() == llvm::Instruction::Ret ||
+              I.getOpcode() == llvm::Instruction::Unreachable ||
+              I.getOpcode() == llvm::Instruction::Br) {
+            continue;
+          }
+          // If function body matched to be instrumented above
+          // then we iterated over its body adding traces otherwise
+          // checking if current instuction is a call and matching
+          // on of the function calls to be instrumented.
+          if (instrumentFunctionBody && !isa<llvm::CallInst>(&I)) {
+            llvm::IRBuilder<> builder(&I);
+            if (isa<llvm::StoreInst>(&I)) {
+              builder.SetInsertPoint(&BB, ++builder.GetInsertPoint());
+              auto *traceCounterValue =
+                  builder.getInt64(static_cast<int64_t>(traceCounter++));
+              builder.CreateCall(
+                  printfF->getFunctionType(), printfF,
+                  {formatInstrArgP_, traceCounterValue,
+                   llvm::cast<llvm::StoreInst>(&I)->getPointerOperand()});
+            } else {
+              builder.SetInsertPoint(&BB, ++builder.GetInsertPoint());
+              auto *traceCounterValue =
+                  builder.getInt64(static_cast<int64_t>(traceCounter++));
+              builder.CreateCall(printfF->getFunctionType(), printfF,
+                                 {formatInstrArgD_, traceCounterValue,
+                                  llvm::cast<llvm::Value>(&I)});
+            }
+          } else if (auto *CI = llvm::dyn_cast<llvm::CallInst>(&I)) {
+            // If current LLVM IR instruction is not a call or the
+            // instruction/call name doesn't match requested set of function
+            // calls to be instrumented, skipping instrumentation, otherwise
+            // wrap function call in traces.
+            auto funcToInstrument = std::find_if(
+                funcsToInstrument_.begin(), funcsToInstrument_.end(),
+                [&](auto &fi) {
+                  if (CI->getCalledFunction() == nullptr ||
+                      !fi.funcReg.match(CI->getCalledFunction()->getName()) ||
+                      fi.style != CALL) {
+                    return false;
+                  }
+                  return true;
+                });
+
+            // If function is in the list to be instumented and
+            // custom functions before (and after specified) use them.
+            if (funcToInstrument != funcsToInstrument_.end() &&
+                funcToInstrument->callBefore) {
+              llvm::IRBuilder<> builder(CI);
+
+              // Args to be used for calling the specialized function.
+              llvm::SmallVector<llvm::Value *, 16> argsForInstr;
+              for (auto &arg : CI->arg_operands()) {
+                argsForInstr.push_back(arg);
+              }
+
+              builder.CreateCall(
+                  funcToInstrument->callBefore->getFunctionType(),
+                  funcToInstrument->callBefore, argsForInstr);
+              if (funcToInstrument->callAfter) {
+                builder.SetInsertPoint(&BB, ++builder.GetInsertPoint());
+                builder.CreateCall(
+                    funcToInstrument->callAfter->getFunctionType(),
+                    funcToInstrument->callAfter, argsForInstr);
+              }
+              // Otherwise check if function body instrumentation is going
+              // or default wrappers for function requested, wrap the
+              // function.
+            } else if (instrumentFunctionBody ||
+                       funcToInstrument != funcsToInstrument_.end()) {
+              instrumentFuntionCall(CI, printfF);
+            }
+          }
+        }
+      }
+    }
+
+    DEBUG_GLOW(llvm::outs() << "LLVM module after instrumentation:\n");
+    DEBUG_GLOW(irgen_.getModule().print(llvm::outs(), nullptr));
+  }
+
+private:
+  // Prints function input parameter values.
+  void instrumentFuntionCall(llvm::CallInst *CI, llvm::Function *printfF) {
+    if (CI->getCalledFunction() == nullptr ||
+        (CI->getCalledFunction()->getName() == printfF->getName())) {
+      return;
+    }
+
+    llvm::IRBuilder<> builder(CI);
+
+    auto *functionName = irgen_.emitStringConst(
+        irgen_.getBuilder(), CI->getCalledFunction()->getName());
+    builder.CreateCall(printfF->getFunctionType(), printfF,
+                       {formatFuncInArg_, functionName});
+
+    // Iterating over all function args. First agr is function output
+    // if function signature is not void.
+#if LLVM_VERSION_MAJOR >= 8
+    for (auto &op : CI->args()) {
+#else
+    for (auto &op : CI->arg_operands()) {
+#endif
+      llvm::Value *argFormat = nullptr;
+      auto type = op.get()->getType();
+
+      // Printing interger values with %d symbol.
+      if (type->isIntegerTy() ||
+          (type->isPointerTy() && dyn_cast<llvm::PointerType>(type)
+                                      ->getElementType()
+                                      ->isIntegerTy())) {
+        auto *value = op.get();
+        // If arg is a pointer to integer value get value and print it.
+        if (type->isPointerTy()) {
+          value = builder.CreateLoad(op.get());
+        }
+
+        argFormat = irgen_.emitStringConst(irgen_.getBuilder(), "\targ: %d\n");
+        builder.CreateCall(printfF->getFunctionType(), printfF,
+                           {argFormat, value});
+        continue;
+      }
+
+      // Processing pointers to structure values.
+      if (type->isPointerTy()) {
+        auto *structType = dyn_cast<llvm::StructType>(
+            dyn_cast<llvm::PointerType>(type)->getElementType());
+        if (structType) {
+          std::string printStructFuncName = "pretty_print_";
+          llvm::StringRef structName;
+          // Structure types usually start either from struct. or class.
+          // stripping it from a name.
+          if (structType->getName().startswith("struct.")) {
+            structName = structType->getName().slice(
+                std::string("struct.").length(), structType->getName().size());
+          } else if (structType->getName().startswith("class.")) {
+            structName = structType->getName().slice(
+                std::string("class.").length(), structType->getName().size());
+          }
+          printStructFuncName += structName;
+          // Checking if module has print_<Struct\Class name> function to
+          // print arg. If not then just jumpring to default printout - ...
+          if (auto *printStruct =
+                  irgen_.getModule().getFunction(printStructFuncName)) {
+            builder.CreateCall(printStruct->getFunctionType(), printStruct,
+                               {op.get()});
+            continue;
+          }
+        }
+      }
+
+      argFormat = irgen_.emitStringConst(irgen_.getBuilder(), "\targ: ...\n");
+      builder.CreateCall(printfF->getFunctionType(), printfF, {argFormat});
+    }
+
+    builder.SetInsertPoint(CI->getParent(), ++builder.GetInsertPoint());
+    builder.CreateCall(printfF->getFunctionType(), printfF,
+                       {formatFuncOutArg_, functionName});
+  }
+
+  // Parsed metadata about instrumentation types.
+  std::vector<InstrumentationMetaInformation> funcsToInstrument_;
+
+  /// LLVMIRGen to be used.
+  LLVMIRGen &irgen_;
+
+  // Format string for simple line instumentation.
+  llvm::Value *formatInstrArgD_ = nullptr;
+  // Format string for simple line instumentation.
+  llvm::Value *formatInstrArgP_ = nullptr;
+  // Format string for trace before function call.
+  llvm::Value *formatFuncInArg_ = nullptr;
+  // Format string for simple after function call.
+  llvm::Value *formatFuncOutArg_ = nullptr;
+};
+
+} // namespace
+
+void LLVMIRGen::performDebugInstrumentation() {
+  DebugInstrumentation debugInstrumentation(*this);
+  debugInstrumentation.run();
+}

--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -182,6 +182,9 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM) {
   // else.
   performSpecialization();
 
+  // Add instrumentation into the code for better debugging experience.
+  performDebugInstrumentation();
+
   M->setTargetTriple(TM.getTargetTriple().normalize());
   M->setDataLayout(TM.createDataLayout());
 


### PR DESCRIPTION
Summary:
Function calls and function bodies instrumentations using either default or provided functions
1. Function body instrumentation. One can specify what function bodies he\she wants to trace. It can be achieved by specializing function name or by giving regular expression. Below example shows that every line in the main will be instrumented. I.e. after every line (except alloca and some specific instructions) there will be trace showing what value was written out. The trace consist of instruction number (which is global counter, i.e. if few functions body is instrumented then every new function will have counter continued from previous). On top of that one can specify the printout function that needs to be used to output traces.
If there is a function call in the body then it will be handled in default manner: there will be trace saying that we are about to call function, then all its parameters (integers will be printed always but complex structs only if there is corresponding function with name pretty_print_<struct_name>(struct_name* ) in the context) and exit trace will also be added.
 **-llvm-code-debug-trace-instrumentation="main:body"**

2. Function calls instrumentation. By default it will wrap all function calls that corresponds to given regular expression into traces before and after. Before can be either default instrumentation that prints function and its input parameters or one can specify the functions to use. The specificified functions have to have the same signature as original function.
**-llvm-code-debug-trace-instrumentation="foo:call[:before_foo[:after_foo]]"**

3. There is possibility to specify printing function by giving its name. The print out function has to have the same signature as printf
**-llvm-debug-trace-print-function-name=my_printf**

4. There is option to output instrumented IR by providing in command line (works only with debug glow build):
**-debug-glow-only=debug-instrumentation**

Reviewed By: opti-mix

Differential Revision: D31940437

