### PR TITLE
Optimize extracts

### DIFF
--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1591,6 +1591,7 @@ void optimize(IRFunction &M, bool shouldShareBuffers) {
   if (!shouldShareBuffers) {
     pipeline->removeAllInstancesOfPass(IRFunctionPassID::ShareBuffers);
   }
+
   IRFunctionPassManager IRFPM("TargetIndependentIROptzFPM",
                               std::move(pipeline));
   CompilationContext cctx;


### PR DESCRIPTION
Summary:
Enable optimization of extracts.

```
AFG_USE_CPU_PRINTF=1 AFG_MIN_STACK_USAGE=1 AFG_REUSE_ACTV_MEM=0 FBA_NO_MEMORY_CACHING=1 buck2 run mode/opt -c glow.fw_use_emulator=true -c glow.dump-ir=true caffe2/torch/fb/acc_runtime/afg/tests:test_afg -- --model 10x_ctr_mbl_feed_tp --model_path /home/slohani/309786571_1.fp32.predictor.tooling.tp
```

__Without opt enabled:__
```
[NNModel execution] Begin mtimer: 10206642695299
[NNModel execution] End mtimer: 10206646250953
[NNModel execution] Duration mtimer: 3555654
```
Total extracts: 679

__With opt enabled:__
```
[NNModel execution] Begin mtimer: 10443975516283
[NNModel execution] End mtimer: 10443978470382
[NNModel execution] Duration mtimer: 2954099
```
Total extracts: 69

Differential Revision: D40291154

