### PR TITLE
Minimum weight thresholds for SLS on NNPI

### DIFF
--- a/torch_glow/src/GlowFuser.h
+++ b/torch_glow/src/GlowFuser.h
@@ -20,6 +20,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 
 #include "PyTorchCommon.h"
+#include "PyTorchModelLoader.h"
 
 namespace glow {
 /// Registers Glow's default symbol on the first call to this function.
@@ -29,13 +30,17 @@ void registDefaultGlowFusionSymbolOnce();
 /// Fuse nodes in \p graph that are supported by glow into a subgraph in a node
 /// with symbol \p kind. NOTE: kind must be registered with jit before calling
 /// this function.
-void glowCustomFuse(std::shared_ptr<torch::jit::Graph> graph,
-                    const PyTorchLoaderSettings &settings, at::Symbol kind);
+void glowCustomFuse(
+    std::shared_ptr<torch::jit::Graph> graph,
+    const PyTorchLoaderSettings &settings, at::Symbol kind,
+    IsSupportedFn isSupported = PyTorchModelLoader::isNodeSupported);
 
 /// Fuse nodes in \p graph that are supported by glow into a subgraph in Glow
 /// fusion group nodes using the settings in \p settings.
-void glowCustomFuse(std::shared_ptr<torch::jit::Graph> graph,
-                    const PyTorchLoaderSettings &settings);
+void glowCustomFuse(
+    std::shared_ptr<torch::jit::Graph> graph,
+    const PyTorchLoaderSettings &settings,
+    IsSupportedFn isSupported = PyTorchModelLoader::isNodeSupported);
 
 /// Fuse nodes in \p graph that have a kind in \p acceptableKinds into a
 /// subgraph in Glow fusion group nodes.

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -302,6 +302,7 @@ enum class GraphOutputType {
 
 using PostFusionProcessFn =
     std::function<void(std::shared_ptr<torch::jit::Graph> graph)>;
+using IsSupportedFn = std::function<bool(const torch::jit::Node *)>;
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
 ElemKind scalarTypeToElemKind(c10::ScalarType ty);
@@ -367,7 +368,8 @@ void glowAOTFusion(
     const std::string &onnxModelFile = "",
     c10::optional<PostFusionProcessFn> postFusionProcessFn = {},
     const c10::optional<ModelCompilationConfigOverride>
-        &modelCompilationConfigOverride = c10::nullopt);
+        &modelCompilationConfigOverride = c10::nullopt,
+    c10::optional<IsSupportedFn> supportFn = c10::nullopt);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMeta is a
 /// vector containing the meta data of the model inputs.
@@ -386,7 +388,8 @@ void glowAOTFusionWithShapeInference(
     const std::string &onnxModelFile = "",
     c10::optional<PostFusionProcessFn> postFusionProcessFn = {},
     const c10::optional<ModelCompilationConfigOverride>
-        &modelCompilationConfigOverride = c10::nullopt);
+        &modelCompilationConfigOverride = c10::nullopt,
+    c10::optional<IsSupportedFn> supportFn = {});
 
 /// Enable overriding signal handlers while exeucting torch_glow code. This
 /// should only be used in Python to enable easier debugging and not in

--- a/torch_glow/tests/unittests/PyTorchCommonTests.cpp
+++ b/torch_glow/tests/unittests/PyTorchCommonTests.cpp
@@ -47,3 +47,60 @@ TEST(PyTorchCommonTests, PostFusionProcessTest) {
 
   ASSERT_EQ(8, *testPtr) << "Ensuring post fusion callback is invoked";
 }
+
+TEST(PyTorchCommonTests, IsSupportedFnTest) {
+  const auto moduleScript = R"JIT(
+    def forward(self, input_0: Tensor, input_1: Tensor):
+        res = input_0 + input_1
+        return res
+  )JIT";
+
+  glow::InputMetaStack inputMeta;
+  const std::vector<glow::sdim_t> dims{3, 4};
+  inputMeta.inputMetas.emplace_back(c10::ScalarType::Float, dims);
+  inputMeta.inputMetas.emplace_back(c10::ScalarType::Float, dims);
+
+  auto settings = glow::getGlobalPyTorchLoaderSettingsSnapshot();
+  settings.minFusionGroupSize = 0;
+
+  auto fusionNodeSymbol = glow::getGlowSymbol(nullptr);
+
+  torch::jit::script::Module module{"ModuleDefaultSupportFn"};
+  module.define(moduleScript);
+  glow::glowAOTFusionWithShapeInference(module, inputMeta, nullptr, settings,
+                                        "forward");
+  int expectedFusionNodeCnt = 1;
+  int fusionNodeCnt = 0;
+  for (auto n : toGraphFunction(module.get_method("forward").function())
+                    .graph()
+                    ->nodes()) {
+    auto kind = n->kind();
+    if (fusionNodeSymbol == kind) {
+      fusionNodeCnt++;
+    }
+  }
+  ASSERT_EQ(expectedFusionNodeCnt, fusionNodeCnt)
+      << "Check that with the default isNodeSupported function, a fusion "
+         "node is created";
+
+  torch::jit::script::Module moduleCustomSupportFn{"ModuleCustomSupportFn"};
+  moduleCustomSupportFn.define(moduleScript);
+  glow::glowAOTFusionWithShapeInference(
+      moduleCustomSupportFn, inputMeta, nullptr, settings, "forward", {},
+      nullptr, nullptr, "", "", c10::nullopt, c10::nullopt,
+      [](auto &&) { return false; });
+  expectedFusionNodeCnt = 0;
+  fusionNodeCnt = 0;
+  for (auto n :
+       toGraphFunction(moduleCustomSupportFn.get_method("forward").function())
+           .graph()
+           ->nodes()) {
+    auto kind = n->kind();
+    if (fusionNodeSymbol == kind) {
+      fusionNodeCnt++;
+    }
+  }
+  ASSERT_EQ(expectedFusionNodeCnt, fusionNodeCnt)
+      << "Check that with the custom isNodeSupported function, no fusion "
+         "nodes are created.";
+}


### PR DESCRIPTION
Summary: Move SLS onto CPU with --pytorch_predictor_glow_min_sls_weight_threshold flag specifying weight size threshold for use on NNPI

Differential Revision: D31808509

