### PR TITLE
Do not save size and stride for compute nodes for lowering.

### DIFF
--- a/include/glow/Graph/FXIRUtils.h
+++ b/include/glow/Graph/FXIRUtils.h
@@ -30,6 +30,9 @@ namespace glow {
 /// Get ElemKind from typeStr.
 ElemKind getElemKind(const std::string &dtypeStr);
 
+/// Get the kwargs of the node.
+const folly::dynamic &getNodeKwargs(const folly::dynamic &node);
+
 /// Helper function to convert \p intArrayStr like "[1, 2, 3]" or "(1, 2, 3)"
 /// to vector [1, 2, 3]. If \p length is greater than 0, append the vector with
 /// last element to such length. \returns a vector of length size.
@@ -91,8 +94,15 @@ std::vector<T> toIntegerArray(const folly::dynamic &dyn,
 }
 
 template <class T> std::vector<T> getNodeStride(const folly::dynamic &node) {
+  if (node.find("kwargs") != node.items().end()) {
+    const auto &kwargs = getNodeKwargs(node);
+    if (kwargs.find("out_memref") != kwargs.items().end()) {
+      const auto &out_memref = kwargs["out_memref"]; // out tensor view
+      return toIntegerArray<glow::dim_t>(out_memref.at("stride").getString());
+    }
+  }
   CHECK(node.find("stride") != node.items().end())
-      << "stride field doesn't exist in node " << node;
+      << "Neither stride nor out_memref exists in node " << node;
   return toIntegerArray<glow::dim_t>(node.at("stride").getString());
 }
 
@@ -108,10 +118,11 @@ std::string getNodeTarget(const folly::dynamic &node);
 /// Get the data type of the node.
 ElemKind getNodeDataType(const folly::dynamic &node);
 
+std::string getNodeShapeAsString(const folly::dynamic &node);
+
 template <class T> std::vector<T> getNodeShape(const folly::dynamic &node) {
-  CHECK(node.find("shape") != node.items().end())
-      << "shape field doesn't exist in node " << node;
-  return toIntegerArray<glow::dim_t>(node.at("shape").getString());
+  const std::string shapeString = getNodeShapeAsString(node);
+  return toIntegerArray<glow::dim_t>(shapeString);
 }
 
 /// Checks if node's padded.
@@ -119,9 +130,6 @@ bool isNodePadded(const folly::dynamic &node);
 
 /// Get the arg of the node.
 const folly::dynamic &getNodeArgs(const folly::dynamic &node);
-
-/// Get the kwargs of the node.
-const folly::dynamic &getNodeKwargs(const folly::dynamic &node);
 
 template <class T> std::vector<T> getConvStride(const folly::dynamic &node) {
   const auto &inputs = getNodeKwargs(node);

--- a/lib/Graph/FXIRUtils.cpp
+++ b/lib/Graph/FXIRUtils.cpp
@@ -133,11 +133,24 @@ Value *glow::valueForNode(
 
 std::vector<dim_t> glow::getOffsets(const folly::dynamic &node) {
   const auto &inputs = getNodeKwargs(node);
-  auto shape = node["shape"].asString();
+  const std::string shape = glow::getNodeShapeAsString(node);
   auto count = std::count(shape.begin(), shape.end(), ',') + 1;
   std::vector<dim_t> offsets(count, 0);
   auto dim = inputs["dim"].asInt();
   auto start = inputs["start"].asInt();
   offsets[dim] = start;
   return offsets;
+}
+
+std::string glow::getNodeShapeAsString(const folly::dynamic &node) {
+  if (node.find("kwargs") != node.items().end()) {
+    const auto &kwargs = getNodeKwargs(node);
+    if (kwargs.find("out_memref") != kwargs.items().end()) {
+      const auto &out_memref = kwargs["out_memref"]; // out tensor view
+      return out_memref.at("shape").getString();
+    }
+  }
+  CHECK(node.find("shape") != node.items().end())
+      << "Neither shape nor out_memref exists in node " << node << "\n";
+  return node.at("shape").getString();
 }


### PR DESCRIPTION
Summary:
When saving JSON and tensor views are used, do
not save shape and stride in compute nodes

Differential Revision: D37606431

