### PR TITLE
Allow backends to perform backend specific verification of glow::Instructions

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -176,6 +176,17 @@ public:
   /// has a good reason not to call IRFunction::verify().
   virtual bool verify(const IRFunction &IR) const;
 
+  /// \returns whether the provided instruction \p I conforms to the
+  /// backend-dependent graph constraints. Giving the backend an opportunity to
+  /// check that everything conforms to its specific restrictions by overriding
+  /// this function. It is highly recommended for backends to make their backend
+  /// specific verifications a super-set of target independent
+  /// Instruction::verify() by calling it in their overridden implementation. It
+  /// is not a strict requirement, of course, in case they diverge / the backend
+  /// has a good reason not to call Instruction::verify().
+  virtual bool verify(const glow::Instruction &I,
+                      bool assertOnErrors = true) const;
+
   /// \returns a reference to the backend-specific tensor layout requirements
   /// singleton. If not overridden, the default requirement is Glow's
   /// "canonical" form.

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -268,6 +268,10 @@ bool Backend::verify(const IRFunction &IR) const {
   return true;
 }
 
+bool Backend::verify(const Instruction &I, bool assertOnErrors) const {
+  return I.verify();
+}
+
 TensorLayoutCommon &Backend::getTensorLayoutRequirements() const {
   return CanonicalTensorLayout::getInstance();
 }


### PR DESCRIPTION
Summary:
This can be useful if a backend needs to perform some extra checks.

By default, a standard glow::Instruction::verify() is used.

Reviewed By: jaybean-dev

Differential Revision: D40508514

