### PR TITLE
Better correctness checks for the parent fusion group field of an instruction

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -251,7 +251,7 @@ public:
 
   /// Sets a Parent Group Fusion Instruction
   void setParentGroupFusionInstr(Instruction *instr) {
-    assert((instr->getKind() == Kinded::Kind::FusionGroupInstKind) &&
+    assert((!instr || instr->getKind() == Kinded::Kind::FusionGroupInstKind) &&
            "Not a FusionGroupInstr");
     parentFusionGroupInstr_ = instr;
   }

--- a/include/glow/IR/Instrs.h
+++ b/include/glow/IR/Instrs.h
@@ -85,6 +85,8 @@ public:
     for (Instruction *instr : instrs) {
       transferOperands(instr);
       instrs_.push_back(instr);
+      assert(!instr->getParentGroupFusionInstr() &&
+             "Instruction should not be part of another fusion");
       instr->setParentGroupFusionInstr(this);
     }
   }

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -229,6 +229,7 @@ InstrIterator IRFunction::removeInstruction(glow::Instruction *I) {
   auto result = I->getIterator();
   ++result;
   instrs_.remove(I);
+  I->setParentGroupFusionInstr(nullptr);
   return result;
 }
 


### PR DESCRIPTION
Reviewed By: SameerAsal

Differential Revision: D41442426

