### PR TITLE
Pass ConvertFusedScaleOffsetToFP32 into torch_glow

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -80,6 +80,11 @@ Error initializeCompilationContextFromGlowFlags(
   if (glow::flags::DumpCompilationLog) {
     cctx.compilationLogPrefix = "torch-glow";
   }
+  if (glow::flags::ConvertFusedScaleOffsetToFP32) {
+    precConfig.convert4BitFusedToFP32 = true;
+    precConfig.convert8BitFusedToFP32 = true;
+    LOG(INFO) << "Conversion of fused scales/offsets to fp32 enabled";
+  }
 
   // glow_sparsenn_partitioning_add_sls_concats
   // (SparseNNPartitioningAddSLSConcats) enables addition of concats to create a


### PR DESCRIPTION
Summary: ConvertFusedScaleOffsetToFP32 is not passing correctly.

Reviewed By: caogao

Differential Revision: D36253757

