### PR TITLE
[Version] Change build date to git date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ add_definitions("-DGIT_TAG=\"${GIT_TAG}\"")
 # Compile definition for Glow build date in Y-M-D format.
 string(TIMESTAMP GLOW_BUILD_DATE "%Y-%m-%d")
 add_definitions("-DGLOW_BUILD_DATE=\"${GLOW_BUILD_DATE}\"")
-add_definitions("-DGLOW_VERSION=\"${GLOW_BUILD_DATE} (${GIT_SHA1}) (${GIT_TAG})\"")
+add_definitions("-DGLOW_VERSION=\"${GIT_DATE} (${GIT_SHA1}) (${GIT_TAG})\"")
 
 if(GLOW_USE_PNG_IF_REQUIRED)
   find_package(PNG)


### PR DESCRIPTION
**Summary**
Replace in the version string the build date with the date of the last git commit.
The version should depend on the commits and not on the build date (building same code but on different dates should provide the same version string).
