### PR TITLE
Do not save size and stride for compute nodes for lowering.

### DIFF
--- a/lib/Graph/FXIRUtils.cpp
+++ b/lib/Graph/FXIRUtils.cpp
@@ -133,11 +133,24 @@ Value *glow::valueForNode(
 
 std::vector<dim_t> glow::getOffsets(const folly::dynamic &node) {
   const auto &inputs = getNodeKwargs(node);
-  auto shape = node["shape"].asString();
+  const std::string shape = glow::getNodeShapeAsString(node);
   auto count = std::count(shape.begin(), shape.end(), ',') + 1;
   std::vector<dim_t> offsets(count, 0);
   auto dim = inputs["dim"].asInt();
   auto start = inputs["start"].asInt();
   offsets[dim] = start;
   return offsets;
+}
+
+std::string glow::getNodeShapeAsString(const folly::dynamic &node) {
+  if (node.find("kwargs") != node.items().end()) {
+    const auto &kwargs = getNodeKwargs(node);
+    if (kwargs.find("out_memref") != kwargs.items().end()) {
+      const auto &out_memref = kwargs["out_memref"]; // out tensor view
+      return out_memref.at("shape").getString();
+    }
+  }
+  CHECK(node.find("shape") != node.items().end())
+      << "Neither shape nor out_memref exists in node " << node << "\n";
+  return node.at("shape").getString();
 }


### PR DESCRIPTION
Summary:
Accesses to allocs should be based only on TVs, so JSON used
for lowering should not contain stride/shape in compute nodes.
Next step is to ensure that lowering is done through TVs
only - this will mainly be done by chasing failures in the compile
caused by remove JSON data.
Do not modify serialize_module() function.

Differential Revision: D37573057

