### PR TITLE
[Importer] Add reshape around softmax

### DIFF
--- a/lib/Importer/TFLiteModelLoader.cpp
+++ b/lib/Importer/TFLiteModelLoader.cpp
@@ -2119,6 +2119,7 @@ Error TFLiteModelLoader::loadSoftmax(const tflite::Operator *op,
     }
 
     // Create float Softmax regardless of the type defined in the model.
+    // Wrap SoftMax between Flatten to ensure kernel compatibility.
     auto *FN =
         F_->createFlattenV1("reshapeInput", input, input.dims().size() - 1);
     auto *SMN = F_->createSoftMax(opInfo.name, FN, selected, nullptr, beta);
@@ -2134,6 +2135,7 @@ Error TFLiteModelLoader::loadSoftmax(const tflite::Operator *op,
       output = F_->createQuantize(opInfo.name + ".Quantize", output, outTy);
     }
   } else {
+    // Wrap SoftMax between Flatten to ensure kernel compatibility.
     auto *FN =
         F_->createFlattenV1("reshapeInput", input, input.dims().size() - 1);
     TypeRef intermOutTy =

--- a/lib/Importer/TFLiteModelLoader.cpp
+++ b/lib/Importer/TFLiteModelLoader.cpp
@@ -2119,7 +2119,10 @@ Error TFLiteModelLoader::loadSoftmax(const tflite::Operator *op,
     }
 
     // Create float Softmax regardless of the type defined in the model.
-    output = F_->createSoftMax(opInfo.name, input, selected, nullptr, beta);
+    auto *FN =
+        F_->createFlattenV1("reshapeInput", input, input.dims().size() - 1);
+    auto *SMN = F_->createSoftMax(opInfo.name, FN, selected, nullptr, beta);
+    output = F_->createReshape("reshapeOutput", SMN, outTy->dims());
 
     // If target output type is quantized we quantize the float output of the
     // Softmax but only if it is not an output placeholder in which case we
@@ -2131,7 +2134,12 @@ Error TFLiteModelLoader::loadSoftmax(const tflite::Operator *op,
       output = F_->createQuantize(opInfo.name + ".Quantize", output, outTy);
     }
   } else {
-    output = F_->createSoftMax(opInfo.name, input, selected, outTy, beta);
+    auto *FN =
+        F_->createFlattenV1("reshapeInput", input, input.dims().size() - 1);
+    TypeRef intermOutTy =
+        F_->getParent()->uniqueTypeWithNewShape(outTy, FN->getResult().dims());
+    auto *SMN = F_->createSoftMax(opInfo.name, FN, selected, intermOutTy, beta);
+    output = F_->createReshape("reshapeOutput", SMN, outTy->dims());
   }
   return setOutputNodeValue(op, output);
 }


### PR DESCRIPTION
Summary:
TFLiteImporter: Wrap Softmax by Reshape nodes to force 2D arrays.

Test Plan:
This fix is tested internally.
