### PR TITLE
Remove `using namespace` from header in glow/glow/include/glow/Base/SliceRange.h +1

### DIFF
--- a/include/glow/Base/SliceRange.h
+++ b/include/glow/Base/SliceRange.h
@@ -24,11 +24,6 @@
 #include <unordered_set>
 #include <vector>
 
-using namespace glow;
-using llvm::cast;
-using llvm::dyn_cast;
-using llvm::isa;
-
 namespace glow {
 
 /// Dimension range representing a contiguous [start, stop) index interval with

--- a/tests/unittests/NodeSplittingTest.cpp
+++ b/tests/unittests/NodeSplittingTest.cpp
@@ -49,8 +49,8 @@ TEST(TestSplitNodeOption, CheckLLVMStyleRTTI) {
             SplitNodeOption::SplitNodeKind::SplitNodeByChunkWeights);
   std::vector<SplitNodeOption *> orthogonalOpts = {&opt1, &opt2, &opt3, &opt4};
   for (auto opt : orthogonalOpts) {
-    EXPECT_NE(nullptr, dyn_cast<SplitNodeOptionOrthogonal>(opt));
-    EXPECT_EQ(nullptr, dyn_cast<SplitNodeBySliceRanges>(opt));
+    EXPECT_NE(nullptr, llvm::dyn_cast<SplitNodeOptionOrthogonal>(opt));
+    EXPECT_EQ(nullptr, llvm::dyn_cast<SplitNodeBySliceRanges>(opt));
   }
   // Check non-orthogonal options.
   std::vector<SliceRange> sliceRanges = {SliceRange({{0, 1}})};
@@ -58,8 +58,9 @@ TEST(TestSplitNodeOption, CheckLLVMStyleRTTI) {
   EXPECT_EQ(opt5.getKind(),
             SplitNodeOption::SplitNodeKind::SplitNodeBySliceRanges);
   SplitNodeOption *nonOrthogonalOpt = &opt5;
-  EXPECT_EQ(nullptr, dyn_cast<SplitNodeOptionOrthogonal>(nonOrthogonalOpt));
-  EXPECT_NE(nullptr, dyn_cast<SplitNodeBySliceRanges>(nonOrthogonalOpt));
+  EXPECT_EQ(nullptr,
+            llvm::dyn_cast<SplitNodeOptionOrthogonal>(nonOrthogonalOpt));
+  EXPECT_NE(nullptr, llvm::dyn_cast<SplitNodeBySliceRanges>(nonOrthogonalOpt));
 }
 
 /// Test for SplitNodeByNumChunks option.


### PR DESCRIPTION
Reviewed By: palmje

Differential Revision: D56222659


