### PR TITLE
Allow glow::Function class to be sub-classed

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -326,7 +326,7 @@ class Backend;
 struct CompilationContext;
 
 /// Represents the compute graph.
-class Function final : public IRContainer {
+class Function : public IRContainer {
   /// A list of nodes that the Function owns.
   NodesList nodes_;
 
@@ -353,7 +353,7 @@ public:
     logCtx_->pushEvent(parent->getModuleLogContext()->getClonedScope());
   }
 
-  ~Function();
+  ~Function() override;
 
   IRKind getIRKind() const override { return IRKind::GlowGraphIRKind; };
 


### PR DESCRIPTION
Summary: Some backends may want to extend Function.

Differential Revision: D36916346

