### PR TITLE
Install OpenSSH 8.1p1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,15 @@ linux_default: &linux_default
   machine:
     image: ubuntu-2004:202010-01
   steps:
+  - run:
+      name: Install OpenSSH 8.1p1
+      command: |
+        sudo apt-get update;
+        mkdir ~/tempdownload;
+        cd ~/tempdownload;
+        wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz;
+        tar zxvf openssh-8.1p1.tar.gz;
+        cd openssh-8.1p1 && ./configure && make && sudo make install;
   - checkout
   - run:
       <<: *merge_with_master


### PR DESCRIPTION
Summary: CI is broken. Trying to fix based on [this](https://support.circleci.com/hc/en-us/articles/4417542273179-GitHub-SSH-Deprecation-Information-Resolutions#:~:text=via%20the%20API-,Add%20a%20run%20step%20before%20your%20%2D%20checkout%20step%20that%20installs,gz%3B%20%0A%20%20%20%20%20%20%20%20%20%20%20%20cd%20openssh%2D8.1p1%20%26%26%20./configure%20%26%26%20make%20%26%26%20sudo%20make%20install%0A%20%20%20%20%20%20%2D%20checkout,-Jobs%20using%20circleci).

Differential Revision: D34874391

