### PR TITLE
Get rid of GlowErrorSuccess

### DIFF
--- a/tests/unittests/ErrorTest.cpp
+++ b/tests/unittests/ErrorTest.cpp
@@ -18,7 +18,12 @@
 
 #include "gtest/gtest.h"
 
+#include "folly/lang/Keep.h"
+
 using namespace glow;
+
+// NOLINTNEXTLINE(facebook-hte-DetailCall)
+FOLLY_KEEP Error check_return_success() { return Error::success(); }
 
 TEST(Error, BasicError) {
   auto err = MAKE_ERR("some error");


### PR DESCRIPTION
Summary: It broke RVO. We still get an assertion at runtime (provided debug builds run) if an Expected is constructed with Error::success().

Differential Revision: D37805862

