### PR TITLE
explicitly use NodeValue for comparison

### DIFF
--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -142,9 +142,9 @@ TEST(GraphAutoGrad, cloneAndDiff) {
     if (!SGD)
       continue;
     ++nbSGDs;
-    if (A == SGD->getWeight())
+    if (NodeValue(A) == SGD->getWeight())
       ++nbSGDA;
-    else if (B == SGD->getWeight())
+    else if (NodeValue(B) == SGD->getWeight())
       ++nbSGDB;
   }
   EXPECT_EQ(nbSGDs, 2);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -930,7 +930,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvButVarReused) {
   EXPECT_TRUE(llvm::isa<Placeholder>(optimizedF_filterSave->getInput()));
   auto *varFilter =
       llvm::dyn_cast<Placeholder>(optimizedF_filterSave->getInput());
-  EXPECT_EQ(varFilter, CV->getFilter());
+  EXPECT_EQ(NodeValue(varFilter), CV->getFilter());
   EXPECT_TRUE(llvm::isa<BatchNormalizationNode>(optimizedF_ret->getInput()));
 
   BatchNormalizationNode *batchNorm =
@@ -2982,7 +2982,7 @@ TEST_F(GraphFold, foldLeakyReluFromSplat) {
   auto *newSplatNode = llvm::dyn_cast<SplatNode>(newPReluNode->getSlope());
   ASSERT_TRUE(newSplatNode);
   EXPECT_EQ(leakyAlpha, newSplatNode->getValue());
-  EXPECT_EQ(input, newPReluNode->getInput());
+  EXPECT_EQ(NodeValue(input), newPReluNode->getInput());
 }
 
 /// This test checks that a lowered LeakyRelu is corrected folded:
@@ -3014,7 +3014,7 @@ TEST_F(GraphFold, foldLeakyReluFromConst) {
   auto *newSplatNode = llvm::dyn_cast<SplatNode>(newPReluNode->getSlope());
   ASSERT_TRUE(newSplatNode);
   EXPECT_EQ(leakyAlpha, newSplatNode->getValue());
-  EXPECT_EQ(input, newPReluNode->getInput());
+  EXPECT_EQ(NodeValue(input), newPReluNode->getInput());
 }
 
 /// Test optimization of  Convolution nodes with small input tensors by reducing
@@ -3988,7 +3988,7 @@ TEST_F(GraphOptz, simplifyArithmeticMultipleUsers) {
   EXPECT_TRUE(llvm::isa<AddNode>(newAN2->getLHS()));
   EXPECT_TRUE(llvm::isa<SplatNode>(newAN2->getRHS()));
 
-  EXPECT_EQ(newAN1, newAN2->getLHS());
+  EXPECT_EQ(NodeValue(newAN1), newAN2->getLHS());
 
   // input1 should still have a single user after optimization.
   EXPECT_EQ(I1->getUsers().size(), 1);

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -1581,13 +1581,13 @@ TEST(Graph, PreOrderTest) {
   EXPECT_EQ(order[4], input1);
   EXPECT_EQ(order[5], mul2);
   EXPECT_EQ(order[6], input2);
-  EXPECT_EQ(order[7], ret1->getOutput());
+  EXPECT_EQ(NodeValue(order[7]), ret1->getOutput());
   EXPECT_EQ(order[8], add3);
   EXPECT_EQ(order[9], add2);
   EXPECT_EQ(order[10], add1);
   EXPECT_EQ(order[11], one);
   EXPECT_EQ(order[12], ret2);
-  EXPECT_EQ(order[13], ret2->getOutput());
+  EXPECT_EQ(NodeValue(order[13]), ret2->getOutput());
 }
 
 /// Verify that the post-order visitor works correctly.
@@ -1622,13 +1622,13 @@ TEST(Graph, PostOrderTest) {
   EXPECT_EQ(order[3], input2);
   EXPECT_EQ(order[4], mul2);
   EXPECT_EQ(order[5], mul3);
-  EXPECT_EQ(order[6], ret1->getOutput());
+  EXPECT_EQ(NodeValue(order[6]), ret1->getOutput());
   EXPECT_EQ(order[7], ret1);
   EXPECT_EQ(order[8], one);
   EXPECT_EQ(order[9], add1);
   EXPECT_EQ(order[10], add2);
   EXPECT_EQ(order[11], add3);
-  EXPECT_EQ(order[12], ret2->getOutput());
+  EXPECT_EQ(NodeValue(order[12]), ret2->getOutput());
   EXPECT_EQ(order[13], ret2);
 }
 

--- a/tests/unittests/NNPIOptPipelineTest.cpp
+++ b/tests/unittests/NNPIOptPipelineTest.cpp
@@ -206,7 +206,7 @@ TEST_F(NNPIOptPipelineTest, ReplaceInefficientConcatTest) {
     EXPECT_EQ(optRN->getResult().dims()[0], inputDim2);
     EXPECT_EQ(optRN->getResult().dims()[1], inputDim1);
 
-    EXPECT_EQ(optRN->getInput().getNode(), inputs[idx]);
+    EXPECT_EQ(NodeValue(optRN->getInput().getNode()), inputs[idx]);
   }
   checkNumericalEquivalence(0.f);
 }


### PR DESCRIPTION
Summary: explicitly use NodeValue for comparison

Differential Revision: D34535117

