### PR TITLE
Ability to print non-lowered path between fusion groups

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -251,7 +251,8 @@ Error ShapeInferenceEngine::shapeOnNode(const torch::jit::Node *node) {
 
   auto &mapping = getShapeSymbolMapping();
   if (!mapping.count(symbol)) {
-    LOG(WARNING) << "Skip shape inference for unsupported op: " << symbol;
+    LOG(WARNING) << "Skip shape inference for unsupported op '" << symbol
+                 << "' at " << *node;
     return Error::success();
   }
 
@@ -776,6 +777,7 @@ void ShapeInferenceEngine::dumpGraph(const torch::jit::Graph &graph) {
   }
   file.close();
   auto groupId = 0;
+  std::vector<const torch::jit::Node *> fusions;
   for (auto *node : graph.nodes()) {
     if (node->hasAttribute(torch::jit::attr::Subgraph)) {
       std::string dotFileName =
@@ -806,6 +808,60 @@ void ShapeInferenceEngine::dumpGraph(const torch::jit::Graph &graph) {
       }
 
       groupId++;
+      fusions.push_back(node);
+    }
+  }
+
+  // If more than one group, then we can find unsupported nodes in between
+  if (fusions.size() > 1) {
+    std::unordered_set<const torch::jit::Node *> allFusionInputs;
+    for (int i = 1; i < fusions.size(); ++i) {
+      for (auto input : fusions[i]->inputs()) {
+        allFusionInputs.insert(input->node());
+      }
+    }
+
+    using NodePath = std::vector<const torch::jit::Node *>;
+
+    std::vector<NodePath> nonLoweredPaths;
+    for (int i = 0; i < fusions.size() - 1; ++i) {
+      auto currFusion = fusions[i];
+
+      std::deque<NodePath> q;
+      for (auto output : currFusion->outputs()) {
+        for (auto use : output->uses()) {
+          q.push_back({use.user});
+        }
+      }
+
+      while (q.size() > 0) {
+        auto path = std::move(q.front());
+        q.pop_front();
+
+        if (allFusionInputs.count(path.back()) > 0) {
+          nonLoweredPaths.push_back(path);
+        }
+
+        for (auto output : path.back()->outputs()) {
+          for (auto use : output->uses()) {
+            NodePath newPath{path};
+            newPath.push_back(use.user);
+            q.push_back(std::move(newPath));
+          }
+        }
+      }
+    }
+
+    LOG(INFO) << "Got " << nonLoweredPaths.size()
+              << " non lowered paths between fusion groups";
+    for (auto path : nonLoweredPaths) {
+      std::ostringstream ss;
+      ss << "[";
+      for (auto n : path) {
+        ss << ", " << *n;
+      }
+      ss << "]";
+      LOG(INFO) << "Non lowered path: " << ss.str();
     }
   }
 }


### PR DESCRIPTION
Summary: This should help us find non-lowered nodes that cause us to have multiple fusion groups.

Differential Revision: D36987198

