### PR TITLE
Skip Conv-BN fusion when Conv has a fused activation

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2435,6 +2435,11 @@ bool OptimizeBatchNorm::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
 
+    // We cannot do this optimization if the conv has an activation fused in.
+    if (CV->getFusedActivation() != FusedActivation::NONE) {
+      continue;
+    }
+
     bool normalizationHappened = false;
     switch (CV->getElementType(ConvolutionNode::ResultIdx)) {
     case ElemKind::FloatTy:


### PR DESCRIPTION
Summary:
att

fixes https://github.com/pytorch/glow/issues/5868
fixes https://github.com/pytorch/glow/issues/5892

Differential Revision: D33535239

