### PR TITLE
Fix CI build failures

### DIFF
--- a/tests/benchmark/CommonSLSEB.h
+++ b/tests/benchmark/CommonSLSEB.h
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "Bench.h"
 #include "glow/Base/DimType.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Type.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
-#include "glow/glow/tests/benchmark/Bench.h"
 #include <algorithm>
 #include <array>
 #include <cstdlib>

--- a/tests/benchmark/EmbeddingBagBench.cpp
+++ b/tests/benchmark/EmbeddingBagBench.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "Bench.h"
-#include "glow/glow/tests/benchmark/CommonSLSEB.h"
+#include "CommonSLSEB.h"
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "Bench.h"
-#include "glow/glow/tests/benchmark/CommonSLSEB.h"
+#include "CommonSLSEB.h"
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"


### PR DESCRIPTION
Summary:
Seeing errors like
```
[723/733] Building CXX object tests/benchmark/CMakeFiles/SLSBench.dir/SLSBench.cpp.o
FAILED: tests/benchmark/CMakeFiles/SLSBench.dir/SLSBench.cpp.o
sccache /usr/bin/clang++-8  -DDIM_T_32 -DFMT_LOCALE -DGIT_DATE=\"2022-04-18\" -DGIT_SHA1=\"966f6d4\" -DGIT_TAG=\"\" -DGLOW_BUILD_DATE=\"2022-04-18\" -DGLOW_VERSION="\"2022-04-18 (966f6d4) ()\"" -DGLOW_WITH_CPU=1 -DGLOW_WITH_LLVMIRCODEGEN=1 -DGLOW_WITH_OPENCL=1 -DWITH_PNG -I../include -Iinclude -I. -I../ -I../externalbackends -I../thirdparty/fp16/include -I../tests/unittests -I../thirdparty/miniz-2.0.8 -I../thirdparty/folly -Ithirdparty/folly -isystem /usr/lib/llvm-8/include -Werror -Wall -Wnon-virtual-dtor -g -fno-omit-frame-pointer -O0 -fPIE -fvisibility=hidden -fvisibility-inlines-hidden   -pthread -std=c++14 -MD -MT tests/benchmark/CMakeFiles/SLSBench.dir/SLSBench.cpp.o -MF tests/benchmark/CMakeFiles/SLSBench.dir/SLSBench.cpp.o.d -o tests/benchmark/CMakeFiles/SLSBench.dir/SLSBench.cpp.o -c ../tests/benchmark/SLSBench.cpp
../tests/benchmark/SLSBench.cpp:25:10: fatal error: 'glow/glow/tests/benchmark/CommonSLSEB.h' file not found
#include "glow/glow/tests/benchmark/CommonSLSEB.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Differential Revision: D35726001

