### PR TITLE
[TFLite] Import Dequantize as Cast operator for Float16 data.

### DIFF
--- a/lib/Importer/TFLiteModelLoader.cpp
+++ b/lib/Importer/TFLiteModelLoader.cpp
@@ -1455,7 +1455,12 @@ Error TFLiteModelLoader::loadUnaryArithmetic(const tflite::Operator *op,
       output = F_->createRescaleQuantized(opInfo.name, input, outTy);
     }
   } else if (opCode == tflite::BuiltinOperator_DEQUANTIZE) {
-    output = F_->createDequantize(opInfo.name, input, outTy);
+    // If the input type is Float16 then we create a Cast operation.
+    if (input.getElementType() == ElemKind::Float16Ty) {
+      output = F_->createConvertTo(opInfo.name, input, outTy);
+    } else {
+      output = F_->createDequantize(opInfo.name, input, outTy);
+    }
   } else {
     return MAKE_ERR(opErrMsg(opInfo, "Unsupported unary arithmetic operator!"));
   }


### PR DESCRIPTION
**Summary**
We have some internal TFLite models where a Dequantize operator had float16 input and float32 output. The Dequantize operator in Glow expects quantized data at the input therefore we switch to a Convert operator in the importer whenever we have float16 data.

**Test Plan**
Some internal (private) models pass.
