### PR TITLE
LLVM-15 fixes for glow/glow/include/glow/Runtime/StatsExporter.h

### DIFF
--- a/include/glow/Runtime/StatsExporter.h
+++ b/include/glow/Runtime/StatsExporter.h
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include <memory>
 #include <vector>
 
 namespace glow {


### PR DESCRIPTION
Reviewed By: bertmaher

Differential Revision: D41603427

