### PR TITLE
Update BatchedUnaryEmbeddings op name in Glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1864,7 +1864,8 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::erf"},
        &PyTorchModelLoader::loadErf,
        &PyTorchModelLoader::getCorrectTypeFromInput<0>},
-      {{"fbgemm_gpu::batched_unary_embeddings"},
+      {{"fbgemm_gpu::batched_unary_embeddings",
+        "fbgemm::batched_unary_embeddings"},
        &PyTorchModelLoader::loadBatchedUnaryEmbeddingsBags,
        &PyTorchModelLoader::getCorrectTypeFromInput<
            BatchedUnaryEmbeddingsBagsInputs::weights>},


### PR DESCRIPTION
Summary: To resolve the op loading issue in torch_glow after its renaming lately.

Reviewed By: jackm321, jfix71

Differential Revision: D33420823

