### PR TITLE
Add support for padded placeholders

### DIFF
--- a/include/glow/Graph/FXIRUtils.h
+++ b/include/glow/Graph/FXIRUtils.h
@@ -114,6 +114,9 @@ template <class T> std::vector<T> getNodeShape(const folly::dynamic &node) {
   return toIntegerArray<glow::dim_t>(node.at("shape").getString());
 }
 
+/// Checks if node's padded.
+bool isNodePadded(const folly::dynamic &node);
+
 /// Get the arg of the node.
 const folly::dynamic &getNodeArgs(const folly::dynamic &node);
 

--- a/lib/Graph/FXIRUtils.cpp
+++ b/lib/Graph/FXIRUtils.cpp
@@ -103,6 +103,16 @@ const folly::dynamic &glow::getNodeKwargs(const folly::dynamic &node) {
   return node["kwargs"];
 }
 
+bool glow::isNodePadded(const folly::dynamic &node) {
+  auto shape = getNodeShape<glow::dim_t>(node);
+  auto stride = getNodeStride<glow::dim_t>(node);
+  if (stride.size() >= 2) {
+    CHECK_EQ(shape.size(), stride.size());
+    return stride[stride.size() - 2] > shape[shape.size() - 1];
+  }
+  return false;
+}
+
 Value *glow::valueForNode(
     const std::string &nodeName,
     const std::unordered_map<std::string, Value *> &storageNodeNameToDest,


### PR DESCRIPTION
Summary:
Currently we always assume that placeholders are not padded, which is not
necessarily true in case of the eager mode.

Differential Revision: D32908587

