### PR TITLE
glow_fw_lab_latest_working.py: copy debug trace file (options --glow_dump_debug_traces -glow_dump_debug_traces_file) to the test result folder

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -952,7 +952,7 @@ int run() {
           mergedTraceContext.dump(path);
         }
       } else {
-        LOG(INFO) << "Trace path=" << path.c_str();
+        LOG(INFO) << "Trace path=" << glowDumpTraceFile.c_str();
         mergedTraceContext.dump(glowDumpTraceFile);
       }
     }


### PR DESCRIPTION
Summary:
When option --glow_dump_debug_traces exists, it will dump trace events to a file on the lab station. By default, the traces are dumped to a temporary file "glow-trace-XXXXXX.json". The -glow_dump_debug_traces_file option allows to specify the filename with the pass.

The output contains the following lines:
```
I0603 16:47:03.960561 414941 Repro.cpp:955] Trace path=/tmp/trace.json
I0603 16:47:03.960562 414941 TraceEvents.cpp:42] dumping 19 trace events to /tmp/trace.json
```
glow_fw_lab_latest_working.py parses the output for pattern matching and copies the trace file to the file 'glow_trace.json' in the test results folder on the dev station.

Differential Revision: D36915134

