### PR TITLE
Compilation fix for issue detected with gcc 9.3

### DIFF
--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -91,7 +91,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
                   : allocatedAddress_) {
     if (isa<AllocActivationInst>(A.first) || isa<TensorViewInst>(A.first))
       continue;
-    CHECK(valueNumbers_.count(A.first)) << "Unknown weight";
+    (CHECK(valueNumbers_.count(A.first)) << "Unknown weight");
     if (isa<Constant>(A.first))
       continue;
     auto *weight = dyn_cast<WeightVar>(A.first);


### PR DESCRIPTION
Summary:
Issue with one MACRO inside another MACRO not handled properly.
CHECK macro is invoked under DEBUG_GLOW macro.