### PR TITLE
Add an optional Backend field to the CompilationContext

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -176,6 +176,17 @@ public:
   /// has a good reason not to call IRFunction::verify().
   virtual bool verify(const IRFunction &IR) const;
 
+  /// \returns whether the provided instruction \p I conforms to the
+  /// backend-dependent graph constraints. Giving the backend an opportunity to
+  /// check that everything conforms to its specific restrictions by overriding
+  /// this function. It is highly recommended for backends to make their backend
+  /// specific verifications a super-set of target independent
+  /// Instruction::verify() by calling it in their overridden implementation. It
+  /// is not a strict requirement, of course, in case they diverge / the backend
+  /// has a good reason not to call Instruction::verify().
+  virtual bool verify(const glow::Instruction &I,
+                      bool assertOnErrors = true) const;
+
   /// \returns a reference to the backend-specific tensor layout requirements
   /// singleton. If not overridden, the default requirement is Glow's
   /// "canonical" form.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -366,6 +366,9 @@ struct CompilationContext {
     NumCompilationModes, /// Used to count the number of CompilationModes.
   } compMode{CompilationMode::Infer};
 
+  /// Backend being used.
+  const Backend *backend{nullptr};
+
   /// Options for the Backend to use.
   BackendOptions backendOpts;
 

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -268,6 +268,10 @@ bool Backend::verify(const IRFunction &IR) const {
   return true;
 }
 
+bool Backend::verify(const Instruction &I, bool assertOnErrors) const {
+  return I.verify();
+}
+
 TensorLayoutCommon &Backend::getTensorLayoutRequirements() const {
   return CanonicalTensorLayout::getInstance();
 }

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1608,6 +1608,7 @@ void optimize(IRFunction &M, const Backend &B, bool shouldShareBuffers) {
                               std::move(pipeline));
   CompilationContext cctx;
   cctx.compMode = CompilationMode::Infer;
+  cctx.backend = &B;
   IRFPM.run(&M, cctx);
   B.runBackendSpecificTransforms(&M);
 }


### PR DESCRIPTION
Summary: If this field is set, transformations and optimizations can use it to perform some backend specific actions.

Reviewed By: jaybean-dev

Differential Revision: D40508515

