### PR TITLE
Support max with two outputs

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -21,6 +21,7 @@
 #include "c10/core/Scalar.h"
 #include "c10/core/ScalarType.h"
 #include "glow/Exporter/ONNXModelWriter.h"
+#include "glow/Importer/CommonOperatorLoader.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Support/Error.h"
 #include "glow/Support/Support.h"
@@ -1641,6 +1642,9 @@ PyTorchModelLoader::buildSymbolsMapping() {
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
       {{"aten::abs"},
        UNARY_NODE_LOADER(Abs),
+       &PyTorchModelLoader::getCorrectTypeFromInput<0>},
+      {{"aten::neg"},
+       UNARY_NODE_LOADER(Neg),
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
       {{"aten::upsample_nearest3d"},
        &PyTorchModelLoader::loadUpsampleNearest,

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -8402,9 +8402,12 @@ Error PyTorchModelLoader::loadEquallySplit(const torch::jit::Node *ptNode) {
       num_split,
       iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::num_split])));
 
-  int dim;
+  int dimRaw;
   ASSIGN_VALUE_OR_RETURN_ERR(
-      dim, iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::dim])));
+      dimRaw, iValToInt(getGlowIValueForValue(inputs[FusedSplitInputs::dim])));
+  int dim = 0;
+  ASSIGN_VALUE_OR_RETURN_ERR(dim,
+                             getPositiveIndex(dimRaw, input.dims().size()));
 
   std::vector<glow::SliceNode *> splitOutputs;
   F_.createSplit("EquallySplit", input, num_split, dim, {}, splitOutputs);

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4017,33 +4017,41 @@ Error PyTorchModelLoader::loadAmax(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(outputs[0], amax));
 }
 
+/*
+  aten::size(Tensor self, int dim) -> int"
+  aten::size(Tensor self) -> int[]
+*/
 Error PyTorchModelLoader::loadSize(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
-  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, -1, outputs, 1));
 
   glow::NodeValue input;
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[SizeInputs::input]));
-
-  int64_t dim;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      dim, iValToInt(getGlowIValueForValue(inputs[SizeInputs::dim])));
-
-  // Convert negative dimension index into corresponding positive index
-  auto origDim = dim;
-  if (dim < 0) {
-    dim += input.dims().size();
-  }
-
-  RETURN_ERR_IF_NOT(dim < input.dims().size() && dim >= 0,
-                    strFormat("Dim value of %ld is out of range. Valid values "
-                              "are in the range [-%ld, %ld]",
-                              origDim, input.dims().size(),
-                              input.dims().size() - 1));
-
   GlowIValue glowIVal;
-  glowIVal.fromInt(input.dims()[dim]);
+  if (ptNode->inputs().size() > 1) {
+    int64_t dim;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        dim, iValToInt(getGlowIValueForValue(inputs[SizeInputs::dim])));
+
+    // Convert negative dimension index into corresponding positive index
+    auto origDim = dim;
+    if (dim < 0) {
+      dim += input.dims().size();
+    }
+
+    RETURN_ERR_IF_NOT(
+        dim < input.dims().size() && dim >= 0,
+        strFormat("Dim value of %ld is out of range. Valid values "
+                  "are in the range [-%ld, %ld]",
+                  origDim, input.dims().size(), input.dims().size() - 1));
+
+    glowIVal.fromInt(input.dims()[dim]);
+  } else {
+    std::vector<int64_t> intList{input.dims().begin(), input.dims().end()};
+    glowIVal.fromIntList(intList);
+  }
 
   RETURN_ERR(addValueMapping(outputs[0], std::move(glowIVal)));
 }

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -1082,6 +1082,10 @@ private:
   // Load Pytorch aten::amax
   // \returns error on failure.
   Error loadAmax(const torch::jit::Node *ptNode);
+
+  // Load Pytorch aten::softplus
+  // \returns error on failure.
+  Error loadSoftPlus(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -1078,6 +1078,10 @@ private:
   // Load fb:int_nbit_split_embedding_codegen_lookup_function
   // \returns error on failure.
   Error loadIntNBitSplitEmbeddingBags(const torch::jit::Node *ptNode);
+
+  // Load Pytorch aten::amax
+  // \returns error on failure.
+  Error loadAmax(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/softplus_test.py
+++ b/torch_glow/tests/nodes/softplus_test.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch.nn.functional as F
+from tests import utils
+
+
+class SimpleSoftPlusModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleSoftPlusModel, self).__init__()
+
+    def forward(self, tensor):
+        tensor = tensor + tensor
+        return F.softplus(tensor)
+
+
+class TestSoftPlus(utils.TorchGlowTestCase):
+    def test_softplus(self):
+        """Basic test of the PyTorch aten::softplus Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleSoftPlusModel(),
+            torch.randn(4, 3),
+            fusible_ops={"aten::softplus"},
+        )

--- a/torch_glow/tests/nodes/sum_test.py
+++ b/torch_glow/tests/nodes/sum_test.py
@@ -72,6 +72,16 @@ class TestSumKeepdim(utils.TorchGlowTestCase):
                 KeepdimSumModule(-2, True),
                 torch.randn(3, 1, 2),
             ),
+            lambda: (
+                "multiple_axes",
+                KeepdimSumModule((0, 1), False, torch.float16),
+                torch.randn(3, 4, 2),
+            ),
+            lambda: (
+                "multiple_axes_keep_dim",
+                KeepdimSumModule((2, 1), True, torch.float16),
+                torch.randn(3, 4, 2),
+            ),
         ]
     )
     def test_sum(self, _, module, a):


### PR DESCRIPTION
Summary: The current implementation of `aten::max` only supports cases with 1 or 2 inputs and 1 outputs, which results in some A* compatability test failures. This adds support for `aten::max` where there are 2 outputs(values and indices).

Differential Revision: D32812198

