### PR TITLE
Removed the multiple occurrence of ImageLayout flag

### DIFF
--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -85,8 +85,6 @@ extern std::vector<ImgDataRange> imageDataRangeOpt;
 /// -image-layout flag.
 extern std::vector<ImageLayout> imageLayoutOpt;
 
-/// -input-layout flag
-extern ImageLayout inputLayout;
 
 /// -input-layout flag
 extern ImageLayout inputLayout;


### PR DESCRIPTION
Summary: There was multiple occurrences of ImageLayout flag . This commit removes the additional ones and only a single flag exists now .


Fixes #5816 

