### PR TITLE
fix platform010 build failure in ReproFXLib

### DIFF
--- a/tests/unittests/ReproFXLib.cpp
+++ b/tests/unittests/ReproFXLib.cpp
@@ -84,9 +84,10 @@ void ReproFXLib::load(const folly::dynamic &data,
     modPathAndWeightName.first.split(modNames, ".");
     auto currMod = container;
     for (const auto &modName : modNames) {
-      currMod = currMod.attr(modName).toModule();
+      currMod = currMod.attr(modName.str()).toModule();
     }
-    torch::Tensor tensor = currMod.attr(modPathAndWeightName.second).toTensor();
+    torch::Tensor tensor =
+        currMod.attr(modPathAndWeightName.second.str()).toTensor();
     weights.insert(key, tensor);
   }
 


### PR DESCRIPTION
Summary:
For platform010 build, this one is failing due to
```
glow/glow/tests/unittests/ReproFXLib.cpp:87:25: error: no matching member function for call to 'attr'
      currMod = currMod.attr(modName).toModule();
                ~~~~~~~~^~~~
caffe2/torch/csrc/jit/api/object.h:74:15: note: candidate function not viable: no known conversion from 'const llvm::StringRef' to 'const std::string' (aka 'const basic_string<char>') for 1st argument
  c10::IValue attr(const std::string& name) const {
              ^
caffe2/torch/csrc/jit/api/object.h:87:15: note: candidate function not viable: requires 2 arguments, but 1 was provided
  c10::IValue attr(const std::string& name, c10::IValue or_else) const {
              ^
glow/glow/tests/unittests/ReproFXLib.cpp:89:36: error: no matching member function for call to 'attr'
    torch::Tensor tensor = currMod.attr(modPathAndWeightName.second).toTensor();
                           ~~~~~~~~^~~~
caffe2/torch/csrc/jit/api/object.h:74:15: note: candidate function not viable: no known conversion from 'llvm::StringRef' to 'const std::string' (aka 'const basic_string<char>') for 1st argument
  c10::IValue attr(const std::string& name) const {
              ^
caffe2/torch/csrc/jit/api/object.h:87:15: note: candidate function not viable: requires 2 arguments, but 1 was provided
  c10::IValue attr(const std::string& name, c10::IValue or_else) const {
              ^
2 errors generated.
```

Differential Revision: D34410208

