### PR TITLE
Support aten::size with single argument

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -21,6 +21,7 @@
 #include "c10/core/Scalar.h"
 #include "c10/core/ScalarType.h"
 #include "glow/Exporter/ONNXModelWriter.h"
+#include "glow/Importer/CommonOperatorLoader.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Support/Error.h"
 #include "glow/Support/Support.h"
@@ -1641,6 +1642,9 @@ PyTorchModelLoader::buildSymbolsMapping() {
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
       {{"aten::abs"},
        UNARY_NODE_LOADER(Abs),
+       &PyTorchModelLoader::getCorrectTypeFromInput<0>},
+      {{"aten::neg"},
+       UNARY_NODE_LOADER(Neg),
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
       {{"aten::upsample_nearest3d"},
        &PyTorchModelLoader::loadUpsampleNearest,

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -8402,9 +8402,12 @@ Error PyTorchModelLoader::loadEquallySplit(const torch::jit::Node *ptNode) {
       num_split,
       iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::num_split])));
 
-  int dim;
+  int dimRaw;
   ASSIGN_VALUE_OR_RETURN_ERR(
-      dim, iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::dim])));
+      dimRaw, iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::dim])));
+  int dim = 0;
+  ASSIGN_VALUE_OR_RETURN_ERR(dim,
+                             getPositiveIndex(dimRaw, input.dims().size()));
 
   std::vector<glow::SliceNode *> splitOutputs;
   F_.createSplit("EquallySplit", input, num_split, dim, {}, splitOutputs);

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4017,33 +4017,41 @@ Error PyTorchModelLoader::loadAmax(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(outputs[0], amax));
 }
 
+/*
+  aten::size(Tensor self, int dim) -> int"
+  aten::size(Tensor self) -> int[]
+*/
 Error PyTorchModelLoader::loadSize(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
-  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, -1, outputs, 1));
 
   glow::NodeValue input;
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[SizeInputs::input]));
-
-  int64_t dim;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      dim, iValToInt(getGlowIValueForValue(inputs[SizeInputs::dim])));
-
-  // Convert negative dimension index into corresponding positive index
-  auto origDim = dim;
-  if (dim < 0) {
-    dim += input.dims().size();
-  }
-
-  RETURN_ERR_IF_NOT(dim < input.dims().size() && dim >= 0,
-                    strFormat("Dim value of %ld is out of range. Valid values "
-                              "are in the range [-%ld, %ld]",
-                              origDim, input.dims().size(),
-                              input.dims().size() - 1));
-
   GlowIValue glowIVal;
-  glowIVal.fromInt(input.dims()[dim]);
+  if (ptNode->inputs().size() > 1) {
+    int64_t dim;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        dim, iValToInt(getGlowIValueForValue(inputs[SizeInputs::dim])));
+
+    // Convert negative dimension index into corresponding positive index
+    auto origDim = dim;
+    if (dim < 0) {
+      dim += input.dims().size();
+    }
+
+    RETURN_ERR_IF_NOT(
+        dim < input.dims().size() && dim >= 0,
+        strFormat("Dim value of %ld is out of range. Valid values "
+                  "are in the range [-%ld, %ld]",
+                  origDim, input.dims().size(), input.dims().size() - 1));
+
+    glowIVal.fromInt(input.dims()[dim]);
+  } else {
+    std::vector<int64_t> intList{input.dims().begin(), input.dims().end()};
+    glowIVal.fromIntList(intList);
+  }
 
   RETURN_ERR(addValueMapping(outputs[0], std::move(glowIVal)));
 }

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -1078,6 +1078,10 @@ private:
   // Load fb:int_nbit_split_embedding_codegen_lookup_function
   // \returns error on failure.
   Error loadIntNBitSplitEmbeddingBags(const torch::jit::Node *ptNode);
+
+  // Load Pytorch aten::amax
+  // \returns error on failure.
+  Error loadAmax(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary: Add support for loading aten::size with one argument(in which case it returns all dimensions of the input).

Differential Revision: D32812197

