### PR TITLE
Upgrade verbosity level for hash log.

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -251,7 +251,9 @@ void HostManager::cleanupAddNetwork(llvm::ArrayRef<std::string> names) {
 Error HostManager::addNetwork(std::unique_ptr<Module> module,
                               CompilationContext &cctx) {
 #ifdef FACEBOOK_INTERNAL
-  LOG(INFO) << "Adding Glow network built with revision hash: " << revisionHash;
+  LOG(WARNING) << "Adding Glow network built with revision hash: "
+               << revisionHash;
+
 #endif /* FACEBOOK_INTERNAL */
   VLOG(1) << "addNetwork";
   ScopeGuard debugDumpDAGGuard([&]() {


### PR DESCRIPTION
Summary:
This is important for reproducibility when we use `minloglevel=2`.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: yuhc

Differential Revision: D37255254

