### PR TITLE
Move FoldArithmeticChainUnderConvIntoBN to Fold pipeline

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2435,6 +2435,11 @@ bool OptimizeBatchNorm::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
 
+    // We cannot do this optimization if the conv has an activation fused in.
+    if (CV->getFusedActivation() != FusedActivation::NONE) {
+      continue;
+    }
+
     bool normalizationHappened = false;
     switch (CV->getElementType(ConvolutionNode::ResultIdx)) {
     case ElemKind::FloatTy:

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -184,11 +184,6 @@ createDefaultGraphOptimizationPassPipeline() {
       {FunctionPassID::OptimizeReshape},
       {FunctionPassID::SinkCode, ConvergenceMode::UntilFixedPoint},
 
-      // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
-      {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,
-       ConvergenceMode::OnePass,
-       {CompilationMode::Infer}},
-
       // Fold Arithmetic chain w/ constants into the preceding Batch Norm.
       {FunctionPassID::FoldBatchNormalizationWithArithmeticChain,
        ConvergenceMode::OnePass,
@@ -273,6 +268,11 @@ std::unique_ptr<FunctionPassPipeline> createDefaultFoldPassPipeline() {
 
       // Fold exp + reduce sum + div into softmax
       {FunctionPassID::FoldExpSumDivIntoSoftmax},
+
+      // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
+      {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,
+       ConvergenceMode::OnePass,
+       {CompilationMode::Infer}},
 
       // Perform Dead Code Elimination.
       getDCEPassConfig(),

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -794,7 +794,9 @@ TEST_F(GraphOptz, FoldArithmeticChainAfterConvIntoBatchNorm) {
   // Compile.
   EXPECT_EQ(F_->getNodes().size(), 6);
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {});
-  optimizedF_ = optimizeFunctionForTest(F_);
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+  CompilationContext cctx;
+  ::glow::fold(optimizedF_, cctx);
   EXPECT_EQ(optimizedF_->getNodes().size(), 3);
 
   auto *opt_res = findFunctionNodeByName<SaveNode>(optimizedF_, res->getName());


### PR DESCRIPTION
Summary:
This pass folds many ops into a BatchNorm op. It makes more sense/is more valid to have as part of the Fold pipeline.

This is necessary for fully fixing https://github.com/pytorch/glow/issues/5868 and https://github.com/pytorch/glow/issues/5892, because previous to this PR we were potentially creating a `BatchNormalizationNode` any time `optimize()` was called, but this isn't valid to do after lowering has occurred in the middle of the pipeline, because the backend (e.g. CPU backend) might not support `BatchNormalizationNode` as unlowered.

Differential Revision: D33593762

