### PR TITLE
Handle removal of torch.split wrapper

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -446,7 +446,6 @@ private:
   loadSplitImpl(const glow::NodeValue &glowInput, const uint64_t dimension,
                 const std::vector<uint64_t> &sizes);
   Error loadSplit(const torch::jit::Node *ptNode);
-  Error loadSplitWithSizes(const torch::jit::Node *ptNode);
 
   // Load a PyTorch fb::equally_split.
   // \returns error on failure.


### PR DESCRIPTION
Summary:
A recent change https://github.com/pytorch/pytorch/pull/74727 was reverted due to test failures, but needs to be re-landed.

The issue with tests was that we're expecting `torch.split` to be JIT traced into `aten::split_with_sizes`, but this won't be the case after the original diff is re-landed.

Reviewed By: mehtanirav

Differential Revision: D37766943

