### PR TITLE
Fix acc_ops.conv2d lowering to get kernel_size from weight shape

### DIFF
--- a/include/glow/Graph/FXIRUtils.h
+++ b/include/glow/Graph/FXIRUtils.h
@@ -145,6 +145,14 @@ template <class T> std::vector<T> getConvKernels(const folly::dynamic &node) {
 }
 
 template <class T>
+std::vector<T> getConvKernelsFromWeightNode(const folly::dynamic &node) {
+  const auto weightShape = getNodeShape<glow::dim_t>(node);
+  CHECK_GE(weightShape.size(), 2) << "Expected weight at least 2D";
+  return std::vector<T>(weightShape[weightShape.size() - 2],
+                        weightShape[weightShape.size() - 1]);
+}
+
+template <class T>
 std::vector<T> getTransposeShuffle(const folly::dynamic &node) {
   const auto &inputs = getNodeKwargs(node);
   CHECK(inputs.find("permutation") != inputs.items().end())

--- a/include/glow/Graph/FXIRWrapper.h
+++ b/include/glow/Graph/FXIRWrapper.h
@@ -91,9 +91,11 @@ public:
 
   /// \returns the name of input \p node. Fatals if \p node is not
   /// specified as is_node. If \p optional then \returns an empty string if \p
-  /// node is null.
-  const std::string &getInputNodeName(const folly::dynamic &node,
-                                      bool optional = false) const;
+  /// node is null. If \p getUnderlyingGetattrWeightName then the underlying
+  /// name of the weight will be returned, else the node's name itself.
+  const std::string &
+  getInputNodeName(const folly::dynamic &node, bool optional = false,
+                   bool getUnderlyingGetattrWeightName = true) const;
 
   /// \returns the underlying name of a Constant given provided \p name. If \p
   /// name is already the name of a Constant it is returned, else looks for
@@ -124,6 +126,9 @@ public:
 
   /// \returns the name of the node.
   const FXNode &getFXNodeByName(llvm::StringRef nodeName) const;
+
+  /// Given \p inputKwarg, \returns corresponding source FX node.
+  const FXNode &getFXNodeFromKwarg(const folly::dynamic &inputKwarg) const;
 
   const llvm::StringMap<const Storage *> &getMapNodeNameToStorage() const {
     return mapNodeNameToStorage_;


### PR DESCRIPTION
Summary:
Added `getConvKernelsFromWeight` to use for this.

Also added a helper `getFXNodeFromKwarg` to clean things up a bit in `FXFBALLVMIRGen.cpp`.

Differential Revision: D35805061

