### PR TITLE
Visualization of jit graph for debugging multiple fusion groups/shape inference

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -56,6 +56,9 @@ public:
   /// Dump Glow dot graph to file after model loading is finished.
   bool dumpGlowDag = false;
 
+  /// Dump JIT IR dot graph to file after fusion/shape inference.
+  bool dumpJitDag = false;
+
   /// A list of symbols for nodes that will be ignored by the Glow fuser and
   /// thus will not be fused to Glow.
   std::unordered_set<torch::jit::Symbol> opBlocklist;

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -94,6 +94,10 @@ public:
   /// %5: [2 4]
   void printShapeMap();
 
+  /// Save dump of JIT graph for debugging multiple fusion groups/shape
+  /// inference
+  void dumpGraph(const torch::jit::Graph &graph);
+
 private:
   /// Graph that needs to be run shape inference.
   const torch::jit::Graph &graph_;


### PR DESCRIPTION
Summary: Add graph drawer for JIT graphs in ShapeInferenceEngine to view fusion groups and shape inference and speed up debugging. Enabled with --dumpJITDag flag

Reviewed By: khabinov

Differential Revision: D33461888

