### PR TITLE
Add a method getNumFixedOperands to glow::Instruction

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -197,6 +197,10 @@ public:
   /// \returns the number of operands.
   unsigned getNumOperands() const { return ops_.size(); }
 
+  /// \returns the number of fixed operands known at the instructon
+  /// definition time.
+  unsigned getNumFixedOperands() const;
+
   /// \returns the number of input operands (includes In and InOut operands).
   unsigned getNumInputs() const;
 

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -103,6 +103,19 @@ Instruction::Operand Instruction::getOperand(unsigned idx) const {
   return ops_[idx];
 }
 
+unsigned Instruction::getNumFixedOperands() const {
+  switch (getKind()) {
+#define DEF_INSTR(CLASS, NAME)                                                 \
+  case glow::Kinded::Kind::CLASS##Kind:                                        \
+    return static_cast<const CLASS *>(this)->getNumFixedOperands();
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME) DEF_INSTR(CLASS, NAME)
+#define DEF_VALUE(CLASS, NAME)
+#include "glow/AutoGenInstr.def"
+  default:
+    llvm_unreachable("Unhandled instruction");
+  }
+}
+
 unsigned Instruction::getNumInputs() const {
   unsigned numInputs = 0;
   for (const auto &op : ops_) {

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -300,6 +300,8 @@ void InstrBuilder::emitClass(std::ostream &os) const {
   os << "\n  Instruction* clone() const;\n";
   os << "\n  void dump(llvm::raw_ostream &os) const;\n";
   os << "\n  llvm::StringRef getOperandName(unsigned idx) const;\n";
+  os << "\n  unsigned getNumFixedOperands() const { return " << operands_.size()
+     << "; }\n\n";
 
   // If there is no auto-verification then we assume verification is manually
   // provided.


### PR DESCRIPTION
Summary:
This method is useful for checking how many operands were defined at the instruction definition time in InstrGen.cpp.

One can use it to check if some operands were added dynamically at runtime. E.g. a ConcatInst has only one pre-defined fixed operand Dest, but may have any number of input operands that are added at runtime by IRGen.

Reviewed By: jfix71

Differential Revision: D34831026

