### PR TITLE
update OSS glow/thirdparty/folly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,11 +222,11 @@ elseif(NOT EXISTS "${GLOW_THIRDPARTY_DIR}/folly/folly")
   message(FATAL_ERROR "No folly git submodule. Run: git submodule update --init --recursive")
 else()
   # Apple-specific definitions for folly.
-  if(APPLE)
-    set(FOLLY_HAVE_WEAK_SYMBOLS ON CACHE BOOL "Compiler supports weak symbols")
-    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
-    find_package(OpenSSL REQUIRED)
-  endif()
+  # if(APPLE)
+  #   set(FOLLY_HAVE_WEAK_SYMBOLS ON CACHE BOOL "Compiler supports weak symbols")
+  #   set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
+  #   find_package(OpenSSL REQUIRED)
+  # endif()
 
   # Remove Glow-specific CMAKE_CXX_FLAGS to build folly.
   set(SAVE_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
Summary: Update it from a version from 2020 https://github.com/facebook/folly/tree/c94486da2f41ff65862197efdaf062944574f56f to a most recent one https://github.com/facebook/folly/tree/v2022.03.28.00 @ 18eb46b2a0f03abc2f5d2b673f41b844dc253590

Differential Revision: D35241991

