### PR TITLE
Use tensor views to remove concats in FX

### DIFF
--- a/include/glow/Graph/FXIRUtils.h
+++ b/include/glow/Graph/FXIRUtils.h
@@ -93,19 +93,6 @@ std::vector<T> toIntegerArray(const folly::dynamic &dyn,
   return vec;
 }
 
-template <class T> std::vector<T> getNodeStride(const folly::dynamic &node) {
-  if (node.find("kwargs") != node.items().end()) {
-    const auto &kwargs = getNodeKwargs(node);
-    if (kwargs.find("out_memref") != kwargs.items().end()) {
-      const auto &out_memref = kwargs["out_memref"]; // out tensor view
-      return toIntegerArray<glow::dim_t>(out_memref.at("stride").getString());
-    }
-  }
-  CHECK(node.find("stride") != node.items().end())
-      << "Neither stride nor out_memref exists in node " << node;
-  return toIntegerArray<glow::dim_t>(node.at("stride").getString());
-}
-
 /// Get the opCode of the node.
 std::string getNodeOpCode(const folly::dynamic &node);
 
@@ -118,11 +105,36 @@ std::string getNodeTarget(const folly::dynamic &node);
 /// Get the data type of the node.
 ElemKind getNodeDataType(const folly::dynamic &node);
 
+bool hasFxOutTensorView(const folly::dynamic &node);
+
+const folly::dynamic &getFxOutTensorView(const folly::dynamic &node);
+
+std::string getNodeItemAsString(const folly::dynamic &node,
+                                const char *itemName);
 std::string getNodeShapeAsString(const folly::dynamic &node);
+std::string getNodeStrideAsString(const folly::dynamic &node);
+
+template <class T>
+std::vector<T> getNodeItem(const folly::dynamic &node, const char *itemName) {
+  const std::string itemString = getNodeItemAsString(node, itemName);
+  return toIntegerArray<glow::dim_t>(itemString);
+}
 
 template <class T> std::vector<T> getNodeShape(const folly::dynamic &node) {
   const std::string shapeString = getNodeShapeAsString(node);
   return toIntegerArray<glow::dim_t>(shapeString);
+}
+
+template <class T> std::vector<T> getNodeStride(const folly::dynamic &node) {
+  const std::string strideString = getNodeStrideAsString(node);
+  return toIntegerArray<glow::dim_t>(strideString);
+}
+
+std::string getNodeOffsetsAsString(const folly::dynamic &node);
+
+template <class T> std::vector<T> getNodeOffsets(const folly::dynamic &node) {
+  const std::string offsetString = getNodeOffsetsAsString(node);
+  return toIntegerArray<glow::dim_t>(offsetString);
 }
 
 /// Checks if node's padded.

--- a/lib/Graph/FXIRUtils.cpp
+++ b/lib/Graph/FXIRUtils.cpp
@@ -131,26 +131,69 @@ Value *glow::valueForNode(
   return value;
 }
 
+bool glow::hasFxOutTensorView(const folly::dynamic &node) {
+  const auto &kwargs = getNodeKwargs(node);
+  return kwargs.find("out_memref") != kwargs.items().end();
+}
+
+const folly::dynamic &glow::getFxOutTensorView(const folly::dynamic &node) {
+  const auto &kwargs = getNodeKwargs(node);
+  CHECK(hasFxOutTensorView(node)) << "Node must have 'out_memref'\n";
+  return kwargs["out_memref"];
+}
+
 std::vector<dim_t> glow::getOffsets(const folly::dynamic &node) {
-  const auto &inputs = getNodeKwargs(node);
+  const auto &kwargs = getNodeKwargs(node);
   const std::string shape = glow::getNodeShapeAsString(node);
   auto count = std::count(shape.begin(), shape.end(), ',') + 1;
   std::vector<dim_t> offsets(count, 0);
-  auto dim = inputs["dim"].asInt();
-  auto start = inputs["start"].asInt();
+  auto dim = kwargs["dim"].asInt();
+  auto start = kwargs["start"].asInt();
   offsets[dim] = start;
   return offsets;
 }
 
+//======================================================================
 std::string glow::getNodeShapeAsString(const folly::dynamic &node) {
+  return glow::getNodeItemAsString(node, "shape");
+}
+
+//======================================================================
+std::string glow::getNodeStrideAsString(const folly::dynamic &node) {
+  return getNodeItemAsString(node, "stride");
+}
+
+//======================================================================
+// Offset is introduced with tensor views, so node must be a tensor view
+// node, not a compute node.
+//======================================================================
+std::string glow::getNodeOffsetsAsString(const folly::dynamic &node) {
+  CHECK(node.find("is_tensor_view") != node.items().end() &&
+        node["is_tensor_view"].asBool())
+      << "Node must be tensor view\n";
+  CHECK(node.find("offset") != node.items().end())
+      << "Missing field 'offset' in tensor view\n";
+  return node.at("offset").getString();
+}
+
+//======================================================================
+// Prior to introduction of tensor views (out_memref is a tensor view
+// for writing the output to an alloc), shape and stride were taken
+// from the output/destination alloc node (that a compute node writes to).
+// The two if statements handle the case with tensor views and the final
+// returns the shape from the destination node.
+//======================================================================
+std::string glow::getNodeItemAsString(const folly::dynamic &node,
+                                      const char *itemName) {
   if (node.find("kwargs") != node.items().end()) {
     const auto &kwargs = getNodeKwargs(node);
     if (kwargs.find("out_memref") != kwargs.items().end()) {
       const auto &out_memref = kwargs["out_memref"]; // out tensor view
-      return out_memref.at("shape").getString();
+      return out_memref.at(itemName).getString();
     }
   }
-  CHECK(node.find("shape") != node.items().end())
-      << "Neither shape nor out_memref exists in node " << node << "\n";
-  return node.at("shape").getString();
+  CHECK(node.find(itemName) != node.items().end())
+      << "Neither " << itemName << " nor out_memref exists in node " << node
+      << "\n";
+  return node.at(itemName).getString();
 }


### PR DESCRIPTION
Summary:
Replace concat with direct partial writes from concat feeders into concat output tensor.
If everything matches shapes, strides for all inputs and output of concat,  remove concat. Calculate offsets for individual partial writes.

Differential Revision: D38004290

